### PR TITLE
Add support for interactive commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Keybinding for jj absorb (`A`)
+- Configurable describe mode (`describe-mode = "jj"` runs `jj describe` interactively instead of using the popup)
 
 ## [0.8.0] - 2026-04-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Message popup now supports scrolling with a scrollbar
 - Command popup output now preserves ANSI color
 - Drag to resize pane divider in all tabs
+- Configurable describe mode (`describe-mode = "jj"` runs `jj describe` interactively instead of using the popup)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   outside also goes on to the tab underneath, which may act on what was hit
 - Context menu popup (right-click or `Menu` key) with the common operations for
   whatever the tab has selected: a change, a file, a version or a bookmark
+- `blazingjj.describe-mode` to set what describing a change puts up, the
+  built-in editor or an interactive `jj describe`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   whatever the tab has selected: a change, a file, a version or a bookmark
 - `blazingjj.describe-mode` to set what describing a change puts up, the
   built-in editor or an interactive `jj describe`
+- `!` opens the command popup with the terminal handed to what is run, so
+  that commands wanting an editor, such as `describe` or `split`, can be
+  used; running one with `:` offers to run it in the terminal rather than
+  hanging
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "shell-words",
+ "signal-hook",
  "tempfile",
  "thiserror 2.0.20",
  "throbber-widgets-tui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,9 @@ tracing-subscriber = "0.3.23"
 ratatui-textarea = "0.9.2"
 version-compare = "0.2.1"
 
+[target."cfg(unix)".dependencies]
+signal-hook = { version = "0.3", default-features = false }
+
 # Release build optimize size.
 # Run strip manually after build to reduce further.
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ You can optionally configure the following options through your jj config:
   - If `blazingjj.diff-tool` is not set but `ui.diff.tool` is, the latter will be used
 - `blazingjj.bookmark-template`: Change the bookmark name template for generated bookmark names. Defaults to `'push-' ++ change_id.short()`
   - If `blazingjj.bookmark-template` is not set but `templates.git_push_bookmark` is, the latter will be used
+- `blazingjj.describe-mode`: What describing a change puts up. Can be `popup` (default) for the built-in editor, or `jj` to hand the terminal to `jj describe` and your own editor
 - `blazingjj.layout`: Changes the layout of the main and details panel. Can be `horizontal` (default) or `vertical`
 - `blazingjj.layout-percent`: Changes the layout split of the main page. Should be number between 0 and 100. Defaults to `50`
 - `blazingjj.poll-interval`: Seconds between checks for work done outside the app. Set to `0` to only check when asked. Defaults to `1`

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -32,6 +32,7 @@ next-tab = "l"
 prev-tab = "h"
 
 command-popup = ":"
