### PR TITLE
LogTab: Update the details panel when selecting a change via mouse click

### DIFF
--- a/src/ui/panel/log_panel.rs
+++ b/src/ui/panel/log_panel.rs
@@ -377,6 +377,7 @@ impl Component for LogPanel<'_> {
                     ) && let Some(head) = self.head_at_log_line(inx)
                     {
                         self.set_head(head);
+                        return Ok(ComponentInputResult::Handled);
                     }
                 }
                 _ => {} // Handle other mouse events if necessary


### PR DESCRIPTION
The click event is not reported as being handled, so the head update is never propagated and the details panel doesn't get updated. By reporting the event as handled the necessary sync is performed.

Fixes #34