### PR TITLE
Cache diff output from jj (only on log tab)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Log panel create new revision with marked commits as parents
 - Add support for copying the Change ID/revision of the current log tab entry using y/Y
 - Fix Describe dialog width at git recommendation for commit message
+- Log tab diff is cached
 
 
 ## [0.7.1] - 2026-01-16

--- a/src/env.rs
+++ b/src/env.rs
@@ -148,7 +148,7 @@ impl Env {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Default, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Default, PartialEq, Eq, Hash)]
 #[serde(rename_all = "kebab-case")]
 pub enum DiffFormat {
     #[default]

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -28,6 +28,7 @@ use crate::ui::ComponentAction;
 use crate::ui::help_popup::HelpPopup;
 use crate::ui::message_popup::MessagePopup;
 use crate::ui::panel::DetailsPanel;
+use crate::ui::panel::TextContent;
 use crate::ui::utils::centered_rect;
 use crate::ui::utils::centered_rect_line_height;
 use crate::ui::utils::tabs_to_spaces;
@@ -437,9 +438,8 @@ impl Component for BookmarksTab<'_> {
                 None => vec![],
             };
             self.bookmark_panel
-                .render_context()
+                .render_context::<TextContent>(bookmark_content)
                 .title(title)
-                .content(bookmark_content)
                 .draw(f, chunks[1]);
         }
 

--- a/src/ui/commit_show_cache.rs
+++ b/src/ui/commit_show_cache.rs
@@ -1,0 +1,175 @@
+/*! This module provides a cache of the output from 'jj show'
+It is optimized for continous editing, which means that the
+automatic rebase that happens when a change is modified will
+also empty cache values. It does allow divergent changes, where
+several visible commits share the same change id.
+
+The design prevents a single huge commit from eating memory if
+an ancester causes it to be rebased without modification lots of time.
+*/
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+
+use crate::commander::ids::ChangeId;
+use crate::commander::log::Head;
+use crate::env::DiffFormat;
+use crate::ui::utils::LargeString;
+
+/// 'jj show' output depends on all these values
+#[derive(PartialEq, Eq, Hash, Clone)]
+pub struct CommitShowKey {
+    /// Commit id of shown change
+    id: Head,
+    /// Formatting used to render change
+    format: DiffFormat,
+    /// Render width.
+    /// Set to 0 for all except format=DiffTool.
+    /// For DiffTool it is set to the inner with of the details panel,
+    /// which is given to the tool via the COLUMNS environment variable.
+    width: usize,
+}
+
+impl CommitShowKey {
+    /// Create a new key. If DiffFormat is not DiffTool, then width
+    /// will be set to zero.
+    pub fn new(id: Head, format: DiffFormat, width: usize) -> Self {
+        // Keep with only for the DiffTool format
+        let width = if let DiffFormat::DiffTool(_) = format {
+            width
+        } else {
+            0
+        };
+        Self { id, format, width }
+    }
+}
+
+/// The output from 'jj show' in a form that is fast to render a subset of
+/// A structure that allows fast rendering of document with millions of lines
+pub struct CommitShowValue {
+    key: CommitShowKey,
+    jj_output: LargeString,
+}
+
+impl CommitShowValue {
+    /// Index value, and store both key and value
+    pub fn new(key: CommitShowKey, value: String) -> Self {
+        Self {
+            key,
+            jj_output: LargeString::new(value),
+        }
+    }
+    pub fn value(&self) -> &LargeString {
+        &self.jj_output
+    }
+}
+
+/// A Cache dedicated to the output of jj show for all entries in jj log.
+/// Entries use the commit id as key. You specify which are currently
+/// active, any commit not active will either be used as default for a
+/// request where the change id match, or discarded if a true value exists.
+/// You provide a list of commits that are active,
+pub struct CommitShowCache {
+    /// These commits will be kept. The output is a set, because
+    /// ChangeId is not unique when a change is divergent
+    active_commits: HashMap<ChangeId, HashSet<CommitShowKey>>,
+    /// These commits will be discarded, once an active commit
+    /// with same change id is in the cache. The output is not a set
+    /// for simplicity. We don't care about old divergent changes and
+    /// pick one at random.
+    old_commits: HashMap<ChangeId, CommitShowKey>,
+    /// The cache of jj show output
+    commit_document: HashMap<CommitShowKey, CommitShowValue>,
+}
+
+impl CommitShowCache {
+    /// Create an empty cache
+    pub fn new() -> Self {
+        Self {
+            active_commits: HashMap::new(),
+            old_commits: HashMap::new(),
+            commit_document: HashMap::new(),
+        }
+    }
+    /// Declare which commits should be kept. Any commit outside this set
+    /// that shares change id with this set will be kept until the correct
+    /// commit is available.
+    ///   The Head of the key is replaced with each head
+    /// from active_heads before inserting in active commits.
+    pub fn set_active(&mut self, active_heads: Vec<Head>, key: &CommitShowKey) {
+        // Construct map of active_commits from ChangeId to HashSet<CommitShowKey>
+        // containing all visible heads
+        self.active_commits = HashMap::new();
+        for head in active_heads {
+            let mut key = key.clone();
+            key.id = head;
+            let change_id = key.id.change_id.clone();
+            self.active_commits
+                .entry(change_id)
+                .or_default()
+                .insert(key);
+        }
+
+        // Construct map of old_commits from ChangeId to CommitShowKey
+        // with all heads in the cache, that is not marked as an active commit
+        self.old_commits = HashMap::new();
+        for key in self.commit_document.keys() {
+            // All cached values should either be an active or old commit.
+            if !self.active_commits.contains_key(&key.id.change_id) {
+                self.old_commits
+                    .insert(key.id.change_id.clone(), key.clone());
+            }
+        }
+    }
+
+    /// Return true if the key is present as active
+    pub fn has_exact_match(&self, key: &CommitShowKey) -> bool {
+        self.commit_document.contains_key(key)
+    }
+
+    /// Search for best match of the provided key.
+    pub fn get(&self, key: &CommitShowKey) -> Option<&CommitShowValue> {
+        // Look for direct hit via CommitId
+        if self.has_exact_match(key) {
+            return self.commit_document.get(key);
+        }
+        // Look for indirect hit via ChangeId
+        if let Some(old_key) = self.old_commits.get(&key.id.change_id) {
+            return self.commit_document.get(old_key);
+        }
+        // Give up
+        None
+    }
+
+    /// Move the specified value into the cache as the active value
+    /// of the key. Will remove any old values with the same change id.
+    pub fn insert_document(&mut self, value: CommitShowValue) {
+        let key = &value.key;
+        if let Some(old_key) = self.old_commits.get(&key.id.change_id) {
+            self.commit_document.remove(old_key);
+            self.old_commits.remove(&key.id.change_id);
+        }
+        self.commit_document.insert(key.clone(), value);
+    }
+
+    /// If key is cached, return a reference to that value,
+    /// otherwise generate the value,
+    /// insert it, and return a reference to the new inserted value.
+    /// This works around current rustc limitations on lifetime.
+    /// NOTE: fn_value must return a CommitShowValue that has the same key
+    /// as the one provided.
+    pub fn get_or_insert<T>(&mut self, key: &CommitShowKey, fn_value: T) -> &CommitShowValue
+    where
+        T: FnOnce() -> CommitShowValue,
+    {
+        // To fool the conservative borrow checker, we must first determine
+        // which code path to follow - and not getting any borrowed value back.
+        if !self.has_exact_match(key) {
+            let value = fn_value();
+            self.insert_document(value);
+            // Assuming that the value has the exact same key as key
+            // we are now guaranteed success on self.get(key) and may unwrap
+        }
+        self.get(key).unwrap()
+    }
+}

