### PR TITLE
Remove duplicated frame time rendering

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -10,6 +10,7 @@ use crate::{
 use anyhow::{Result, anyhow};
 use core::fmt;
 use ratatui::crossterm::event::{self, Event, KeyCode, KeyModifiers};
+use std::time::Instant;
 use tracing::{info, info_span};
 
 #[derive(PartialEq, Copy, Clone)]
@@ -35,6 +36,10 @@ impl Tab {
     pub const VALUES: [Self; 4] = [Tab::Log, Tab::Files, Tab::Bookmarks, Tab::CommandLog];
 }
 
+pub struct Stats {
+    pub start_time: Instant,
+}
+
 pub struct App<'a> {
     pub env: Env,
     pub current_tab: Tab,
@@ -43,6 +48,7 @@ pub struct App<'a> {
     pub bookmarks: Option<BookmarksTab<'a>>,
     pub command_log: Option<CommandLogTab>,
     pub popup: Option<Box<dyn Component>>,
+    pub stats: Stats,
 }
 
 impl<'a> App<'a> {
@@ -55,6 +61,9 @@ impl<'a> App<'a> {
             bookmarks: None,
             command_log: None,
             popup: None,
+            stats: Stats {
+                start_time: Instant::now(),
+            },
         })
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,8 +25,6 @@ use ratatui::{
             supports_keyboard_enhancement,
         },
     },
-    layout::{Alignment, Rect},
-    widgets::Paragraph,
 };
 use tracing::{info, trace_span};
 use tracing_chrome::ChromeLayerBuilder;
@@ -153,7 +151,6 @@ fn run_app<B: Backend>(
     app: &mut App,
     commander: &mut Commander,
 ) -> Result<()> {
-    let mut start_time = Instant::now();
     loop {
         // Draw
         let mut terminal_draw_res = Ok(());
@@ -174,23 +171,7 @@ fn run_app<B: Backend>(
             }
 
             let draw_span = trace_span!("draw");
-            terminal_draw_res = draw_span.in_scope(|| -> Result<()> {
-                ui(f, app)?;
-
-                {
-                    let paragraph =
-                        Paragraph::new(format!("{}ms", start_time.elapsed().as_millis()))
-                            .alignment(Alignment::Right);
-                    let position = Rect {
-                        x: 0,
-                        y: 1,
-                        height: 1,
-                        width: f.area().width - 1,
-                    };
-                    f.render_widget(paragraph, position);
-                }
-                Ok(())
-            });
+            terminal_draw_res = draw_span.in_scope(|| ui(f, app));
         })?;
         terminal_draw_res?;
 
@@ -207,8 +188,7 @@ fn run_app<B: Backend>(
             }
         };
 
-        start_time = Instant::now();
-
+        app.stats.start_time = Instant::now();
         let should_stop = input_spawn.in_scope(|| -> Result<bool> {
             if app.input(event, commander)? {
                 return Ok(true);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -11,8 +11,6 @@ pub mod rebase_popup;
 pub mod styles;
 pub mod utils;
 
-use std::time::Instant;
-
 use crate::{
     ComponentInputResult,
     app::{App, Tab},
@@ -53,8 +51,6 @@ pub trait Component {
 }
 
 pub fn ui(f: &mut Frame, app: &mut App) -> Result<()> {
-    let start_time = Instant::now();
-
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Length(3), Constraint::Min(1)])
@@ -110,7 +106,7 @@ pub fn ui(f: &mut Frame, app: &mut App) -> Result<()> {
     }
 
     {
-        let paragraph = Paragraph::new(format!("{}ms", start_time.elapsed().as_millis()))
+        let paragraph = Paragraph::new(format!("{}ms", app.stats.start_time.elapsed().as_millis()))
             .alignment(Alignment::Right);
         let position = Rect {
             x: 0,


### PR DESCRIPTION
The frame time is rendered in the same place by both ui::ui() as well as run_app(). The former renders the raw rendering time, the latter includes the time for any performed actions, and only that is actually visible.

So we can remove the duplicate code, and show only the action+render time. As we want that to happen in ui::ui(), we need to make the start time part of the app struct.

<!-- Please provide some information on what this PR tries to accomplish, please also make sure to have proper commit messages, those are more importantn than the PR message -->
