### PR TITLE
Use a bookmark template instead of a simple prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Details panel responds to mouse scroll in all tabs
 - Details panel sets COLUMNS to allow jj diff tool to fit window
+
+### Changed
+
+- Move from bookmark-prefix to bookmark-template for the bookmark generation to match the behaviour from jj 0.31+

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ You can optionally configure the following options through your jj config:
   - If `lazyjj.diff-format` is not set but `ui.diff.format` is, the latter will be used
 - `lazyjj.diff-tool`: Specify which diff tool to use by default
   - If `lazyjj.diff-tool` is not set but `ui.diff.tool` is, the latter will be used
-- `lazyjj.bookmark-prefix`: Change the bookmark name prefix for generated bookmark names. Defaults to `push-`
-  - If `lazyjj.bookmark-prefix` is not set but `git.push-bookmark-prefix` is, the latter will be used
+- `lazyjj.bookmark-template`: Change the bookmark name template for generated bookmark names. Defaults to `'push-' ++ change_id.short()`
+  - If `lazyjj.bookmark-template` is not set but `templates.git_push_bookmark` is, the latter will be used
 - `lazyjj.layout`: Changes the layout of the main and details panel. Can be `horizontal` (default) or `vertical`
 - `lazyjj.layout-percent`: Changes the layout split of the main page. Should be number between 0 and 100. Defaults to `50`
 

--- a/src/commander/bookmarks.rs
+++ b/src/commander/bookmarks.rs
@@ -7,7 +7,7 @@ other jj bookmark commands are defined in module [jj][super::jj].
 It is mostly used in the [bookmarks_tab][crate::ui::bookmarks_tab] module.
 */
 use crate::{
-    commander::{CommandError, Commander, RemoveEndLine},
+    commander::{CommandError, Commander, RemoveEndLine, ids::ChangeId},
     env::DiffFormat,
 };
 use ansi_to_tui::IntoText;
@@ -185,6 +185,22 @@ impl Commander {
         }
 
         Ok(self.execute_jj_command(args, true, true)?.remove_end_line())
+    }
+
+    #[instrument(level = "trace", skip(self))]
+    pub fn generate_bookmark_name(&self, change_id: &ChangeId) -> Result<String, CommandError> {
+        self.execute_jj_command(
+            [
+                "show",
+                "--no-patch",
+                "--template",
+                self.env.config.bookmark_template().as_str(),
+                "-r",
+                change_id.as_str(),
+            ],
+            false,
+            false,
+        )
     }
 }
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -18,8 +18,8 @@ pub struct Config {
     lazyjj_diff_format: Option<DiffFormat>,
     #[serde(rename = "lazyjj.diff-tool")]
     lazyjj_diff_tool: Option<String>,
-    #[serde(rename = "lazyjj.bookmark-prefix")]
-    lazyjj_bookmark_prefix: Option<String>,
+    #[serde(rename = "lazyjj.bookmark-template")]
+    lazyjj_bookmark_template: Option<String>,
     #[serde(rename = "lazyjj.layout")]
     lazyjj_layout: Option<JJLayout>,
     #[serde(rename = "lazyjj.layout-percent")]
@@ -30,8 +30,8 @@ pub struct Config {
     ui_diff_format: Option<DiffFormat>,
     #[serde(rename = "ui.diff.tool")]
     ui_diff_tool: Option<()>,
-    #[serde(rename = "git.push-bookmark-prefix")]
-    git_push_bookmark_prefix: Option<String>,
+    #[serde(rename = "templates.git_push_bookmark")]
+    git_push_bookmark_template: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Clone, Default)]
@@ -39,7 +39,7 @@ pub struct Config {
 pub struct JjConfig {
     lazyjj: Option<JjConfigLazyjj>,
     ui: Option<JjConfigUi>,
-    git: Option<JjConfigGit>,
+    templates: Option<JjConfigTemplates>,
 }
 
 #[derive(Deserialize, Debug, Clone, Default)]
@@ -68,9 +68,8 @@ pub struct JjConfigUiDiff {
 }
 
 #[derive(Deserialize, Debug, Clone, Default)]
-#[serde(rename_all = "kebab-case")]
-pub struct JjConfigGit {
-    push_bookmark_prefix: Option<String>,
+pub struct JjConfigTemplates {
+    git_push_bookmark: Option<String>,
 }
 
 impl Config {
@@ -102,12 +101,11 @@ impl Config {
             .unwrap_or(Color::Rgb(50, 50, 150))
     }
 
-    pub fn bookmark_prefix(&self) -> String {
-        self.lazyjj_bookmark_prefix.clone().unwrap_or(
-            self.git_push_bookmark_prefix
-                .clone()
-                .unwrap_or("push-".to_owned()),
-        )
+    pub fn bookmark_template(&self) -> String {
+        self.lazyjj_bookmark_template
+            .clone()
+            .or(self.git_push_bookmark_template.clone())
+            .unwrap_or("'push-' ++ change_id.short()".to_string())
     }
 
     pub fn layout(&self) -> JJLayout {
@@ -186,7 +184,7 @@ impl Env {
                             .lazyjj
                             .as_ref()
                             .and_then(|lazyjj| lazyjj.diff_tool.clone()),
-                        lazyjj_bookmark_prefix: config
+                        lazyjj_bookmark_template: config
                             .lazyjj
                             .as_ref()
                             .and_then(|lazyjj| lazyjj.bookmark_prefix.clone()),
@@ -208,9 +206,9 @@ impl Env {
                                 .as_ref()
                                 .and_then(|diff| diff.tool.as_ref().map(|_| ()))
                         }),
-                        git_push_bookmark_prefix: config
-                            .git
-                            .and_then(|git| git.push_bookmark_prefix),
+                        git_push_bookmark_template: config
+                            .templates
+                            .and_then(|templates| templates.git_push_bookmark),
                     })?
             }
         };

--- a/src/ui/bookmark_set_popup.rs
+++ b/src/ui/bookmark_set_popup.rs
@@ -57,7 +57,7 @@ fn generate_options(
     let mut options = vec![BookmarkSetOption::CreateBookmark];
 
     if let Some(change_id) = change_id {
-        let generated_name = generate_name(&commander.env.config.bookmark_prefix(), change_id);
+        let generated_name = generate_name(commander, change_id);
         let exists = bookmarks.as_ref().is_ok_and(|bookmarks| {
             bookmarks
                 .iter()
@@ -81,10 +81,10 @@ fn generate_options(
     options
 }
 
-fn generate_name(git_push_bookmark_prefix: &str, change_id: &ChangeId) -> String {
-    let mut change_id = change_id.to_string();
-    change_id.truncate(12);
-    format!("{git_push_bookmark_prefix}{change_id}",)
+fn generate_name(commander: &Commander, change_id: &ChangeId) -> String {
+    commander
+        .generate_bookmark_name(change_id)
+        .unwrap_or_else(|_| format!("error-{change_id}"))
 }
 
 impl BookmarkSetPopup<'_> {
@@ -135,7 +135,7 @@ impl BookmarkSetPopup<'_> {
     }
     fn generate_bookmark(&self, commander: &mut Commander) -> Result<()> {
         if let Some(change_id) = self.change_id.as_ref() {
-            let generated_name = generate_name(&commander.env.config.bookmark_prefix(), change_id);
+            let generated_name = generate_name(commander, change_id);
             if commander
                 .get_bookmarks_list(false)?
                 .iter()


### PR DESCRIPTION
JJ 0.31 deprecated the bookmark prefix option and replaced it with a template mechanism, we should adapt that as well, dropping the old prefix mechanism.