--- a/src/ui/commit_show_cache.rs
+++ b/src/ui/commit_show_cache.rs
@@ -122,6 +122,23 @@ impl CommitShowCache {
         }
     }
 
+    /// Mark all active heads as dirty by changing their width to 1.
+    /// This way they will all be seen as old next time [set_active] is called.
+    pub fn mark_dirty(&mut self) {
+        // Collect all keys for active commits
+        // std::mem::take moves the map out of self and leaves an empty one in its place
+        let active_commits = std::mem::take(&mut self.active_commits);
+        let active_keys: Vec<CommitShowKey> = active_commits.values().flatten().cloned().collect();
+        // Mark document as dirty
+        for ac_key in active_keys {
+            let Some(mut value) = self.commit_document.remove(&ac_key) else {
+                continue;
+            };
+            value.key.width = 1;
+            self.insert_document(value);
+        }
+    }
+
     /// Return true if the key is present as active
     pub fn has_exact_match(&self, key: &CommitShowKey) -> bool {
         self.commit_document.contains_key(key)

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -22,6 +22,7 @@ use crate::ui::ComponentAction;
 use crate::ui::help_popup::HelpPopup;
 use crate::ui::message_popup::MessagePopup;
 use crate::ui::panel::DetailsPanel;
+use crate::ui::panel::TextContent;
 use crate::ui::utils::tabs_to_spaces;
 
 /// Files tab. Shows files in selected change in main panel and selected file diff in details panel
@@ -317,9 +318,8 @@ impl Component for FilesTab {
                 Err(err) => err.into_text("Error getting diff")?,
             };
             self.diff_panel
-                .render_context()
+                .render_context::<TextContent>(diff_content)
                 .title(" Diff ")
-                .content(diff_content)
                 .draw(f, chunks[1]);
         }
 

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -183,11 +183,45 @@ impl<'a> LogTab<'a> {
         })
     }
 
