### PR TITLE
Fix ansi-to-tui dependency to allow publishing to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ pkg-url = "{ repo }/releases/download/v{ version }/blazingjj-v{ version }-{ targ
 
 
 [dependencies]
-ansi-to-tui = { git = "https://github.com/Cretezy/ansi-to-tui.git", rev = "74bd97e" }
+ansi-to-tui = "7.0.0"
 anyhow = "1.0.95"
 chrono = "0.4.39"
 clap = { version = "4.5.31", features = ["derive", "env"] }
@@ -39,6 +39,9 @@ tracing-subscriber = "0.3.19"
 tui-textarea = "0.7.0"
 tui_confirm_dialog = "0.3.1"
 version-compare = "0.2.0"
+
+[patch.crates-io]
+ansi-to-tui = { git = "https://github.com/Cretezy/ansi-to-tui.git", rev = "74bd97e" }
 
 # Release build optimize size.
 # Run strip manually after build to reduce further.


### PR DESCRIPTION
For the ansi-to-tui we want to use a patched version to incorporate a fix for some crlf issues and we currently simply refer to the specific git revision in the [dependencies] section, but this blocks publishing on crates.io which only allows properly released versions there.

Instead, we can use the [patch.crates-io] section, so local builds use the patched version, but crates.io is still happy.