+interactive-command-popup = "!"
 quit = ["q", "ctrl+c"]
 ```
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,5 @@
 use core::fmt;
+use std::process::Command;
 use std::time::Instant;
 
 use anyhow::Result;
@@ -51,6 +52,9 @@ pub struct App<'a> {
     pub bookmarks: Option<BookmarksTab<'a>>,
     pub popup: Option<Box<dyn Component>>,
     pub stats: Stats,
+    /// Interactive command queued by a component for the main loop to run
+    /// after restoring the terminal.
+    pub pending_interactive: Option<Command>,
 }
 
 impl<'a> App<'a> {
@@ -64,6 +68,7 @@ impl<'a> App<'a> {
             stats: Stats {
                 start_time: Instant::now(),
             },
+            pending_interactive: None,
         })
     }
 
@@ -148,6 +153,22 @@ impl<'a> App<'a> {
         }
     }
 
+    /// Re-sync the current view's state with the working copy. Called by the
+    /// main loop after an interactive command may have mutated the repo.
+    pub fn refresh_current_view(&mut self) -> Result<()> {
+        match self.current_tab {
+            Tab::Log => {
+                if let Some(log) = self.log.as_mut() {
+                    log.refresh_selected_head()?;
+                }
+            }
+            Tab::Files | Tab::Bookmarks => {
+                self.handle_action(ComponentAction::RefreshTab())?;
+            }
+        }
+        Ok(())
+    }
+
     pub fn handle_action(&mut self, component_action: ComponentAction) -> Result<()> {
         match component_action {
             ComponentAction::ViewFiles(head) => {
@@ -175,6 +196,9 @@ impl<'a> App<'a> {
                     let head = new_commander().get_current_head()?.clone();
                     self.get_log_tab()?.set_head(head);
                 };
+            }
+            ComponentAction::RunInteractive(command) => {
+                self.pending_interactive = Some(command);
             }
         }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -47,6 +47,7 @@ use crate::ui::Interactive;
 use crate::ui::Scroll;
 use crate::ui::Tab;
 use crate::ui::bookmarks_tab::BookmarksTab;
+use crate::ui::dialog::CommandMode;
 use crate::ui::dialog::CommandPopup;
 use crate::ui::dialog::HelpPopup;
 use crate::ui::evolog_tab::EvologTab;
@@ -685,7 +686,12 @@ impl<'a> App<'a> {
                             GlobalEvent::BookmarksTab => self.set_tab(TabId::Bookmarks),
                             GlobalEvent::EvologTab => self.set_tab(TabId::Evolog),
                             GlobalEvent::CommandPopup => {
-                                self.popup = Some(Box::new(CommandPopup::new()));
+                                self.popup =
+                                    Some(Box::new(CommandPopup::new(CommandMode::Capture)));
+                            }
+                            GlobalEvent::InteractiveCommandPopup => {
+                                self.popup =
+                                    Some(Box::new(CommandPopup::new(CommandMode::Interactive)));
                             }
                             GlobalEvent::OpenHelp => self.open_help()?,
                             GlobalEvent::Quit => {

--- a/src/app.rs
+++ b/src/app.rs
@@ -43,6 +43,7 @@ use crate::keybinds::PopupKeybinds;
 use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
+use crate::ui::Interactive;
 use crate::ui::Scroll;
 use crate::ui::Tab;
 use crate::ui::bookmarks_tab::BookmarksTab;
@@ -109,6 +110,10 @@ pub struct App<'a> {
 
     repo_watch: RepoWatch,
 
+    /// Interactive command queued by a component for the main loop to run
+    /// after restoring the terminal.
+    pending_interactive: Option<Interactive>,
+
     // event handling
     running: Arc<AtomicBool>,
     event_source: EventSource,
@@ -142,6 +147,7 @@ impl<'a> App<'a> {
             popup_keybinds: PopupKeybinds::dialog(),
 
             repo_watch: RepoWatch::new(get_env().jj_config.poll_interval(), Instant::now()),
+            pending_interactive: None,
 
             running,
             event_source,
@@ -275,6 +281,16 @@ impl<'a> App<'a> {
         }
     }
 
+    /// Take the interactive command a component has asked for, if any.
+    pub fn take_pending_interactive(&mut self) -> Option<Interactive> {
+        self.pending_interactive.take()
+    }
+
+    /// Have every tab read the repo again.
+    pub fn catch_up_with_repo(&mut self) -> Result<()> {
+        self.handle_action(AppAction::MarkTabsStale)
+    }
+
     /// When a component wants the app to do something,
     /// it sends a AppAction which the App handles.
     pub fn handle_action(&mut self, app_action: AppAction) -> Result<()> {
@@ -331,6 +347,9 @@ impl<'a> App<'a> {
                     snapshot: false,
                     ours: true,
                 });
+            }
+            AppAction::RunInteractive(interactive) => {
+                self.pending_interactive = Some(interactive);
             }
         }
 
@@ -496,6 +515,17 @@ impl<'a> App<'a> {
     /// Set up threads that capture input and send AppEvents
     pub fn launch_input_channel(&mut self) {
         self.event_source.launch_user_input();
+    }
+
+    /// Stop reading user input, handing the terminal over to a foreground
+    /// process
+    pub fn pause_input(&mut self) {
+        self.event_source.pause_user_input();
+    }
+
+    /// Read user input again after a foreground process is done
+    pub fn resume_input(&mut self) {
+        self.event_source.resume_user_input();
     }
 
     /// Recieve an AppEvent if one is waiting

--- a/src/app.rs
+++ b/src/app.rs
@@ -18,6 +18,7 @@ use ratatui::widgets::*;
 use tracing::info;
 use tracing::instrument;
 
+use crate::commander::JjCommand;
 use crate::commander::new_commander;
 use crate::env::get_env;
 use crate::ui::AppAction;
@@ -60,6 +61,9 @@ pub struct App<'a> {
     pub bookmarks: Option<BookmarksTab<'a>>,
     pub popup: Option<Box<dyn Component>>,
     pub stats: Stats,
+    /// Interactive command queued by a component for the main loop to run
+    /// after restoring the terminal.
+    pub pending_interactive: Option<JjCommand>,
 }
 
 impl<'a> App<'a> {
@@ -73,6 +77,7 @@ impl<'a> App<'a> {
             stats: Stats {
                 start_time: Instant::now(),
             },
+            pending_interactive: None,
         })
     }
 
@@ -158,6 +163,22 @@ impl<'a> App<'a> {
         }
     }
 
+    /// Re-sync the current view's state with the working copy. Called by the
+    /// main loop after an interactive command may have mutated the repo.
+    pub fn refresh_current_view(&mut self) -> Result<()> {
+        match self.current_tab {
+            Tab::Log => {
+                if let Some(log) = self.log.as_mut() {
+                    log.refresh_selected_head()?;
+                }
+            }
+            Tab::Files | Tab::Bookmarks => {
+                self.handle_action(AppAction::RefreshTab())?;
+            }
+        }
+        Ok(())
+    }
+
     /// When a component wants the app to do something,
     /// it sends a AppAction which the App handles.
     pub fn handle_action(&mut self, app_action: AppAction) -> Result<()> {
@@ -187,6 +208,9 @@ impl<'a> App<'a> {
                     let head = new_commander().get_current_head()?.clone();
                     self.get_log_tab()?.set_head(head);
                 };
+            }
+            AppAction::RunInteractive(command) => {
+                self.pending_interactive = Some(command);
             }
         }
 

--- a/src/app/command.rs
+++ b/src/app/command.rs
@@ -34,10 +34,10 @@ use crate::ui::dialog::BookmarkNameMode;
 use crate::ui::dialog::BookmarkNamePopup;
 use crate::ui::dialog::BookmarkSetPopup;
 use crate::ui::dialog::ConfirmPopup;
-use crate::ui::dialog::DescribePopup;
 use crate::ui::dialog::LoaderPopup;
 use crate::ui::dialog::MessagePopup;
 use crate::ui::dialog::RebasePopup;
+use crate::ui::dialog::describe_action;
 use crate::ui::dialog::new_insert;
 
 /// What a new change is created from, which decides whether the log is
@@ -144,10 +144,7 @@ impl Command {
                     actions.push(AppAction::ClearLogMarks);
                 }
                 if describe {
-                    actions.push(AppAction::SetPopup(Box::new(DescribePopup::new(
-                        head,
-                        vec![],
-                    ))));
+                    actions.push(describe_action(&head, || Ok(vec![]))?);
                 }
 
                 Ok(Some(AppAction::Multiple(actions)))
@@ -358,16 +355,13 @@ pub fn describe(head: &Head) -> Result<AppAction> {
         ));
     }
 
-    let lines = new_commander()
-        .get_commit_description(&head.commit_id)?
-        .split('\n')
-        .map(str::to_owned)
-        .collect();
-
-    Ok(AppAction::SetPopup(Box::new(DescribePopup::new(
-        head.clone(),
-        lines,
-    ))))
+    describe_action(head, || {
+        Ok(new_commander()
+            .get_commit_description(&head.commit_id)?
+            .split('\n')
+            .map(str::to_owned)
+            .collect())
+    })
 }
 
 /// Asking to rebase the working copy commit onto `destination`.

--- a/src/commander/mod.rs
+++ b/src/commander/mod.rs
@@ -146,16 +146,8 @@ impl Commander {
     /// Execute a command and record to history.
     /// Environment variables can be set with set_env.
     /// They are cleared after execution.
-    fn execute_command(&self, command: &mut Command) -> Result<String, CommandError> {
-        // Set current directory to root
-        command.current_dir(&self.env.root);
-
-        // Set environment variables and clear them for the next command
-        command.envs(self.env_var.lock().unwrap().iter().cloned());
-        self.env_var.lock().unwrap().clear();
-
-        let output = command.output();
-        let output = output?;
+    fn execute_command(&self, mut command: Command) -> Result<String, CommandError> {
+        let output = command.output()?;
 
         if !output.status.success() {
             // Return JjError if non-zero status code
@@ -179,17 +171,7 @@ impl Commander {
         I: IntoIterator<Item = S>,
         S: AsRef<OsStr>,
     {
-        let mut command = Command::new(&self.env.jj_bin);
-        command.args(args);
-        command.args(get_output_args(!self.force_no_color && color, quiet));
-
-        if let Some(jj_config_toml) = &self.jj_config_toml {
-            for cfg in jj_config_toml {
-                command.args(["--config", cfg]);
-            }
-        }
-
-        self.execute_command(&mut command)
+        self.execute_command(self.build_jj_command(args, color, quiet))
     }
 
     /// Execute a jj command without using the output.
@@ -199,8 +181,54 @@ impl Commander {
         S: AsRef<OsStr>,
     {
         // Since no result is used, enable color for command log
-        self.execute_jj_command(args, true, true)?;
-        Ok(())
+        self.execute_command(self.build_jj_command(args, true, true))
+            .and(Ok(()))
+    }
+
+    /// Build a jj command intended to run interactively (taking over the terminal).
+    /// Execution must happen in the main loop after restoring the terminal.
+    pub fn build_interactive_jj_command<I, S>(&self, args: I) -> Command
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        self.build_jj_command(args, true, true)
+    }
+
+    fn build_command<B, I, S>(&self, bin: B, args: I) -> Command
+    where
+        I: IntoIterator<Item = S>,
+        B: AsRef<OsStr>,
+        S: AsRef<OsStr>,
+    {
+        let mut command = Command::new(bin);
+        command.args(args);
+
+        // Set current directory to root
+        command.current_dir(&self.env.root);
+
+        // Set environment variables and clear them for the next command
+        command.envs(self.env_var.lock().unwrap().iter().cloned());
+        self.env_var.lock().unwrap().clear();
+
+        command
+    }
+
+    fn build_jj_command<I, S>(&self, args: I, color: bool, quiet: bool) -> Command
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        let mut command = self.build_command(&self.env.jj_bin, args);
+        command.args(get_output_args(!self.force_no_color && color, quiet));
+
+        if let Some(jj_config_toml) = &self.jj_config_toml {
+            for cfg in jj_config_toml {
+                command.args(["--config", cfg]);
+            }
+        }
+
+        command
     }
 
     /// Check that the version of jj is recent enough to work with blazingjj

--- a/src/commander/mod.rs
+++ b/src/commander/mod.rs
@@ -33,6 +33,7 @@ use std::ffi::OsString;
 use std::io;
 use std::io::Write;
 use std::process::Command;
+use std::process::ExitStatus;
 use std::process::Stdio;
 use std::string::FromUtf8Error;
 
@@ -147,7 +148,7 @@ impl Commander {
     /// The returned [JjCommand] carries the per-command options (color,
     /// quiet, ...) and is executed with [JjCommand::run] or
     /// [JjCommand::run_void].
-    pub fn jj<I, S>(&self, args: I) -> JjCommand<'_>
+    pub fn jj<I, S>(&self, args: I) -> JjCommand
     where
         I: IntoIterator<Item = S>,
         S: AsRef<OsStr>,
@@ -156,11 +157,19 @@ impl Commander {
         if let Some(columns) = self.columns {
             env_var.push(("COLUMNS".to_owned(), columns.to_string()));
         }
+        let mut args: Vec<_> = args.into_iter().map(|s| s.as_ref().to_owned()).collect();
+        if let Some(jj_config_toml) = &self.jj_config_toml {
+            for cfg in jj_config_toml {
+                args.extend_from_slice(&["--config".into(), cfg.into()]);
+            }
+        }
 
         JjCommand {
-            commander: self,
-            args: args.into_iter().map(|s| s.as_ref().to_owned()).collect(),
+            jj_bin: self.env.jj_bin.clone(),
+            root: self.env.root.clone(),
+            args,
             color: false,
+            force_no_color: self.force_no_color,
             quiet: true,
             stdin: None,
             env_var,
@@ -210,13 +219,15 @@ impl Commander {
 /// Carries the arguments and the per-command options. Configuration
 /// methods consume and return the builder so they can be chained; the
 /// command is run exactly once with [Self::run] or [Self::run_void].
-pub struct JjCommand<'a> {
-    commander: &'a Commander,
+pub struct JjCommand {
+    jj_bin: String,
+    root: String,
     args: Vec<OsString>,
     /// Whether the command should emit ANSI color. Off by default so output
     /// is safe to parse; enable with [Self::color] for output shown to the
     /// user.
     color: bool,
+    force_no_color: bool,
     /// Whether to pass `--quiet`. On by default.
     quiet: bool,
     /// Data to feed the command on standard input, if any.
@@ -225,7 +236,7 @@ pub struct JjCommand<'a> {
     env_var: Vec<(String, String)>,
 }
 
-impl JjCommand<'_> {
+impl JjCommand {
     /// Enable ANSI color in the command's output.
     ///
     /// Off by default, so parsed output stays free of escape codes; enable it
@@ -267,27 +278,33 @@ impl JjCommand<'_> {
         Ok(())
     }
 
+    /// Execute the command and return its standard output.
+    pub fn run_foreground(self) -> io::Result<ExitStatus> {
+        let mut command = self.build_command();
+        command.spawn()?.wait()
+    }
+
+    fn build_command(&self) -> Command {
+        let mut command = Command::new(&self.jj_bin);
+        command
+            .args(&self.args)
+            .args(get_output_args(
+                !self.force_no_color && self.color,
+                self.quiet,
+            ))
+            .current_dir(&self.root)
+            .envs(self.env_var.iter().cloned());
+        command
+    }
+
     /// Configure and run the command, returning the captured standard output.
     ///
     /// `stdout` selects how the child's standard output is handled: piped to
     /// be captured and returned, or null to be discarded. Standard error is
     /// always captured so it can be surfaced on failure.
     fn execute(self, stdout: Stdio) -> Result<Vec<u8>, CommandError> {
-        let mut command = Command::new(&self.commander.env.jj_bin);
-        command.args(&self.args);
-        command.args(get_output_args(
-            !self.commander.force_no_color && self.color,
-            self.quiet,
-        ));
+        let mut command = self.build_command();
 
-        if let Some(jj_config_toml) = &self.commander.jj_config_toml {
-            for cfg in jj_config_toml {
-                command.args(["--config", cfg]);
-            }
-        }
-
-        command.current_dir(&self.commander.env.root);
-        command.envs(self.env_var.iter().cloned());
         command.stdout(stdout);
         command.stderr(Stdio::piped());
 

--- a/src/commander/mod.rs
+++ b/src/commander/mod.rs
@@ -20,6 +20,7 @@ invocation with [Commander::jj], which returns a [JjCommand] builder:
 * [JjCommand::run] - Execute the command and return its output
 * [JjCommand::run_void] - Execute the command and discard the output
 * [JjCommand::run_cancellable] - Execute the command so it can be killed
+* [JjCommand::run_foreground] - Execute the command attached to the terminal
 
 */
 
@@ -39,6 +40,7 @@ use std::io::Read;
 use std::io::Write;
 use std::process::Child;
 use std::process::Command;
+use std::process::ExitStatus;
 use std::process::Stdio;
 use std::string::FromUtf8Error;
 use std::thread;
@@ -158,7 +160,8 @@ impl Commander {
     ///
     /// The returned [JjCommand] carries the per-command options (color,
     /// quiet, ...) and is executed with [JjCommand::run],
-    /// [JjCommand::run_void] or [JjCommand::run_cancellable].
+    /// [JjCommand::run_void], [JjCommand::run_cancellable] or
+    /// [JjCommand::run_foreground].
     pub fn jj<I, S>(&self, args: I) -> JjCommand
     where
         I: IntoIterator<Item = S>,
@@ -230,8 +233,9 @@ impl Commander {
 ///
 /// Carries the arguments and the per-command options. Configuration
 /// methods consume and return the builder so they can be chained; the
-/// command is run exactly once with [Self::run], [Self::run_void] or
-/// [Self::run_cancellable].
+/// command is run exactly once with [Self::run], [Self::run_void],
+/// [Self::run_cancellable] or [Self::run_foreground], the last of which
+/// leaves the output options to jj.
 pub struct JjCommand {
     jj_bin: String,
     root: String,
@@ -319,6 +323,15 @@ impl JjCommand {
         }))
     }
 
+    /// Run the command with the terminal handed over to it, so it can page,
+    /// colorize and prompt as it would outside the app, and return how it
+    /// exited. The terminal is the command's to read and write as it sees
+    /// fit, so [Self::stdin], [Self::color] and [Self::verbose] have no say
+    /// here.
+    pub fn run_foreground(self) -> io::Result<ExitStatus> {
+        self.build_command().status()
+    }
+
     /// Configure and run the command in a child process `cancel` can kill,
     /// blocking until it is done, and return its captured standard output.
     ///
@@ -329,6 +342,10 @@ impl JjCommand {
         let input = self.stdin.take();
 
         let mut command = self.build_command();
+        command.args(get_output_args(
+            !self.force_no_color && self.color,
+            self.quiet,
+        ));
         command
             .stdin(if input.is_some() {
                 Stdio::piped()
@@ -392,14 +409,11 @@ impl JjCommand {
         Ok(output)
     }
 
-    /// Construct a Command ready for execution
+    /// Construct a Command ready for execution. The caller adds the output
+    /// args, which only suit a command whose output it captures.
     fn build_command(&self) -> Command {
         let mut command = Command::new(&self.jj_bin);
         command.args(&self.args);
-        command.args(get_output_args(
-            !self.force_no_color && self.color,
-            self.quiet,
-        ));
 
         if self.ignore_working_copy {
             command.arg("--ignore-working-copy");
@@ -528,6 +542,21 @@ pub mod tests {
         let test_repo = TestRepo::new()?;
 
         test_repo.commander.jj(["status"]).color().run()?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn run_foreground_reports_how_the_command_exited() -> Result<()> {
+        let test_repo = TestRepo::new()?;
+
+        // The command writes to the terminal the test runs in, so it has
+        // to be one that says nothing in a fresh repo.
+        let status = test_repo
+            .commander
+            .jj(["bookmark", "list"])
+            .run_foreground()?;
+        assert!(status.success());
 
         Ok(())
     }

--- a/src/commander/mod.rs
+++ b/src/commander/mod.rs
@@ -73,6 +73,11 @@ const JJ_VERSION_IGNORE_HELP: &str = "If you want to continue anyway, use --igno
 /// size, so it makes no difference to what they print.
 pub const MIN_SETTABLE_WIDTH: usize = 20;
 
+/// The editor a command run with [JjCommand::no_editor] is given. There is
+/// no such program, so jj names it in the error it fails with, which is how
+/// a command that wanted an editor is recognized.
+pub const NO_EDITOR: &str = "blazingjj-no-editor";
+
 impl DiffFormat {
     pub fn get_args(&self) -> Vec<&str> {
         match self {
@@ -285,6 +290,17 @@ impl JjCommand {
         self
     }
 
+    /// Leave the command no editor to open, so that one meant to be used
+    /// interactively fails instead of taking the terminal from under the
+    /// app. A failure is told apart from any other by [NO_EDITOR].
+    pub fn no_editor(mut self) -> Self {
+        for setting in ["ui.editor", "ui.diff-editor", "ui.merge-editor"] {
+            self.args.push("--config".into());
+            self.args.push(format!("{setting}=\"{NO_EDITOR}\"").into());
+        }
+        self
+    }
+
     /// Feed `stdin` to the command on standard input.
     ///
     /// Useful for commands like `jj describe --stdin`, where passing the value
@@ -474,6 +490,8 @@ pub fn get_output_args(color: bool, quiet: bool) -> Vec<String> {
 
 #[cfg(test)]
 pub mod tests {
+    use std::time::Duration;
+
     use tempfile::TempDir;
 
     use super::*;
@@ -557,6 +575,31 @@ pub mod tests {
             .jj(["bookmark", "list"])
             .run_foreground()?;
         assert!(status.success());
+
+        Ok(())
+    }
+
+    #[test]
+    fn a_command_that_wants_an_editor_fails_instead_of_waiting_for_one() -> Result<()> {
+        let test_repo = TestRepo::new()?;
+
+        // Should the command get an editor after all, it waits on it for
+        // as long as this test is left to run.
+        let cancel = CancelToken::new();
+        let watchdog = cancel.clone();
+        thread::spawn(move || {
+            thread::sleep(Duration::from_secs(30));
+            watchdog.cancel();
+        });
+
+        let err = test_repo
+            .commander
+            .jj(["describe"])
+            .no_editor()
+            .run_cancellable(&cancel)
+            .expect_err("describe has no editor to open");
+
+        assert!(err.to_string().contains(NO_EDITOR), "{err}");
 
         Ok(())
     }

--- a/src/env.rs
+++ b/src/env.rs
@@ -44,6 +44,7 @@ pub struct JjConfig {
 #[serde(rename_all = "kebab-case", default)]
 pub struct JjConfigBlazingjj {
     highlight_color: Color,
+    describe_mode: DescribeMode,
     diff_format: Option<DiffFormat>,
     diff_tool: Option<String>,
     bookmark_template: Option<String>,
@@ -57,6 +58,7 @@ impl Default for JjConfigBlazingjj {
         Self {
             highlight_color: Color::Rgb(50, 50, 150),
             layout_percent: 50,
+            describe_mode: DescribeMode::default(),
             // Standard defaults for the rest
             diff_format: None,
             diff_tool: None,
@@ -114,6 +116,9 @@ impl JjConfig {
             .or(self.templates.git_push_bookmark.clone())
             .unwrap_or("'push-' ++ change_id.short()".to_string())
     }
+    pub fn describe_mode(&self) -> DescribeMode {
+        self.blazingjj.describe_mode
+    }
 
     pub fn layout(&self) -> JJLayout {
         self.blazingjj.layout
@@ -167,6 +172,14 @@ impl Env {
             jj_bin,
         })
     }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Default, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum DescribeMode {
+    #[default]
+    Popup,
+    Jj,
 }
 
 #[derive(Clone, Debug, Deserialize, Default, PartialEq, Eq, Hash)]

--- a/src/env.rs
+++ b/src/env.rs
@@ -67,6 +67,7 @@ pub struct JjConfig {
 #[serde(rename_all = "kebab-case", default)]
 pub struct JjConfigBlazingjj {
     highlight_color: Color,
+    describe_mode: DescribeMode,
     diff_format: Option<DiffFormat>,
     diff_tool: Option<String>,
     bookmark_template: Option<String>,
@@ -86,6 +87,7 @@ impl Default for JjConfigBlazingjj {
             layout_percent: 50,
             poll_interval: Some(Duration::from_secs(1)),
             // Standard defaults for the rest
+            describe_mode: DescribeMode::default(),
             diff_format: None,
             diff_tool: None,
             bookmark_template: None,
@@ -153,6 +155,10 @@ impl JjConfig {
             .unwrap_or("'push-' ++ change_id.short()".to_string())
     }
 
+    pub fn describe_mode(&self) -> DescribeMode {
+        self.blazingjj.describe_mode
+    }
+
     pub fn layout(&self) -> JJLayout {
         self.blazingjj.layout
     }
@@ -209,6 +215,14 @@ impl Env {
             jj_bin,
         })
     }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Default, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum DescribeMode {
+    #[default]
+    Popup,
+    Jj,
 }
 
 #[derive(Clone, Debug, Deserialize, Default, PartialEq, Eq, Hash)]
@@ -343,5 +357,18 @@ mod tests {
                 toml::from_str::<JjConfig>(&format!("blazingjj.poll-interval = {interval}\n"));
             assert!(config.is_err(), "{interval}");
         }
+    }
+
+    #[test]
+    fn describe_mode() {
+        assert_eq!(JjConfig::default().describe_mode(), DescribeMode::Popup);
+
+        let config: JjConfig = toml::from_str("blazingjj.describe-mode = \"jj\"\n").unwrap();
+        assert_eq!(config.describe_mode(), DescribeMode::Jj);
+
+        let config: JjConfig = toml::from_str("blazingjj.describe-mode = \"popup\"\n").unwrap();
+        assert_eq!(config.describe_mode(), DescribeMode::Popup);
+
+        assert!(toml::from_str::<JjConfig>("blazingjj.describe-mode = \"editor\"\n").is_err());
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -8,6 +8,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::mpsc;
 use std::thread;
+use std::thread::JoinHandle;
 use std::time::Duration;
 
 use ratatui::crossterm;
@@ -25,10 +26,19 @@ pub enum AppEvent {
     TaskDone(TaskResult),
 }
 
+/// The input reader thread, and the flag that keeps it reading.
+struct Reader {
+    reading: Arc<AtomicBool>,
+    thread: JoinHandle<()>,
+}
+
 /// Generator of events to the app
 pub struct EventSource {
     // Global shut down flag
     running: Arc<AtomicBool>,
+
+    // The input reader, while there is one
+    reader: Option<Reader>,
 
     // Channel for app events
     app_event_sender: mpsc::Sender<AppEvent>,
@@ -40,8 +50,49 @@ impl EventSource {
         let (tx, rx) = mpsc::channel();
         Self {
             running,
+            reader: None,
             app_event_sender: tx,
             app_event_receiver: rx,
+        }
+    }
+
+    /// Stop the input reader and return once it is gone, so that a
+    /// foreground process has the terminal and the user's keys to itself.
+    pub fn pause_user_input(&mut self) {
+        let Some(reader) = self.reader.take() else {
+            return;
+        };
+
+        reader.reading.store(false, Ordering::Relaxed);
+        if reader.thread.join().is_err() {
+            error!("crossterm reader panicked");
+        }
+    }
+
+    /// Read user input again, dropping everything the user typed at the
+    /// foreground process in the meantime.
+    pub fn resume_user_input(&mut self) {
+        self.discard_user_input();
+        self.launch_user_input();
+    }
+
+    /// Discard user input, keeping other events. What the user typed while
+    /// the terminal belonged to someone else was not meant for us, whether
+    /// it is still sitting in the terminal or already on our channel.
+    fn discard_user_input(&mut self) {
+        while let Ok(true) = crossterm::event::poll(Duration::ZERO) {
+            if crossterm::event::read().is_err() {
+                break;
+            }
+        }
+
+        let keep: Vec<AppEvent> = self
+            .app_event_receiver
+            .try_iter()
+            .filter(|event| !matches!(event, AppEvent::UserInput(_)))
+            .collect();
+        for event in keep {
+            let _ = self.app_event_sender.send(event);
         }
     }
 
@@ -54,37 +105,43 @@ impl EventSource {
     pub fn launch_user_input(&mut self) {
         // Spawn user input thread
         let running = self.running.clone();
+        let reading = Arc::new(AtomicBool::new(true));
         let app_event_tx = self.app_event_sender.clone();
         trace!("spawn crossterm reader");
-        thread::Builder::new()
+        let thread = thread::Builder::new()
             .name("crossterm reader".to_string())
-            .spawn(move || {
-                let poll_period = Duration::from_millis(100);
-                trace!("crossterm reader - started");
-                while running.load(Ordering::Relaxed) {
-                    // Block until an event arrives
-                    match crossterm::event::poll(poll_period) {
-                        Err(err) => {
-                            error!("cossterm reader - poll abort: {:?}", err);
-                            break;
+            .spawn({
+                let reading = reading.clone();
+                move || {
+                    let poll_period = Duration::from_millis(100);
+                    trace!("crossterm reader - started");
+                    while running.load(Ordering::Relaxed) && reading.load(Ordering::Relaxed) {
+                        // Block until an event arrives
+                        match crossterm::event::poll(poll_period) {
+                            Err(err) => {
+                                error!("cossterm reader - poll abort: {:?}", err);
+                                break;
+                            }
+                            Ok(false) => continue, // No event yet
+                            Ok(true) => (),
                         }
-                        Ok(false) => continue, // No event yet
-                        Ok(true) => (),
+                        let Ok(event) = crossterm::event::read() else {
+                            error!("crossterm reader - read abort");
+                            break;
+                        };
+                        // Send event to main thread
+                        let Ok(_) = app_event_tx.send(AppEvent::UserInput(event)) else {
+                            error!("crossterm reader - send abort");
+                            break;
+                        };
+                        trace!("crossterm reader - event forwarded");
                     }
-                    let Ok(event) = crossterm::event::read() else {
-                        error!("crossterm reader - read abort");
-                        break;
-                    };
-                    // Send event to main thread
-                    let Ok(_) = app_event_tx.send(AppEvent::UserInput(event)) else {
-                        error!("crossterm reader - send abort");
-                        break;
-                    };
-                    trace!("crossterm reader - event forwarded");
+                    trace!("crossterm reader - stopped");
                 }
-                trace!("crossterm reader - stopped");
             })
             .unwrap();
+
+        self.reader = Some(Reader { reading, thread });
     }
 
     /// Receive an AppEvent if one is waiting.
@@ -101,5 +158,41 @@ impl EventSource {
                 None
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::crossterm::event::KeyCode;
+    use ratatui::crossterm::event::KeyEvent;
+
+    use super::*;
+
+    fn event_source() -> EventSource {
+        EventSource::new(Arc::new(AtomicBool::new(true)))
+    }
+
+    #[test]
+    fn pausing_without_a_reader_does_not_wait() {
+        // There is nothing to stop before the reader has been launched.
+        let (done, paused) = mpsc::channel();
+        thread::spawn(move || {
+            event_source().pause_user_input();
+            done.send(())
+        });
+
+        assert!(paused.recv_timeout(Duration::from_secs(10)).is_ok());
+    }
+
+    #[test]
+    fn what_was_typed_at_the_foreground_process_is_discarded() {
+        let mut source = event_source();
+        let sender = source.clone_event_sender();
+        let key = crossterm::event::Event::Key(KeyEvent::from(KeyCode::Char('q')));
+        sender.send(AppEvent::UserInput(key)).unwrap();
+
+        source.discard_user_input();
+
+        assert!(source.try_recv(Duration::ZERO).is_none());
     }
 }

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -1,0 +1,44 @@
+//! Surviving a Ctrl-C that was meant for a process we put in front of the
+//! user.
+
+use std::sync::Arc;
+use std::sync::LazyLock;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+
+use anyhow::Result;
+
+/// Whether a SIGINT still ends the process, which it does unless someone
+/// else has the terminal.
+static ENDS_US: LazyLock<Arc<AtomicBool>> = LazyLock::new(|| Arc::new(AtomicBool::new(true)));
+
+/// Route SIGINT through us rather than straight to the default of ending
+/// the process, so that [catch_interrupts] can hold it back. Until it
+/// does, the signal goes on ending us as it always has.
+///
+/// Windows delivers Ctrl-C to every process on the console rather than to
+/// a process group, and taking it over there needs a console control
+/// handler we do not have, so this does nothing and a Ctrl-C aimed at a
+/// foreground process still ends the app.
+pub fn watch_for_interrupts() -> Result<()> {
+    #[cfg(unix)]
+    signal_hook::flag::register_conditional_default(signal_hook::consts::SIGINT, ENDS_US.clone())?;
+
+    Ok(())
+}
+
+/// Keep a Ctrl-C from ending the process for as long as the returned guard
+/// lives, leaving it to whoever we handed the terminal to.
+pub fn catch_interrupts() -> CaughtInterrupts {
+    ENDS_US.store(false, Ordering::Relaxed);
+    CaughtInterrupts
+}
+
+/// Lets SIGINT end the process again when dropped.
+pub struct CaughtInterrupts;
+
+impl Drop for CaughtInterrupts {
+    fn drop(&mut self) {
+        ENDS_US.store(true, Ordering::Relaxed);
+    }
+}

--- a/src/keybinds/config.rs
+++ b/src/keybinds/config.rs
@@ -16,6 +16,7 @@ pub struct KeybindsConfig {
     pub prev_tab: Option<Keybind>,
 
     pub command_popup: Option<Keybind>,
+    pub interactive_command_popup: Option<Keybind>,
     pub quit: Option<Keybind>,
 
     pub log_tab: Option<LogTabKeybindsConfig>,

--- a/src/keybinds/global.rs
+++ b/src/keybinds/global.rs
@@ -34,6 +34,7 @@ pub enum GlobalEvent {
     EvologTab,
 
     CommandPopup,
+    InteractiveCommandPopup,
     OpenHelp,
     Quit,
 
@@ -61,6 +62,7 @@ impl Default for GlobalKeybinds {
             GlobalEvent::BookmarksTab => "3",
             GlobalEvent::EvologTab => "4",
             GlobalEvent::CommandPopup => ":",
+            GlobalEvent::InteractiveCommandPopup => "!",
             GlobalEvent::OpenHelp => "?",
             GlobalEvent::Quit => "q",
             GlobalEvent::Quit => "ctrl+c",
@@ -87,6 +89,7 @@ impl GlobalKeybinds {
             GlobalEvent::NextTab => config.next_tab,
             GlobalEvent::PrevTab => config.prev_tab,
             GlobalEvent::CommandPopup => config.command_popup,
+            GlobalEvent::InteractiveCommandPopup => config.interactive_command_popup,
             GlobalEvent::Quit => config.quit,
         );
     }
@@ -107,6 +110,7 @@ impl GlobalKeybinds {
             GlobalEvent::BookmarksTab => "bookmarks tab",
             GlobalEvent::EvologTab => "evolog tab",
             GlobalEvent::CommandPopup => "run jj command",
+            GlobalEvent::InteractiveCommandPopup => "run jj command interactively",
             GlobalEvent::OpenHelp => "open help",
             GlobalEvent::Quit => "quit",
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,11 +166,21 @@ fn init_env() -> Result<Env> {
 fn run_app(terminal: &mut DefaultTerminal, app: &mut App) -> Result<()> {
     loop {
         app.update()?;
+
         terminal.draw(|f| {
             let _ = ui(f, app);
         })?;
 
         let should_stop = input_to_app(app)?;
+
+        if let Some(mut command) = app.pending_interactive.take() {
+            restore_terminal()?;
+            let status = command.spawn()?.wait();
+            setup_terminal()?;
+            terminal.clear()?;
+            status?;
+            app.refresh_current_view()?;
+        }
 
         if should_stop {
             return Ok(());

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,7 +75,8 @@ fn main() -> Result<()> {
     let mut app = App::new()?;
 
     install_panic_hook();
-    let mut terminal = setup_terminal()?;
+    let mut terminal = create_terminal()?;
+    setup_terminal()?;
 
     // Run app
     let res = run_app(&mut terminal, &mut app);
@@ -208,7 +209,12 @@ fn input_to_app(app: &mut App) -> Result<bool> {
     Ok(should_stop)
 }
 
-fn setup_terminal() -> Result<DefaultTerminal> {
+fn create_terminal() -> Result<DefaultTerminal> {
+    let backend = CrosstermBackend::new(io::stdout());
+    Ok(DefaultTerminal::new(backend)?)
+}
+
+fn setup_terminal() -> Result<()> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(
@@ -226,8 +232,7 @@ fn setup_terminal() -> Result<DefaultTerminal> {
         )?;
     }
 
-    let backend = CrosstermBackend::new(stdout);
-    Ok(DefaultTerminal::new(backend)?)
+    Ok(())
 }
 
 fn restore_terminal() -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,11 +163,21 @@ fn init_env() -> Result<Env> {
 fn run_app(terminal: &mut DefaultTerminal, app: &mut App) -> Result<()> {
     loop {
         app.update()?;
+
         terminal.draw(|f| {
             let _ = app.draw(f, f.area());
         })?;
 
         let should_stop = input_to_app(app)?;
+
+        if let Some(command) = app.pending_interactive.take() {
+            restore_terminal()?;
+            let status = command.run_foreground();
+            setup_terminal()?;
+            terminal.clear()?;
+            status?;
+            app.refresh_current_view()?;
+        }
 
         if should_stop {
             return Ok(());

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,7 @@ mod background_tasks;
 mod commander;
 mod env;
 mod event;
+mod interrupt;
 mod keybinds;
 mod ui;
 use crate::app::App;
@@ -44,6 +45,9 @@ use crate::app::Handled;
 use crate::commander::Commander;
 use crate::env::Env;
 use crate::env::set_env;
+use crate::interrupt::catch_interrupts;
+use crate::interrupt::watch_for_interrupts;
+use crate::ui::Interactive;
 
 /// Command line arguments
 #[derive(Parser, Debug)]
@@ -74,6 +78,7 @@ fn main() -> Result<()> {
     let mut app = App::new()?;
 
     install_panic_hook();
+    watch_for_interrupts()?;
     let mut terminal = create_terminal()?;
     setup_terminal()?;
 
@@ -170,6 +175,14 @@ fn run_app(terminal: &mut DefaultTerminal, app: &mut App) -> Result<()> {
 
         changed |= app.refresh_view()?;
 
+        // Before the wait below, which anything but user input may be a
+        // long time coming to.
+        if let Some(interactive) = app.take_pending_interactive() {
+            run_interactive(terminal, app, interactive)?;
+            quiet = false;
+            continue;
+        }
+
         // Waking up on a timer to find nothing has happened must not
         // cost a frame, or an app nobody is touching would rebuild the
         // whole display every poll interval.
@@ -185,6 +198,37 @@ fn run_app(terminal: &mut DefaultTerminal, app: &mut App) -> Result<()> {
             Handled::Nothing => quiet = true,
         }
     }
+}
+
+/// Hand the terminal over to a command and take it back once it is done.
+fn run_interactive(
+    terminal: &mut DefaultTerminal,
+    app: &mut App,
+    interactive: Interactive,
+) -> Result<()> {
+    app.pause_input();
+    restore_terminal()?;
+
+    let ran = {
+        let _interrupts = catch_interrupts();
+        match interactive.command.run_foreground() {
+            Ok(status) => status.success(),
+            Err(err) => {
+                println!("Could not run jj: {err}");
+                false
+            }
+        }
+    };
+    // What the command left is on the screen we are about to take back,
+    // so it has to be read before we do.
+    if !ran || interactive.hold_screen {
+        wait_for_user()?;
+    }
+
+    setup_terminal()?;
+    terminal.clear()?;
+    app.resume_input();
+    app.catch_up_with_repo()
 }
 
 /// Let app process all input events in queue before returning.
@@ -228,6 +272,13 @@ fn input_to_app(app: &mut App) -> Result<Handled> {
 fn create_terminal() -> Result<DefaultTerminal> {
     let backend = CrosstermBackend::new(io::stdout());
     Ok(DefaultTerminal::new(backend)?)
+}
+
+/// Leave the terminal as it is until the user says they are done with it.
+fn wait_for_user() -> Result<()> {
+    println!("\nPress enter to return to blazingjj");
+    io::stdin().read_line(&mut String::new())?;
+    Ok(())
 }
 
 fn setup_terminal() -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,8 @@ fn main() -> Result<()> {
     let mut app = App::new()?;
 
     install_panic_hook();
-    let mut terminal = setup_terminal()?;
+    let mut terminal = create_terminal()?;
+    setup_terminal()?;
 
     // Run app
     let res = run_app(&mut terminal, &mut app);
@@ -205,7 +206,12 @@ fn input_to_app(app: &mut App) -> Result<bool> {
     Ok(should_stop)
 }
 
-fn setup_terminal() -> Result<DefaultTerminal> {
+fn create_terminal() -> Result<DefaultTerminal> {
+    let backend = CrosstermBackend::new(io::stdout());
+    Ok(DefaultTerminal::new(backend)?)
+}
+
+fn setup_terminal() -> Result<()> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(
@@ -223,8 +229,7 @@ fn setup_terminal() -> Result<DefaultTerminal> {
         )?;
     }
 
-    let backend = CrosstermBackend::new(stdout);
-    Ok(DefaultTerminal::new(backend)?)
+    Ok(())
 }
 
 fn restore_terminal() -> Result<()> {

--- a/src/ui/dialog/command.rs
+++ b/src/ui/dialog/command.rs
@@ -1,6 +1,6 @@
-use anyhow::Context;
 use anyhow::Result;
 use ratatui::crossterm::event::Event;
+use ratatui::crossterm::event::KeyEventKind;
 use ratatui::layout::Alignment;
 use ratatui::layout::Constraint;
 use ratatui::layout::Direction;
@@ -17,26 +17,145 @@ use ratatui::widgets::Paragraph;
 use ratatui_textarea::TextArea;
 use shell_words::split;
 
+use crate::commander::JjCommand;
+use crate::commander::NO_EDITOR;
 use crate::commander::new_commander;
 use crate::keybinds::PopupEvent;
 use crate::keybinds::PopupKeybinds;
 use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
+use crate::ui::Interactive;
 use crate::ui::dialog::MessagePopup;
 use crate::ui::utils::centered_rect_line_height;
 
+/// What to tell someone whose command turned out to want an editor.
+const NEEDS_INTERACTIVE: &str = "This command wants an editor, which it cannot have while \
+                                 blazingjj holds the terminal.";
+
+/// How the command popup runs what is typed into it.
+#[derive(Clone, Copy)]
+pub enum CommandMode {
+    /// Capture the output and put it up in a popup.
+    Capture,
+    /// Hand the terminal over, so that the command can be interactive.
+    Interactive,
+}
+
 pub struct CommandPopup<'a> {
+    mode: CommandMode,
     command_textarea: TextArea<'a>,
     keybinds: PopupKeybinds,
 }
 
 impl CommandPopup<'_> {
-    pub fn new() -> Self {
+    pub fn new(mode: CommandMode) -> Self {
         Self {
+            mode,
             command_textarea: TextArea::new(vec![]),
             keybinds: PopupKeybinds::text_line(),
         }
+    }
+
+    /// What was typed, without the `jj` it may have been started with.
+    fn command(&self) -> String {
+        let typed = self.command_textarea.lines().join(" ");
+        let command = match typed.strip_prefix("jj") {
+            Some(rest) if rest.is_empty() || rest.starts_with(' ') => rest.trim_start(),
+            _ => &typed,
+        };
+
+        command.to_owned()
+    }
+}
+
+/// Run the command and put its output up. It is left without an editor, as
+/// it cannot have the terminal while we hold it.
+fn run_captured(title: String, args: &[String]) -> ComponentInputResult {
+    let said = match new_commander().jj(args).no_editor().color().verbose().run() {
+        Ok(output) if output.trim().is_empty() => AppAction::ClosePopup,
+        Ok(output) => popup(title, output),
+        Err(err) => {
+            // Having named the editor ourselves, we know a command that
+            // wanted one when we see it, and can offer the way out.
+            let wants_editor = err.to_string().contains(NO_EDITOR);
+            let report = format!("Failed to execute jj command: {title}\n\n{err}");
+            if wants_editor {
+                AppAction::SetPopup(Box::new(RetryInteractivelyPopup::new(
+                    title,
+                    report,
+                    new_commander().jj(args),
+                )))
+            } else {
+                popup(title, report)
+            }
+        }
+    };
+
+    // Even a command that came back unhappy may have moved the repo, jj
+    // snapshotting the working copy before it gets that far.
+    ComponentInputResult::HandledAction(AppAction::Multiple(vec![said, AppAction::MarkTabsStale]))
+}
+
+/// Put `output` up under `title`.
+fn popup(title: String, output: String) -> AppAction {
+    AppAction::SetPopup(Box::new(
+        MessagePopup::new(title, output).text_align(Alignment::Left),
+    ))
+}
+
+/// Run `command` with the terminal handed over to it, holding it once the
+/// command is done so that what it printed can be read.
+fn run_interactively(command: JjCommand) -> AppAction {
+    AppAction::RunInteractive(Interactive {
+        command,
+        hold_screen: true,
+    })
+}
+
+/// Offers to hand the terminal to a command that could not be run with its
+/// output captured.
+struct RetryInteractivelyPopup<'a> {
+    message: MessagePopup<'a>,
+    keybinds: PopupKeybinds,
+    /// Taken when the offer is accepted, which happens at most once.
+    command: Option<JjCommand>,
+}
+
+impl RetryInteractivelyPopup<'_> {
+    fn new(title: String, report: String, command: JjCommand) -> Self {
+        let keybinds = PopupKeybinds::dialog();
+        let offer = keybinds.hint("run it interactively");
+
+        Self {
+            message: MessagePopup::new(
+                title,
+                format!("{report}\n\n{NEEDS_INTERACTIVE}\n\n{offer}"),
+            )
+            .text_align(Alignment::Left),
+            keybinds,
+            command: Some(command),
+        }
+    }
+}
+
+impl Component for RetryInteractivelyPopup<'_> {
+    fn draw(&mut self, f: &mut ratatui::Frame<'_>, area: ratatui::prelude::Rect) -> Result<()> {
+        self.message.draw(f, area)
+    }
+
+    fn input(&mut self, event: Event) -> Result<ComponentInputResult> {
+        if let Event::Key(key) = event
+            && key.kind == KeyEventKind::Press
+            && self.keybinds.match_event(key) == PopupEvent::Accept
+            && let Some(command) = self.command.take()
+        {
+            return Ok(ComponentInputResult::HandledAction(AppAction::Multiple(
+                vec![AppAction::ClosePopup, run_interactively(command)],
+            )));
+        }
+
+        self.message.input(event)
     }
 }
 
@@ -46,8 +165,12 @@ impl Component for CommandPopup<'_> {
         f: &mut ratatui::Frame<'_>,
         area: ratatui::prelude::Rect,
     ) -> anyhow::Result<()> {
+        let title = match self.mode {
+            CommandMode::Capture => " Command ",
+            CommandMode::Interactive => " Interactive command ",
+        };
         let block = Block::bordered()
-            .title(Span::styled(" Command ", Style::new().bold().cyan()))
+            .title(Span::styled(title, Style::new().bold().cyan()))
             .title_alignment(Alignment::Center)
             .border_type(BorderType::Rounded)
             .border_style(Style::default().fg(Color::Green));
@@ -78,58 +201,63 @@ impl Component for CommandPopup<'_> {
 
     fn input(&mut self, event: Event) -> anyhow::Result<ComponentInputResult> {
         if let Event::Key(key) = event {
+            let cancel = Ok(ComponentInputResult::HandledAction(AppAction::ClosePopup));
             match self.keybinds.match_event(key) {
                 PopupEvent::Accept => {
-                    let command_input = self.command_textarea.lines().join(" ");
-                    let mut command_input = command_input.as_str();
-
-                    if command_input.trim().is_empty() {
-                        return Ok(ComponentInputResult::HandledAction(AppAction::ClosePopup));
+                    let command = self.command();
+                    if command.trim().is_empty() {
+                        return cancel;
                     }
 
-                    if command_input == "jj" {
-                        command_input = "";
-                    }
-                    command_input = command_input.trim_start_matches("jj ");
-
-                    let res: Result<String> = split(command_input)
-                        .context("Failed to split command input")
-                        .and_then(|command| {
-                            Ok(new_commander().jj(command).color().verbose().run()?)
-                        });
-                    let output_str = match res {
-                        Ok(output) => output,
-                        Err(err) => [
-                            format!("Failed to execute jj command: jj {command_input}"),
-                            String::new(),
-                            err.to_string(),
-                        ]
-                        .join("\n"),
+                    let title = format!("jj {command}");
+                    let args = match split(&command) {
+                        Ok(args) => args,
+                        Err(err) => {
+                            let report = format!("Failed to split command input\n\n{err}");
+                            return Ok(ComponentInputResult::HandledAction(popup(title, report)));
+                        }
                     };
 
-                    if output_str.trim().is_empty() {
-                        return Ok(ComponentInputResult::HandledAction(AppAction::Multiple(
-                            vec![AppAction::ClosePopup, AppAction::MarkTabsStale],
-                        )));
-                    }
-
-                    return Ok(ComponentInputResult::HandledAction(AppAction::Multiple(
-                        vec![
-                            AppAction::SetPopup(Box::new(
-                                MessagePopup::new(format!("jj {command_input}"), output_str)
-                                    .text_align(Alignment::Left),
-                            )),
-                            AppAction::MarkTabsStale,
-                        ],
-                    )));
+                    return Ok(match self.mode {
+                        CommandMode::Capture => run_captured(title, &args),
+                        CommandMode::Interactive => {
+                            ComponentInputResult::HandledAction(AppAction::Multiple(vec![
+                                AppAction::ClosePopup,
+                                run_interactively(new_commander().jj(args)),
+                            ]))
+                        }
+                    });
                 }
-                PopupEvent::Cancel => {
-                    return Ok(ComponentInputResult::HandledAction(AppAction::ClosePopup));
-                }
+                PopupEvent::Cancel => return cancel,
                 _ => {}
             }
         };
         self.command_textarea.input(event);
         Ok(ComponentInputResult::Handled)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn command_for(typed: &str) -> String {
+        CommandPopup {
+            mode: CommandMode::Capture,
+            command_textarea: TextArea::new(vec![typed.to_owned()]),
+            keybinds: PopupKeybinds::text_line(),
+        }
+        .command()
+    }
+
+    #[test]
+    fn the_jj_one_may_type_is_not_passed_on_to_jj() {
+        assert_eq!(command_for("status"), "status");
+        assert_eq!(command_for("jj status"), "status");
+        assert_eq!(command_for("jj"), "");
+        // Only the one we put there ourselves, and only where a command
+        // would otherwise stand.
+        assert_eq!(command_for("jj jj status"), "jj status");
+        assert_eq!(command_for("jjdescribe"), "jjdescribe");
     }
 }

--- a/src/ui/dialog/describe.rs
+++ b/src/ui/dialog/describe.rs
@@ -23,21 +23,44 @@ use ratatui_textarea::TextArea;
 
 use crate::app::command::Command;
 use crate::commander::log::Head;
+use crate::commander::new_commander;
+use crate::env::DescribeMode;
+use crate::env::get_env;
 use crate::keybinds::PopupEvent;
 use crate::keybinds::PopupKeybinds;
 use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
+use crate::ui::Interactive;
 use crate::ui::utils::centered_rect_fixed;
 
-pub struct DescribePopup<'a> {
+/// Put the user in front of an editor for `head`'s description, in whichever
+/// way `blazingjj.describe-mode` asks for. `seed` gives the text the in-app
+/// editor starts out with, and is only asked for when that is the editor in
+/// use.
+pub fn describe_action(
+    head: &Head,
+    seed: impl FnOnce() -> Result<Vec<String>>,
+) -> Result<AppAction> {
+    Ok(match get_env().jj_config.describe_mode() {
+        DescribeMode::Popup => {
+            AppAction::SetPopup(Box::new(DescribePopup::new(head.clone(), seed()?)))
+        }
+        DescribeMode::Jj => AppAction::RunInteractive(Interactive {
+            command: new_commander().jj(["describe", head.commit_id.as_str()]),
+            hold_screen: false,
+        }),
+    })
+}
+
+struct DescribePopup<'a> {
     head: Head,
     textarea: TextArea<'a>,
     keybinds: PopupKeybinds,
 }
 
 impl DescribePopup<'_> {
-    pub fn new(head: Head, lines: Vec<String>) -> DescribePopup<'static> {
+    fn new(head: Head, lines: Vec<String>) -> DescribePopup<'static> {
         let mut textarea = TextArea::new(lines);
         textarea.move_cursor(CursorMove::End);
         DescribePopup {

--- a/src/ui/dialog/mod.rs
+++ b/src/ui/dialog/mod.rs
@@ -25,6 +25,7 @@ pub use bookmark_name::BookmarkNameMode;
 pub use bookmark_name::BookmarkNamePopup;
 pub use bookmark_set::BookmarkSetPopup;
 pub use choice::ChoicePopup;
+pub use command::CommandMode;
 pub use command::CommandPopup;
 pub use confirm::ConfirmPopup;
 pub use context_menu::bookmarks_context_menu;

--- a/src/ui/dialog/mod.rs
+++ b/src/ui/dialog/mod.rs
@@ -31,7 +31,7 @@ pub use context_menu::bookmarks_context_menu;
 pub use context_menu::evolog_context_menu;
 pub use context_menu::files_context_menu;
 pub use context_menu::log_context_menu;
-pub use describe::DescribePopup;
+pub use describe::describe_action;
 pub use help::HelpPopup;
 pub use loader::LoaderPopup;
 pub use message::MessagePopup;

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -23,6 +23,7 @@ use crate::ComponentInputResult;
 use crate::commander::ids::CommitId;
 use crate::commander::log::Head;
 use crate::commander::new_commander;
+use crate::env::DescribeMode;
 use crate::env::DiffFormat;
 use crate::env::JjConfig;
 use crate::env::get_env;
@@ -191,6 +192,13 @@ impl<'a> LogTab<'a> {
     pub fn set_head(&mut self, head: Head) {
         self.log_panel.set_head(head);
         self.refresh_log_output();
+    }
+
+    /// Re-fetch the latest version of the currently selected head.
+    pub fn refresh_selected_head(&mut self) -> Result<()> {
+        let latest = new_commander().get_head_latest(&self.head)?;
+        self.set_head(latest);
+        Ok(())
     }
 
     /// Update the log panel and diff panel. This will also refresh
@@ -542,16 +550,29 @@ impl<'a> LogTab<'a> {
                         }))),
                     ));
                 } else {
-                    let mut textarea = TextArea::new(
-                        new_commander()
-                            .get_commit_description(&self.head.commit_id)?
-                            .split("\n")
-                            .map(|line| line.to_string())
-                            .collect(),
-                    );
-                    textarea.move_cursor(CursorMove::End);
-                    self.describe_textarea = Some(textarea);
-                    return Ok(ComponentInputResult::Handled);
+                    match self.config.describe_mode() {
+                        DescribeMode::Popup => {
+                            let mut textarea = TextArea::new(
+                                new_commander()
+                                    .get_commit_description(&self.head.commit_id)?
+                                    .split("\n")
+                                    .map(|line| line.to_string())
+                                    .collect(),
+                            );
+                            textarea.move_cursor(CursorMove::End);
+                            self.describe_textarea = Some(textarea);
+                            return Ok(ComponentInputResult::Handled);
+                        }
+                        DescribeMode::Jj => {
+                            let command = new_commander().build_interactive_jj_command([
+                                "describe",
+                                self.head.commit_id.as_str(),
+                            ]);
+                            return Ok(ComponentInputResult::HandledAction(
+                                ComponentAction::RunInteractive(command),
+                            ));
+                        }
+                    }
                 }
             }
             LogTabEvent::EditRevset => {

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -20,6 +20,7 @@ use tui_confirm_dialog::Listener;
 use crate::commander::ids::CommitId;
 use crate::commander::log::Head;
 use crate::commander::new_commander;
+use crate::env::DescribeMode;
 use crate::env::DiffFormat;
 use crate::env::JjConfig;
 use crate::env::get_env;
@@ -188,6 +189,13 @@ impl<'a> LogTab<'a> {
     pub fn set_head(&mut self, head: Head) {
         self.log_panel.set_head(head);
         self.refresh_log_output();
+    }
+
+    /// Re-fetch the latest version of the currently selected head.
+    pub fn refresh_selected_head(&mut self) -> Result<()> {
+        let latest = new_commander().get_head_latest(&self.head)?;
+        self.set_head(latest);
+        Ok(())
     }
 
     /// Update the log panel and diff panel. This will also refresh
@@ -543,16 +551,29 @@ impl<'a> LogTab<'a> {
                         ))),
                     )));
                 } else {
-                    let mut textarea = TextArea::new(
-                        new_commander()
-                            .get_commit_description(&self.head.commit_id)?
-                            .split("\n")
-                            .map(|line| line.to_string())
-                            .collect(),
-                    );
-                    textarea.move_cursor(CursorMove::End);
-                    self.describe_textarea = Some(textarea);
-                    return Ok(ComponentInputResult::Handled);
+                    match self.config.describe_mode() {
+                        DescribeMode::Popup => {
+                            let mut textarea = TextArea::new(
+                                new_commander()
+                                    .get_commit_description(&self.head.commit_id)?
+                                    .split("\n")
+                                    .map(|line| line.to_string())
+                                    .collect(),
+                            );
+                            textarea.move_cursor(CursorMove::End);
+                            self.describe_textarea = Some(textarea);
+                            return Ok(ComponentInputResult::Handled);
+                        }
+                        DescribeMode::Jj => {
+                            let command = new_commander().jj([
+                                "describe",
+                                self.head.commit_id.as_str(),
+                            ]);
+                            return Ok(ComponentInputResult::HandledAction(
+                                AppAction::RunInteractive(command),
+                            ));
+                        }
+                    }
                 }
             }
             LogTabEvent::EditRevset => {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -12,6 +12,8 @@ pub mod rebase_popup;
 pub mod styles;
 pub mod utils;
 
+use std::process::Command;
+
 use anyhow::Result;
 use ratatui::Frame;
 use ratatui::crossterm::event::Event;
@@ -39,6 +41,9 @@ pub enum ComponentAction {
     SetPopup(Option<Box<dyn Component>>),
     Multiple(Vec<ComponentAction>),
     RefreshTab(),
+    /// Run a command that takes over the terminal. The main loop drains
+    /// these and refreshes the current view once the command exits.
+    RunInteractive(Command),
 }
 
 pub trait Component {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -15,6 +15,7 @@ use ratatui::layout::Rect;
 
 use crate::app::command::Command;
 use crate::background_tasks::TaskResult;
+use crate::commander::JjCommand;
 use crate::commander::log::Head;
 
 /// Action commmands from component to application
@@ -45,6 +46,18 @@ pub enum AppAction {
     /// raises one has named it in full, so the app can run it without
     /// asking anything of the component the request came from.
     Run(Command),
+    /// Run a command that takes over the terminal, in place of whatever
+    /// other one is queued, and read the repo again once it is done.
+    RunInteractive(Interactive),
+}
+
+/// A command to run with the terminal handed over to it.
+pub struct Interactive {
+    pub command: JjCommand,
+    /// Whether to wait for the user before taking the screen back. Off for
+    /// a command run for its effect, whose output is beside the point
+    /// unless it failed.
+    pub hold_screen: bool,
 }
 
 /// When a Component process an input event, it returns an ComponentInputResult

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -6,11 +6,13 @@ pub mod log_tab;
 pub mod panel;
 pub mod styles;
 pub mod utils;
+
 use anyhow::Result;
 use ratatui::Frame;
 use ratatui::crossterm::event::Event;
 use ratatui::layout::Rect;
 
+use crate::commander::JjCommand;
 use crate::commander::log::Head;
 
 /// Action commmands from component to application
@@ -21,6 +23,9 @@ pub enum AppAction {
     SetPopup(Option<Box<dyn Component>>),
     Multiple(Vec<AppAction>),
     RefreshTab(),
+    /// Run a command that takes over the terminal. The main loop drains
+    /// these and refreshes the current view once the command exits.
+    RunInteractive(JjCommand),
 }
 
 /// When a Component process an input event, it returns an ComponentInputResult


### PR DESCRIPTION
This adds support for interactive commands that want to take control of the terminal, say `jj desc` or `squash -i`.

The initial use case I added is indeed `jj desc`, because the default editor popup lacks formatting help to keep line length in check etc. It comes with a configurable option to choose between the popup and `jj desc` to describe a change.

Before merging, I'd like to improve the handling of the terminal restore/init split. Having half of it in the Commander and the other half in the main loop feels wrong.

Up for discussion:
We might also want to make the commands run through `:` use this code path, because we basically have no idea what the user will be running. Thoughts?