+    /// Set cursor and update log panel and diff panel
+    pub fn set_head(&mut self, commander: &mut Commander, head: Head) {
+        self.log_panel.set_head(head);
+        self.log_panel.refresh_log_output(commander);
+        self.sync_head_output(commander);
+    }
+
     /// Extract selection from log panel and update change details panel
     fn sync_head_output(&mut self, commander: &mut Commander) {
         self.head = self.log_panel.head.clone();
         self.refresh_head_output(commander);
     }
+
+    /// Refesh the diff of the currently selected change
+    fn refresh_head_output(&mut self, commander: &mut Commander) {
+        // If the key matches, then we can use the cached value.
+        // This is not entierly true. A reconfiguration of jj could
+        // generate different output for some keys. We probably need
+        // a forced cache clear function.
+
+        // TODO use shared function to build key, so width can be cleared if not needed
+        let inner_width = self.head_panel.columns() as usize;
+        let key = CommitShowKey::new(self.head.clone(), self.diff_format.clone(), inner_width);
+        let _new_content = self.commit_show_cache.get_or_insert(&key, || {
+            Self::compute_head_content(commander, inner_width, &self.head, &self.diff_format)
+        });
+
+        let content_changed = self.head_key != key;
+
+        // Only update if content actually changed to prevent scroll jumping
+        if content_changed {
+            self.head_key = key;
+            self.head_panel.scroll_to(0);
+        }
+    }
+
+    //
+    // Cache related
+    //
 
     // TODO Add a function clear_commit_show_cache that is used
     // if the user asks for an application refresh.
@@ -217,36 +251,6 @@ impl<'a> LogTab<'a> {
         // Build value used by cache and return it
         let key = CommitShowKey::new(head.clone(), diff_format.clone(), inner_width);
         CommitShowValue::new(key, output)
-    }
-
-    /// Refesh the diff of the currently selected change
-    fn refresh_head_output(&mut self, commander: &mut Commander) {
-        // If the key matches, then we can use the cached value.
-        // This is not entierly true. A reconfiguration of jj could
-        // generate different output for some keys. We probably need
-        // a forced cache clear function.
-
-        // TODO use shared function to build key, so width can be cleared if not needed
-        let inner_width = self.head_panel.columns() as usize;
-        let key = CommitShowKey::new(self.head.clone(), self.diff_format.clone(), inner_width);
-        let _new_content = self.commit_show_cache.get_or_insert(&key, || {
-            Self::compute_head_content(commander, inner_width, &self.head, &self.diff_format)
-        });
-
-        let content_changed = self.head_key != key;
-
-        // Only update if content actually changed to prevent scroll jumping
-        if content_changed {
-            self.head_key = key;
-            self.head_panel.scroll_to(0);
-        }
-    }
-
-    /// Set cursor and update log panel and diff panel
-    pub fn set_head(&mut self, commander: &mut Commander, head: Head) {
-        self.log_panel.set_head(head);
-        self.log_panel.refresh_log_output(commander);
-        self.sync_head_output(commander);
     }
 }
 

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -89,6 +89,29 @@ pub struct LogTab<'a> {
     keybinds: LogTabKeybinds,
 }
 
+/**
+# Supporting functions
+Normally the event handling code would call
+member functions on log_panel and head_panel, but some operations
+are a little more complex. They get a supporting function.
+
+The main functions are:
+
+* [set_head](LogTab::set_head) - Move the selection to a particular
+  commit. Update panels.
+
+* [sync_head_output](LogTab::sync_head_output) - Make right panel show
+  what left panel selected.
+  (called by set_head)
+
+* [refresh_head_output](LogTab::refresh_head_output) - Update content of
+  right panel
+  (called by sync_head_output)
+
+* [compute_head_content](LogTab::compute_head_content) - Call jj show and
+  wrap the output as a ShowCacheValue
+  (called by refresh_head_output)
+*/
 impl<'a> LogTab<'a> {
     #[instrument(level = "info", name = "Initializing log tab", parent = None, skip(commander))]
     pub fn new(commander: &mut Commander) -> Result<Self> {
@@ -147,7 +170,7 @@ impl<'a> LogTab<'a> {
         })
     }
 
-    /// Update change details panel
+    /// Extract selection from log panel and update change details panel
     fn sync_head_output(&mut self, commander: &mut Commander) {
         self.head = self.log_panel.head.clone();
         self.refresh_head_output(commander);
@@ -179,7 +202,22 @@ impl<'a> LogTab<'a> {
         self.log_panel.refresh_log_output(commander);
         self.sync_head_output(commander);
     }
+}
 
