### PR TITLE
Prefer `instrument` annotations over inline spans

### DIFF
--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -111,7 +111,7 @@ fn get_current_bookmark_index(
 }
 
 impl BookmarksTab<'_> {
-    #[instrument(level = "trace", skip(commander))]
+    #[instrument(level = "info", name = "Initializing bookmarks tab", parent = None, skip(commander))]
     pub fn new(commander: &mut Commander) -> Result<Self> {
         let diff_format = commander.env.config.diff_format();
 

--- a/src/ui/command_log_tab.rs
+++ b/src/ui/command_log_tab.rs
@@ -33,7 +33,7 @@ pub struct CommandLogTab {
 }
 
 impl CommandLogTab {
-    #[instrument(level = "trace", skip(commander))]
+    #[instrument(level = "info", name = "Initializing command log tab", parent = None, skip(commander))]
     pub fn new(commander: &mut Commander) -> Result<Self> {
         let command_history = commander.command_history.lock().unwrap().clone();
         let selected_index = command_history.first().map(|_| 0);

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -58,7 +58,7 @@ fn get_current_file_index(
 }
 
 impl FilesTab {
-    #[instrument(level = "trace", skip(commander))]
+    #[instrument(level = "info", name = "Initializing files tab", parent = None, skip(commander))]
     pub fn new(commander: &mut Commander, head: &Head) -> Result<Self> {
         let head = head.clone();
         let is_current_head = head == commander.get_current_head()?;

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -78,7 +78,7 @@ pub struct LogTab<'a> {
 }
 
 impl<'a> LogTab<'a> {
-    #[instrument(level = "trace", skip(commander))]
+    #[instrument(level = "info", name = "Initializing log tab", parent = None, skip(commander))]
     pub fn new(commander: &mut Commander) -> Result<Self> {
         let diff_format = commander.env.config.diff_format();
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -25,6 +25,7 @@ use ratatui::{
     symbols,
 };
 use ratatui::{prelude::*, widgets::*};
+use tracing::instrument;
 
 pub enum ComponentAction {
     ViewFiles(Head),
@@ -50,6 +51,7 @@ pub trait Component {
     fn input(&mut self, commander: &mut Commander, event: Event) -> Result<ComponentInputResult>;
 }
 
+#[instrument(level = "trace", name = "draw", skip(f, app))]
 pub fn ui(f: &mut Frame, app: &mut App) -> Result<()> {
     let chunks = Layout::default()
         .direction(Direction::Vertical)


### PR DESCRIPTION
This just makes the code so much more readable.
