### PR TITLE
Update details pane on focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Details panel responds to mouse scroll in all tabs
 - Details panel sets COLUMNS to allow jj diff tool to fit window
+- Update the details panel when gaining focus
 
 ### Changed
 


### PR DESCRIPTION
When doing a push or a fetch that didn't change the change_id, the pane view (that shows the jj show view in the right) was not refreshed. This meant that even though the push finished you wouldn't see the bookmark from the remote being added to the change.