+/**
+# Event handling
+Event handling happens in [`LogTab::handle_event`]. Over time, this has
+caused it to grow to a very long match with many arms. The size makes it hard
+to see what is going on, and the indentation is very deep.
+
+To fix this, we have begun a new code pattern, were the match arm simply
+calls a function. Most actions are two step operations, first create a dialog
+, then execcute some command. This is reflected in two functions located near
+each other in code:
+* `handle_<action>` - Set up the dialog and show it.
+* `execute_<action>` - Perform some action after the dialog closed.
+*/
+impl<'a> LogTab<'a> {
     fn handle_new(&mut self, describe: bool) -> Result<ComponentInputResult> {
         let mark_count = self.log_panel.marked_heads.len();
         let text = if mark_count > 0 {

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -20,7 +20,6 @@ use tui_confirm_dialog::ConfirmDialogState;
 use tui_confirm_dialog::Listener;
 
 use crate::ComponentInputResult;
-use crate::commander::CommandError;
 use crate::commander::Commander;
 use crate::commander::ids::CommitId;
 use crate::commander::log::Head;
@@ -31,10 +30,14 @@ use crate::keybinds::LogTabKeybinds;
 use crate::ui::Component;
 use crate::ui::ComponentAction;
 use crate::ui::bookmark_set_popup::BookmarkSetPopup;
+use crate::ui::commit_show_cache::CommitShowCache;
+use crate::ui::commit_show_cache::CommitShowKey;
+use crate::ui::commit_show_cache::CommitShowValue;
 use crate::ui::help_popup::HelpPopup;
 use crate::ui::loader_popup::LoaderPopup;
 use crate::ui::message_popup::MessagePopup;
 use crate::ui::panel::DetailsPanel;
+use crate::ui::panel::LargeStringContent;
 use crate::ui::panel::LogPanel;
 use crate::ui::rebase_popup::RebasePopup;
 use crate::ui::utils::centered_rect_fixed;
@@ -54,14 +57,17 @@ pub struct LogTab<'a> {
     /// The list of changes shown to the left
     log_panel: LogPanel<'a>,
 
-    /// The change content shown to the right
+    /// The panel showing change content to the right
     head_panel: DetailsPanel,
-    head_output: Result<String, CommandError>,
 
-    /// The currently selected change. Indicates what to render
-    /// in head_output. It is a copy of self.log_panel.head,
-    /// so if these differ, we need to update self.head and
-    /// self.head_output
+    /// The selected change content key in the cache
+    head_key: CommitShowKey,
+
+    /// Cached change content
+    commit_show_cache: CommitShowCache,
+
+    /// The currently selected change. It is a copy of `self.log_panel.head`,
+    /// so if these differ, we need to update `self.head`
     head: Head,
 
     // Location of panels on screen. [0] = log, [1] = details
@@ -119,9 +125,14 @@ impl<'a> LogTab<'a> {
 
         let head = commander.get_current_head()?;
 
-        let head_output = commander
-            .get_commit_show(&head.commit_id, &diff_format, true)
-            .map(|text| tabs_to_spaces(&text));
+        const NO_WIDTH: usize = 0;
+        let head_key = CommitShowKey::new(head.clone(), diff_format.clone(), NO_WIDTH);
+
+        let mut commit_show_cache = CommitShowCache::new();
+
+        let _new_content = commit_show_cache.get_or_insert(&head_key, || {
+            Self::compute_head_content(commander, NO_WIDTH, &head, &diff_format)
+        });
 
         let (popup_tx, popup_rx) = std::sync::mpsc::channel();
         let (bookmark_set_popup_tx, bookmark_set_popup_rx) = std::sync::mpsc::channel();
@@ -143,7 +154,9 @@ impl<'a> LogTab<'a> {
 
             head,
             head_panel: DetailsPanel::new(),
-            head_output,
+            head_key,
+
+            commit_show_cache,
 
             panel_rect: [Rect::ZERO, Rect::ZERO],
 
@@ -176,22 +189,55 @@ impl<'a> LogTab<'a> {
         self.refresh_head_output(commander);
     }
 
-    fn refresh_head_output(&mut self, commander: &mut Commander) {
-        let inner_width = self.head_panel.columns() as usize;
-        commander.limit_width(inner_width);
-        let new_output = commander
-            .get_commit_show(&self.head.commit_id, &self.diff_format, true)
-            .map(|text| tabs_to_spaces(&text));
+    // TODO Add a function clear_commit_show_cache that is used
+    // if the user asks for an application refresh.
+    //fn clear_commit_show_cache(&mut self) {
+    //    self.commit_show_cache.clear();
+    //}
 
-        let content_changed = match (&self.head_output, &new_output) {
-            (Ok(old), Ok(new)) => old != new,
-            (Err(old), Err(new)) => old.to_string() != new.to_string(),
-            _ => true,
+    /// Extract head content from commander.get_commit_show
+    /// Wraps it in a cache value before returning it.
+    fn compute_head_content(
+        commander: &mut Commander,
+        inner_width: usize,
+        head: &Head,
+        diff_format: &DiffFormat,
+    ) -> CommitShowValue {
+        // Call jj show
+        let commit_id = &head.commit_id;
+        commander.limit_width(inner_width);
+        let head_output = commander
+            .get_commit_show(commit_id, diff_format, true)
+            .map(|text| tabs_to_spaces(&text));
+        // Format output as string
+        let output = match head_output {
+            Ok(head_output) => head_output,
+            Err(err) => err.to_string(),
         };
+        // Build value used by cache and return it
+        let key = CommitShowKey::new(head.clone(), diff_format.clone(), inner_width);
+        CommitShowValue::new(key, output)
+    }
+
+    /// Refesh the diff of the currently selected change
+    fn refresh_head_output(&mut self, commander: &mut Commander) {
+        // If the key matches, then we can use the cached value.
+        // This is not entierly true. A reconfiguration of jj could
+        // generate different output for some keys. We probably need
+        // a forced cache clear function.
+
+        // TODO use shared function to build key, so width can be cleared if not needed
+        let inner_width = self.head_panel.columns() as usize;
+        let key = CommitShowKey::new(self.head.clone(), self.diff_format.clone(), inner_width);
+        let _new_content = self.commit_show_cache.get_or_insert(&key, || {
+            Self::compute_head_content(commander, inner_width, &self.head, &self.diff_format)
+        });
+
+        let content_changed = self.head_key != key;
 
         // Only update if content actually changed to prevent scroll jumping
         if content_changed {
-            self.head_output = new_output;
+            self.head_key = key;
             self.head_panel.scroll_to(0);
         }
     }
@@ -638,15 +684,10 @@ impl Component for LogTab<'_> {
         self.log_panel.draw(f, chunks[0])?;
 
         // Draw change details
-        {
-            let head_content = match self.head_output.as_ref() {
-                Ok(head_output) => head_output.into_text()?.lines,
-                Err(err) => err.into_text("Error getting head details")?.lines,
-            };
+        if let Some(content) = self.commit_show_cache.get(&self.head_key) {
             self.head_panel
-                .render_context()
+                .render_context::<LargeStringContent>(content.value())
                 .title(format!(" Details for {} ", self.head.change_id))
-                .content(head_content)
                 .draw(f, chunks[1])
         }
 

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -234,11 +234,11 @@ impl<'a> LogTab<'a> {
     // Cache related
     //
 
-    // TODO Add a function clear_commit_show_cache that is used
-    // if the user asks for an application refresh.
-    //fn clear_commit_show_cache(&mut self) {
-    //    self.commit_show_cache.clear();
-    //}
+    /// Mark all active elements as dirty, which will trigger a cache
+    /// update next time they are requested.
+    fn mark_cache_as_dirty(&mut self) {
+        self.commit_show_cache.mark_dirty();
+    }
 
     /// Get the list of active commits from the log panel, and mark
     /// the changes there as active. For non-active changes, keep at most
@@ -429,6 +429,7 @@ impl<'a> LogTab<'a> {
                 self.refresh_head_output(commander);
             }
             LogTabEvent::Refresh => {
+                self.mark_cache_as_dirty();
                 self.refresh_log_output(commander);
             }
 

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -106,15 +106,19 @@ The main functions are:
 * [set_head](LogTab::set_head) - Move the selection to a particular
   commit. Update panels.
 
+* [refresh_log_output](LogTab::refresh_log_output) - Update the log panel
+  by running `jj log`, and update the details panel.
+  (called by set_head)
+
 * [sync_head_output](LogTab::sync_head_output) - Make right panel show
   what left panel selected.
-  (called by set_head)
+  (called by refresh_log_output)
 
 * [refresh_head_output](LogTab::refresh_head_output) - Update content of
   right panel
   (called by sync_head_output)
 
-* [compute_head_content](LogTab::compute_head_content) - Call jj show and
+* [compute_head_content](LogTab::compute_head_content) - Call `jj show` and
   wrap the output as a ShowCacheValue
   (called by refresh_head_output)
 */
@@ -186,7 +190,14 @@ impl<'a> LogTab<'a> {
     /// Set cursor and update log panel and diff panel
     pub fn set_head(&mut self, commander: &mut Commander, head: Head) {
         self.log_panel.set_head(head);
+        self.refresh_log_output(commander);
+    }
+
+    /// Update the log panel and diff panel. This will also refresh
+    /// the diff cache.
+    fn refresh_log_output(&mut self, commander: &mut Commander) {
         self.log_panel.refresh_log_output(commander);
+        self.update_cache_active_commits();
         self.sync_head_output(commander);
     }
 
@@ -228,6 +239,19 @@ impl<'a> LogTab<'a> {
     //fn clear_commit_show_cache(&mut self) {
     //    self.commit_show_cache.clear();
     //}
+
+    /// Get the list of active commits from the log panel, and mark
+    /// the changes there as active. For non-active changes, keep at most
+    /// one commit.
+    fn update_cache_active_commits(&mut self) {
+        let key = CommitShowKey::new(
+            self.head.clone(),
+            self.diff_format.clone(),
+            self.head_panel.columns() as usize,
+        );
+        let active_heads = self.log_panel.log_heads();
+        self.commit_show_cache.set_active(active_heads, &key);
+    }
 
     /// Extract head content from commander.get_commit_show
     /// Wraps it in a cache value before returning it.
@@ -405,14 +429,12 @@ impl<'a> LogTab<'a> {
                 self.refresh_head_output(commander);
             }
             LogTabEvent::Refresh => {
-                self.log_panel.refresh_log_output(commander);
-                self.refresh_head_output(commander);
+                self.refresh_log_output(commander);
             }
 
             LogTabEvent::Duplicate => {
                 let _ = commander.run_duplicate(&self.head.change_id.to_string());
-                self.log_panel.refresh_log_output(commander);
-                self.refresh_head_output(commander);
+                self.refresh_log_output(commander);
             }
 
             LogTabEvent::CreateNew { describe } => {
@@ -645,8 +667,7 @@ impl Component for LogTab<'_> {
                 }
                 EDIT_POPUP_ID => {
                     commander.run_edit(self.head.commit_id.as_str(), self.edit_ignore_immutable)?;
-                    self.log_panel.refresh_log_output(commander);
-                    self.refresh_head_output(commander);
+                    self.refresh_log_output(commander);
                     return Ok(Some(ComponentAction::ChangeHead(self.head.clone())));
                 }
                 ABANDON_POPUP_ID => {
@@ -663,8 +684,7 @@ impl Component for LogTab<'_> {
         }
 
         if let Ok(true) = self.bookmark_set_popup_rx.try_recv() {
-            self.log_panel.refresh_log_output(commander);
-            self.refresh_head_output(commander)
+            self.refresh_log_output(commander);
         }
 
         Ok(None)
@@ -828,7 +848,7 @@ impl Component for LogTab<'_> {
                         } else {
                             Some(log_revset)
                         };
-                        self.log_panel.refresh_log_output(commander);
+                        self.refresh_log_output(commander);
                         self.log_revset_textarea = None;
                         return Ok(ComponentInputResult::Handled);
                     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,6 +1,7 @@
 pub mod bookmark_set_popup;
 pub mod bookmarks_tab;
 pub mod command_popup;
+pub mod commit_show_cache;
 pub mod files_tab;
 pub mod help_popup;
 pub mod loader_popup;

--- a/src/ui/panel/details_panel.rs
+++ b/src/ui/panel/details_panel.rs
@@ -1,3 +1,16 @@
+/*!
+The details_panel module contains the main class [DetailsPanel] which
+can show various content with an automatic scroll bar.
+
+There is no content in the DetailsPanel, that is provided every frame
+and rendered using the DetailsPanelRenderContext.
+
+To make this effcicient there are two ways to provide content.
+* TextContent - for small texts rendered as a Ratatui Paragraph.
+* LargeStringContent - to render only the visible subset.
+
+*/
+
 use ratatui::crossterm::event::KeyCode;
 use ratatui::crossterm::event::KeyEvent;
 use ratatui::crossterm::event::KeyModifiers;
@@ -18,6 +31,8 @@ use ratatui::widgets::ScrollbarState;
 use ratatui::widgets::Wrap;
 use tracing::trace;
 
+use crate::ui::utils::LargeString;
+
 /// Details panel used for the right side of each tab.
 /// This handles scrolling and wrapping.
 pub struct DetailsPanel {
@@ -33,11 +48,30 @@ pub struct DetailsPanel {
     wrap: bool,
 }
 
+/// Content of the detail panel must be able to render as a paragraph
+pub trait DetailContent<'a> {
+    /// Render content as a paragraph, and update panel total lines
+    fn render_as_paragraph(&self, panel: &mut DetailsPanel, area: Rect) -> Paragraph<'_>;
+}
+
+/// Content is preformatted ratatui Text
+pub struct TextContent<'a> {
+    text: Text<'a>,
+}
+
+/// Content is a large string that can quickly fetch a range of lines
+pub struct LargeStringContent<'a> {
+    large_string: &'a LargeString,
+}
+
 /// Transient object holding render data
-pub struct DetailsPanelRenderContext<'a> {
+pub struct DetailsPanelRenderContext<'a, Content>
+where
+    Content: DetailContent<'a>,
+{
     panel: &'a mut DetailsPanel,
     title: Option<Line<'a>>,
-    content: Option<Text<'a>>,
+    content: Content,
 }
 
 /// Commands that can be handled by the details panel
@@ -51,12 +85,59 @@ pub enum DetailsPanelEvent {
     ToggleWrap,
 }
 
-impl<'a> DetailsPanelRenderContext<'a> {
-    pub fn new(panel: &'a mut DetailsPanel) -> Self {
+//
+//  implementation
+//
+
+impl<'a> From<&'a LargeString> for LargeStringContent<'a> {
+    fn from(large_string: &'a LargeString) -> Self {
+        Self { large_string }
+    }
+}
+
+//impl<'a> From<Text<'a>> for TextContent<'a> {
+impl<'a, T: Into<Text<'a>>> From<T> for TextContent<'a> {
+    fn from(content: T) -> Self {
+        let text = content.into();
+        Self { text }
+    }
+}
+
+impl<'a> DetailContent<'a> for LargeStringContent<'a> {
+    fn render_as_paragraph(&self, panel: &mut DetailsPanel, area: Rect) -> Paragraph<'_> {
+        // Update total length. This is used by the scroll bar
+        panel.lines = self.large_string.lines() as u16;
+        // Extract visible part of content
+        let top_line = panel.scroll as usize;
+        let line_count = area.height as usize;
+        let content_text = self.large_string.render(top_line, line_count);
+        Paragraph::new(content_text)
+    }
+}
+
+impl<'a> DetailContent<'a> for TextContent<'a> {
+    fn render_as_paragraph(&self, panel: &mut DetailsPanel, area: Rect) -> Paragraph<'_> {
+        let content_text = &self.text;
+        let mut paragraph = Paragraph::new(content_text.clone());
+
+        panel.content_rect = area;
+        panel.lines = paragraph.line_count(area.width) as u16;
+
+        paragraph = paragraph.scroll((panel.scroll.min(panel.lines.saturating_sub(1)), 0));
+
+        paragraph
+    }
+}
+
+impl<'a, Content> DetailsPanelRenderContext<'a, Content>
+where
+    Content: DetailContent<'a>,
+{
+    pub fn new(panel: &'a mut DetailsPanel, content: Content) -> Self {
         Self {
             panel,
             title: None,
-            content: None,
+            content,
         }
     }
     /// Set the title on the frame that surrounds the content
@@ -65,14 +146,6 @@ impl<'a> DetailsPanelRenderContext<'a> {
         T: Into<Line<'a>>,
     {
         self.title = Some(title.into());
-        self
-    }
-    /// Set the text inside the panel
-    pub fn content<T>(&mut self, content: T) -> &mut Self
-    where
-        T: Into<Text<'a>>,
-    {
-        self.content = Some(content.into());
         self
     }
 
@@ -89,17 +162,16 @@ impl<'a> DetailsPanelRenderContext<'a> {
             border = border.title_top(title.clone());
         }
 
-        // Find text inside border
-        let content_text = match &self.content {
-            Some(text) => text,
-            None => &Text::raw(""),
-        };
         // Create content widget that uses border
         let paragraph_area = border.inner(area);
-        let paragraph = self
-            .panel
-            .render(content_text.clone(), paragraph_area)
+        let content = &self.content;
+        let mut paragraph = content
+            .render_as_paragraph(self.panel, paragraph_area)
             .block(border);
+
+        if self.panel.wrap {
+            paragraph = paragraph.wrap(Wrap { trim: false });
+        }
 
         // render content and border
         f.render_widget(paragraph, area);
@@ -134,27 +206,16 @@ impl DetailsPanel {
         }
     }
 
-    pub fn render_context(&mut self) -> DetailsPanelRenderContext<'_> {
-        DetailsPanelRenderContext::new(self)
-    }
-
-    /// Render the content into the area.
-    pub fn render<'a, T>(&mut self, content: T, area: Rect) -> Paragraph<'a>
+    /// Create a RenderContext that can render the provided content
+    /// as a Paragraph into an area.
+    pub fn render_context<'a, Content>(
+        &'a mut self,
+        content: impl Into<Content>,
+    ) -> DetailsPanelRenderContext<'a, Content>
     where
-        T: Into<Text<'a>>,
+        Content: DetailContent<'a>,
     {
-        let mut paragraph = Paragraph::new(content);
-
-        if self.wrap {
-            paragraph = paragraph.wrap(Wrap { trim: false });
-        }
-
-        self.content_rect = area;
-        self.lines = paragraph.line_count(area.width) as u16;
-
-        paragraph = paragraph.scroll((self.scroll.min(self.lines.saturating_sub(1)), 0));
-
-        paragraph
+        DetailsPanelRenderContext::new(self, content.into())
     }
 
     /// Return number of columns available for content at last call to render.

--- a/src/ui/panel/log_panel.rs
+++ b/src/ui/panel/log_panel.rs
@@ -218,6 +218,14 @@ impl<'a> LogPanel<'a> {
         }
     }
 
+    /// Get a list of all heads in log list
+    pub fn log_heads(&self) -> Vec<Head> {
+        match self.log_output.as_ref() {
+            Ok(log_output) => log_output.heads.clone(),
+            Err(_) => vec![],
+        }
+    }
+
     //
     //  Selected head and the special head index
     //

--- a/src/ui/panel/mod.rs
+++ b/src/ui/panel/mod.rs
@@ -2,4 +2,6 @@ mod details_panel;
 mod log_panel;
 
 pub use details_panel::DetailsPanel;
+pub use details_panel::LargeStringContent;
+pub use details_panel::TextContent;
 pub use log_panel::LogPanel;

--- a/src/ui/utils.rs
+++ b/src/ui/utils.rs
@@ -1,3 +1,6 @@
+mod large_string;
+pub use large_string::LargeString;
+
 use ratatui::layout::Constraint;
 use ratatui::layout::Direction;
 use ratatui::layout::Layout;

--- a/src/ui/utils.rs
+++ b/src/ui/utils.rs
@@ -1,6 +1,5 @@
 mod large_string;
 pub use large_string::LargeString;
-
 use ratatui::layout::Constraint;
 use ratatui::layout::Direction;
 use ratatui::layout::Layout;

--- a/src/ui/utils/large_string.rs
+++ b/src/ui/utils/large_string.rs
@@ -1,0 +1,72 @@
+/*! The LargeString structure is optimized for storing large output of jj
+in a way that can be quickly rendered. Normally you could convert the
+output to a Text but this require more space. Instead, the LargeString
+findes all line breaks, and provide methods for converting only the
+visible lines into a Text. */
+
+use ansi_to_tui::IntoText;
+use ratatui::text::Text;
+use tracing::error;
+
+/// Store a large ANSI colour coded string in a way that allows you
+/// to quickly extract a small range and convert it into Text
+pub struct LargeString {
+    /// The stored string
+    content: String,
+    /// First byte of each line in content
+    line_start: Vec<usize>,
+}
+
+impl LargeString {
+    /// Find line start of all lines
+    /// to enable quick rendering of a small range of lines.
+    pub fn new(content: String) -> Self {
+        // Index content
+        let bytes = content.as_bytes();
+        let mut line_start = vec![];
+        let mut i = 0;
+        while i < bytes.len() {
+            // Found new line start
+            line_start.push(i);
+            // Skip all non-EOL chars
+            fn is_eol_char(c: u8) -> bool {
+                c == b'\n' || c == b'\r'
+            }
+            while i < bytes.len() && !is_eol_char(bytes[i]) {
+                i += 1;
+            }
+            // If at a pair of CR LF, then skip the first of those
+            if i + 1 < bytes.len() && is_eol_char(bytes[i + 1]) && bytes[i] != bytes[i + 1] {
+                i += 1;
+            }
+            // Include the last EOL char in this line
+            i += 1;
+        }
+        // Create object
+        Self {
+            content,
+            line_start,
+        }
+    }
+
+    /// Number of lines in content
+    pub fn lines(&self) -> usize {
+        self.line_start.len()
+    }
+
+    /// Render a range of lines of the content as Text
+    pub fn render(&self, top_line: usize, line_count: usize) -> Text<'_> {
+        let end_of_content = self.content.len();
+        let get_line_start = |line| self.line_start.get(line).copied().unwrap_or(end_of_content);
+        let start = get_line_start(top_line);
+        let end = get_line_start(top_line + line_count);
+        let content_str: &str = &self.content[start..end];
+        match content_str.into_text() {
+            Ok(text) => text,
+            Err(err) => {
+                error!("Error converting \"{}\" into ratatui::Text", content_str);
+                Text::from(format!("{}", err))
+            }
+        }
+    }
+}


### PR DESCRIPTION
A cache of the `jj show` output used on the log tab.

Features:
* Speed up selecting a change in log tab: Eliminates redundant call to `jj show` 
* Slow memory growth: Only stores one entry per change seen during the current blazingjj session.
* Play nice with rebase: Provides the previous commit content for a change, until the change is updated.
* Handles divergent changes: Each commit gets a separate cache entry.
* RAM efficient: Stores the raw jj output (ANSI-string) instead of ratatui::Text
* Fast render of large change: Process only the visible lines during draw.
* Manual forced refresh: Marks every change as needing-an-update on an explicit refresh action.
