### PR TITLE
Limit width of describe window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Log panel can mark and abandon multiple commits
 - Log panel create new revision with marked commits as parents
 - Add support for copying the Change ID/revision of the current log tab entry using y/Y
+- Fix Describe dialog width at git recommendation for commit message
 
 
 ## [0.7.1] - 2026-01-16

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -1,5 +1,7 @@
 #![expect(clippy::borrow_interior_mutable_const)]
 
+use std::cmp::max;
+
 use ansi_to_tui::IntoText;
 use anyhow::Result;
 use ratatui::crossterm::clipboard::CopyToClipboard;
@@ -35,7 +37,7 @@ use crate::ui::message_popup::MessagePopup;
 use crate::ui::panel::DetailsPanel;
 use crate::ui::panel::LogPanel;
 use crate::ui::rebase_popup::RebasePopup;
-use crate::ui::utils::centered_rect;
+use crate::ui::utils::centered_rect_fixed;
 use crate::ui::utils::centered_rect_line_height;
 use crate::ui::utils::tabs_to_spaces;
 
@@ -632,7 +634,15 @@ impl Component for LogTab<'_> {
                     .title_alignment(Alignment::Center)
                     .border_type(BorderType::Rounded)
                     .border_style(Style::default().fg(Color::Green));
-                let area = centered_rect(area, 50, 50);
+                // Text target size
+                const MAX_COMMIT_WIDTH: u16 = 72; // git recommended max width
+                const MIN_COMMIT_HEIGHT: u16 = 5; // heading + blank + 3 lines
+                // Include margin and help text to get size
+                let area = centered_rect_fixed(
+                    area,
+                    /* width */ MAX_COMMIT_WIDTH + 2,
+                    /* height */ max(MIN_COMMIT_HEIGHT + 4, area.height / 2),
+                );
                 f.render_widget(Clear, area);
                 f.render_widget(&block, area);
 


### PR DESCRIPTION
Git commits have a recommended max width of 72 chars, with the summary having a 50 char recommendation.
It is easier to honour these recommendations if the Describe dialog is exactly this many chars wide.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
