### PR TITLE
Faster event processing

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -93,14 +93,13 @@ impl<'a> App<'a> {
     pub fn set_tab(&mut self, tab: Tab) -> Result<()> {
         info!("Setting tab to {}", tab);
         self.current_tab = tab;
-        let mut commander = self.commander.clone();
-        self.get_or_init_current_tab()?.focus(&mut commander)?;
+        self.get_or_init_current_tab()?.focus()?;
         Ok(())
     }
 
     pub fn get_log_tab(&mut self) -> Result<&mut LogTab<'a>> {
         if self.log.is_none() {
-            self.log = Some(LogTab::new(&mut self.commander)?);
+            self.log = Some(LogTab::new(self.commander.clone())?);
         }
 
         self.log
@@ -111,7 +110,7 @@ impl<'a> App<'a> {
     pub fn get_files_tab(&mut self) -> Result<&mut FilesTab> {
         if self.files.is_none() {
             let current_head = self.commander.get_current_head()?;
-            self.files = Some(FilesTab::new(&mut self.commander, &current_head)?);
+            self.files = Some(FilesTab::new(self.commander.clone(), &current_head)?);
         }
 
         self.files
@@ -121,7 +120,7 @@ impl<'a> App<'a> {
 
     pub fn get_bookmarks_tab(&mut self) -> Result<&mut BookmarksTab<'a>> {
         if self.bookmarks.is_none() {
-            self.bookmarks = Some(BookmarksTab::new(&mut self.commander)?);
+            self.bookmarks = Some(BookmarksTab::new(self.commander.clone())?);
         }
 
         self.bookmarks
@@ -155,18 +154,17 @@ impl<'a> App<'a> {
     }
 
     pub fn handle_action(&mut self, component_action: ComponentAction) -> Result<()> {
-        let mut commander = self.commander.clone();
         match component_action {
             ComponentAction::ViewFiles(head) => {
                 self.set_tab(Tab::Files)?;
-                self.get_files_tab()?.set_head(&mut commander, &head)?;
+                self.get_files_tab()?.set_head(&head)?;
             }
             ComponentAction::ViewLog(head) => {
-                self.get_log_tab()?.set_head(&mut commander, head);
+                self.get_log_tab()?.set_head(head);
                 self.set_tab(Tab::Log)?;
             }
             ComponentAction::ChangeHead(head) => {
-                self.get_files_tab()?.set_head(&mut commander, &head)?;
+                self.get_files_tab()?.set_head(&head)?;
             }
             ComponentAction::SetPopup(popup) => {
                 self.popup = popup;
@@ -179,9 +177,8 @@ impl<'a> App<'a> {
             ComponentAction::RefreshTab() => {
                 self.set_tab(self.current_tab)?;
                 if self.current_tab == Tab::Log {
-                    let mut commander = self.commander.clone();
-                    let head = commander.get_current_head()?.clone();
-                    self.get_log_tab()?.set_head(&mut commander, head);
+                    let head = self.commander.get_current_head()?.clone();
+                    self.get_log_tab()?.set_head(head);
                 };
             }
         }
@@ -191,14 +188,13 @@ impl<'a> App<'a> {
 
     #[instrument(level = "trace", skip(self))]
     pub fn update(&mut self) -> Result<()> {
-        let mut commander = self.commander.clone();
         if let Some(popup) = self.popup.as_mut()
-            && let Some(component_action) = popup.update(&mut commander)?
+            && let Some(component_action) = popup.update()?
         {
             self.handle_action(component_action)?;
         }
 
-        if let Some(component_action) = self.get_or_init_current_tab()?.update(&mut commander)? {
+        if let Some(component_action) = self.get_or_init_current_tab()?.update()? {
             self.handle_action(component_action)?;
         }
 
@@ -207,9 +203,8 @@ impl<'a> App<'a> {
 
     #[instrument(level = "trace", skip(self))]
     pub fn input(&mut self, event: Event) -> Result<bool> {
-        let mut commander = self.commander.clone();
         if let Some(popup) = self.popup.as_mut() {
-            match popup.input(&mut commander, event.clone())? {
+            match popup.input(event.clone())? {
                 ComponentInputResult::HandledAction(component_action) => {
                     self.handle_action(component_action)?
                 }
@@ -234,12 +229,9 @@ impl<'a> App<'a> {
                 }
             };
         } else if event == event::Event::FocusGained {
-            self.get_or_init_current_tab()?.focus(&mut commander)?;
+            self.get_or_init_current_tab()?.focus()?;
         } else {
-            match self
-                .get_or_init_current_tab()?
-                .input(&mut commander, event.clone())?
-            {
+            match self.get_or_init_current_tab()?.input(event.clone())? {
                 ComponentInputResult::HandledAction(component_action) => {
                     self.handle_action(component_action)?
                 }
@@ -275,7 +267,7 @@ impl<'a> App<'a> {
                         }
                         // General jj command runner
                         else if key.code == KeyCode::Char(':') {
-                            self.popup = Some(Box::new(CommandPopup::new()));
+                            self.popup = Some(Box::new(CommandPopup::new(self.commander.clone())));
                         }
                     }
                 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -47,6 +47,7 @@ pub struct Stats {
 
 pub struct App<'a> {
     pub env: Env,
+    pub commander: Commander,
     pub current_tab: Tab,
     pub log: Option<LogTab<'a>>,
     pub files: Option<FilesTab>,
@@ -56,9 +57,10 @@ pub struct App<'a> {
 }
 
 impl<'a> App<'a> {
-    pub fn new(env: Env) -> Result<App<'a>> {
+    pub fn new(env: Env, commander: Commander) -> Result<App<'a>> {
         Ok(App {
             env,
+            commander,
             current_tab: Tab::Log,
             log: None,
             files: None,
@@ -70,21 +72,14 @@ impl<'a> App<'a> {
         })
     }
 
-    pub fn get_or_init_current_tab(
-        &mut self,
-        commander: &mut Commander,
-    ) -> Result<&mut dyn Component> {
-        self.get_or_init_tab(commander, self.current_tab)
+    pub fn get_or_init_current_tab(&mut self) -> Result<&mut dyn Component> {
+        self.get_or_init_tab(self.current_tab)
     }
     pub fn get_current_tab(&mut self) -> Option<&mut dyn Component> {
         self.get_tab(self.current_tab)
     }
 
-    pub fn set_next_tab_with_offset(
-        &mut self,
-        commander: &mut Commander,
-        offset: i64,
-    ) -> Result<()> {
+    pub fn set_next_tab_with_offset(&mut self, offset: i64) -> Result<()> {
         let current_index = Tab::VALUES
             .iter()
             .position(|&t| t == self.current_tab)
@@ -92,20 +87,20 @@ impl<'a> App<'a> {
         let new_index =
             (current_index as i64 + Tab::VALUES.len() as i64 + offset) as usize % Tab::VALUES.len();
         let new_tab: Tab = Tab::VALUES[new_index];
-        self.set_tab(commander, new_tab)
+        self.set_tab(new_tab)
     }
 
-    pub fn set_tab(&mut self, commander: &mut Commander, tab: Tab) -> Result<()> {
+    pub fn set_tab(&mut self, tab: Tab) -> Result<()> {
         info!("Setting tab to {}", tab);
         self.current_tab = tab;
-
-        self.get_or_init_current_tab(commander)?.focus(commander)?;
+        let mut commander = self.commander.clone();
+        self.get_or_init_current_tab()?.focus(&mut commander)?;
         Ok(())
     }
 
-    pub fn get_log_tab(&mut self, commander: &mut Commander) -> Result<&mut LogTab<'a>> {
+    pub fn get_log_tab(&mut self) -> Result<&mut LogTab<'a>> {
         if self.log.is_none() {
-            self.log = Some(LogTab::new(commander)?);
+            self.log = Some(LogTab::new(&mut self.commander)?);
         }
 
         self.log
@@ -113,10 +108,10 @@ impl<'a> App<'a> {
             .ok_or_else(|| anyhow!("Failed to get mutable reference to LogTab"))
     }
 
-    pub fn get_files_tab(&mut self, commander: &mut Commander) -> Result<&mut FilesTab> {
+    pub fn get_files_tab(&mut self) -> Result<&mut FilesTab> {
         if self.files.is_none() {
-            let current_head = commander.get_current_head()?;
-            self.files = Some(FilesTab::new(commander, &current_head)?);
+            let current_head = self.commander.get_current_head()?;
+            self.files = Some(FilesTab::new(&mut self.commander, &current_head)?);
         }
 
         self.files
@@ -124,12 +119,9 @@ impl<'a> App<'a> {
             .ok_or_else(|| anyhow!("Failed to get mutable reference to FilesTab"))
     }
 
-    pub fn get_bookmarks_tab(
-        &mut self,
-        commander: &mut Commander,
-    ) -> Result<&mut BookmarksTab<'a>> {
+    pub fn get_bookmarks_tab(&mut self) -> Result<&mut BookmarksTab<'a>> {
         if self.bookmarks.is_none() {
-            self.bookmarks = Some(BookmarksTab::new(commander)?);
+            self.bookmarks = Some(BookmarksTab::new(&mut self.commander)?);
         }
 
         self.bookmarks
@@ -137,15 +129,11 @@ impl<'a> App<'a> {
             .ok_or_else(|| anyhow!("Failed to get mutable reference to BookmarksTab"))
     }
 
-    pub fn get_or_init_tab(
-        &mut self,
-        commander: &mut Commander,
-        tab: Tab,
-    ) -> Result<&mut dyn Component> {
+    pub fn get_or_init_tab(&mut self, tab: Tab) -> Result<&mut dyn Component> {
         Ok(match tab {
-            Tab::Log => self.get_log_tab(commander)?,
-            Tab::Files => self.get_files_tab(commander)?,
-            Tab::Bookmarks => self.get_bookmarks_tab(commander)?,
+            Tab::Log => self.get_log_tab()?,
+            Tab::Files => self.get_files_tab()?,
+            Tab::Bookmarks => self.get_bookmarks_tab()?,
         })
     }
 
@@ -166,36 +154,34 @@ impl<'a> App<'a> {
         }
     }
 
-    pub fn handle_action(
-        &mut self,
-        component_action: ComponentAction,
-        commander: &mut Commander,
-    ) -> Result<()> {
+    pub fn handle_action(&mut self, component_action: ComponentAction) -> Result<()> {
+        let mut commander = self.commander.clone();
         match component_action {
             ComponentAction::ViewFiles(head) => {
-                self.set_tab(commander, Tab::Files)?;
-                self.get_files_tab(commander)?.set_head(commander, &head)?;
+                self.set_tab(Tab::Files)?;
+                self.get_files_tab()?.set_head(&mut commander, &head)?;
             }
             ComponentAction::ViewLog(head) => {
-                self.get_log_tab(commander)?.set_head(commander, head);
-                self.set_tab(commander, Tab::Log)?;
+                self.get_log_tab()?.set_head(&mut commander, head);
+                self.set_tab(Tab::Log)?;
             }
             ComponentAction::ChangeHead(head) => {
-                self.get_files_tab(commander)?.set_head(commander, &head)?;
+                self.get_files_tab()?.set_head(&mut commander, &head)?;
             }
             ComponentAction::SetPopup(popup) => {
                 self.popup = popup;
             }
             ComponentAction::Multiple(component_actions) => {
                 for component_action in component_actions.into_iter() {
-                    self.handle_action(component_action, commander)?;
+                    self.handle_action(component_action)?;
                 }
             }
             ComponentAction::RefreshTab() => {
-                self.set_tab(commander, self.current_tab)?;
+                self.set_tab(self.current_tab)?;
                 if self.current_tab == Tab::Log {
-                    let head = commander.get_current_head()?;
-                    self.get_log_tab(commander)?.set_head(commander, head);
+                    let mut commander = self.commander.clone();
+                    let head = commander.get_current_head()?.clone();
+                    self.get_log_tab()?.set_head(&mut commander, head);
                 };
             }
         }
@@ -203,29 +189,29 @@ impl<'a> App<'a> {
         Ok(())
     }
 
-    #[instrument(level = "trace", skip(self, commander))]
-    pub fn update(&mut self, commander: &mut Commander) -> Result<()> {
+    #[instrument(level = "trace", skip(self))]
+    pub fn update(&mut self) -> Result<()> {
+        let mut commander = self.commander.clone();
         if let Some(popup) = self.popup.as_mut()
-            && let Some(component_action) = popup.update(commander)?
+            && let Some(component_action) = popup.update(&mut commander)?
         {
-            self.handle_action(component_action, commander)?;
+            self.handle_action(component_action)?;
         }
 
-        if let Some(component_action) =
-            self.get_or_init_current_tab(commander)?.update(commander)?
-        {
-            self.handle_action(component_action, commander)?;
+        if let Some(component_action) = self.get_or_init_current_tab()?.update(&mut commander)? {
+            self.handle_action(component_action)?;
         }
 
         Ok(())
     }
 
-    #[instrument(level = "trace", skip(self, commander))]
-    pub fn input(&mut self, event: Event, commander: &mut Commander) -> Result<bool> {
+    #[instrument(level = "trace", skip(self))]
+    pub fn input(&mut self, event: Event) -> Result<bool> {
+        let mut commander = self.commander.clone();
         if let Some(popup) = self.popup.as_mut() {
-            match popup.input(commander, event.clone())? {
+            match popup.input(&mut commander, event.clone())? {
                 ComponentInputResult::HandledAction(component_action) => {
-                    self.handle_action(component_action, commander)?
+                    self.handle_action(component_action)?
                 }
                 ComponentInputResult::Handled => {}
                 ComponentInputResult::NotHandled => {
@@ -248,14 +234,14 @@ impl<'a> App<'a> {
                 }
             };
         } else if event == event::Event::FocusGained {
-            self.get_or_init_current_tab(commander)?.focus(commander)?;
+            self.get_or_init_current_tab()?.focus(&mut commander)?;
         } else {
             match self
-                .get_or_init_current_tab(commander)?
-                .input(commander, event.clone())?
+                .get_or_init_current_tab()?
+                .input(&mut commander, event.clone())?
             {
                 ComponentInputResult::HandledAction(component_action) => {
-                    self.handle_action(component_action, commander)?
+                    self.handle_action(component_action)?
                 }
                 ComponentInputResult::Handled => {}
                 ComponentInputResult::NotHandled => {
@@ -273,9 +259,9 @@ impl<'a> App<'a> {
                         //
                         // Tab switching
                         else if key.code == KeyCode::Char('l') {
-                            self.set_next_tab_with_offset(commander, 1)?;
+                            self.set_next_tab_with_offset(1)?;
                         } else if key.code == KeyCode::Char('h') {
-                            self.set_next_tab_with_offset(commander, -1)?;
+                            self.set_next_tab_with_offset(-1)?;
                         } else if let Some((_, tab)) =
                             Tab::VALUES.iter().enumerate().find(|(i, _)| {
                                 key.code
@@ -285,7 +271,7 @@ impl<'a> App<'a> {
                                     )
                             })
                         {
-                            self.set_tab(commander, *tab)?;
+                            self.set_tab(*tab)?;
                         }
                         // General jj command runner
                         else if key.code == KeyCode::Char(':') {

--- a/src/commander/mod.rs
+++ b/src/commander/mod.rs
@@ -95,7 +95,7 @@ impl CommandError {
 /// Struct used to interact with the jj cli using commanders.
 ///
 /// Handles arguments and recording of history.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Commander {
     pub env: Env,
     /// Environment variables.

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,34 +128,34 @@ fn main() -> Result<()> {
 
     // Setup environment
     let env = Env::new(path, args.revisions, jj_bin)?;
-    let mut commander = Commander::new(&env);
+    let commander = Commander::new(&env);
 
     if !args.ignore_jj_version {
         commander.check_jj_version()?;
     }
 
     // Setup app
-    let mut app = App::new(env.clone())?;
+    let mut app = App::new(env.clone(), commander)?;
 
     install_panic_hook();
     let mut terminal = setup_terminal()?;
 
     // Run app
-    let res = run_app(&mut terminal, &mut app, &mut commander);
+    let res = run_app(&mut terminal, &mut app);
     restore_terminal()?;
     res?;
 
     Ok(())
 }
 
-fn run_app(terminal: &mut DefaultTerminal, app: &mut App, commander: &mut Commander) -> Result<()> {
+fn run_app(terminal: &mut DefaultTerminal, app: &mut App) -> Result<()> {
     loop {
-        app.update(commander)?;
+        app.update()?;
         terminal.draw(|f| {
             let _ = ui(f, app);
         })?;
 
-        let should_stop = input_to_app(app, commander)?;
+        let should_stop = input_to_app(app)?;
 
         if should_stop {
             return Ok(());
@@ -166,7 +166,7 @@ fn run_app(terminal: &mut DefaultTerminal, app: &mut App, commander: &mut Comman
 /// Let app process all input events in queue before returning
 /// to draw the next frame.
 /// Return true if application should stop
-fn input_to_app(app: &mut App, commander: &mut Commander) -> Result<bool> {
+fn input_to_app(app: &mut App) -> Result<bool> {
     // Duration::MAX overflows the timespec struct used by kevent/kqueue on macOS,
     // causing EINVAL (os error 22). Use a safe large value instead.
     const FOREVER: Duration = Duration::from_secs(24 * 3600);
@@ -189,7 +189,7 @@ fn input_to_app(app: &mut App, commander: &mut Commander) -> Result<bool> {
     let mut should_stop: bool = false;
     while event::poll(Duration::ZERO)? && !should_stop {
         let event = event::read()?;
-        should_stop = app.input(event, commander)?;
+        should_stop = app.input(event)?;
     }
     Ok(should_stop)
 }

--- a/src/ui/bookmark_set_popup.rs
+++ b/src/ui/bookmark_set_popup.rs
@@ -44,6 +44,7 @@ enum BookmarkSetOption {
 }
 
 pub struct BookmarkSetPopup<'a> {
+    commander: Commander,
     pub change_id: Option<ChangeId>,
     commit_id: CommitId,
     options: Vec<BookmarkSetOption>,
@@ -100,13 +101,15 @@ fn generate_name(commander: &Commander, change_id: &ChangeId) -> String {
 impl BookmarkSetPopup<'_> {
     pub fn new(
         config: JjConfig,
-        commander: &mut Commander,
+        mut commander: Commander,
         change_id: Option<ChangeId>,
         commit_id: CommitId,
         tx: std::sync::mpsc::Sender<bool>,
     ) -> Self {
+        let options = generate_options(&mut commander, change_id.as_ref());
         Self {
-            options: generate_options(commander, change_id.as_ref()),
+            commander,
+            options,
             change_id,
             list_state: ListState::default().with_selected(Some(0)),
             list_height: 0,
@@ -131,29 +134,34 @@ impl BookmarkSetPopup<'_> {
         self.creating = Some(TextArea::default());
     }
 
-    fn create_bookmark(&self, commander: &mut Commander, name: &str) -> Result<()> {
-        if commander
+    fn create_bookmark(&self, name: &str) -> Result<()> {
+        if self
+            .commander
             .get_bookmarks_list(false)?
             .iter()
             .any(|bookmark| bookmark.name == name)
         {
-            commander.set_bookmark_commit(name, &self.commit_id)?;
+            self.commander.set_bookmark_commit(name, &self.commit_id)?;
         } else {
-            commander.create_bookmark_commit(name, &self.commit_id)?;
+            self.commander
+                .create_bookmark_commit(name, &self.commit_id)?;
         }
         Ok(())
     }
-    fn generate_bookmark(&self, commander: &mut Commander) -> Result<()> {
+    fn generate_bookmark(&self) -> Result<()> {
         if let Some(change_id) = self.change_id.as_ref() {
-            let generated_name = generate_name(commander, change_id);
-            if commander
+            let generated_name = generate_name(&self.commander, change_id);
+            if self
+                .commander
                 .get_bookmarks_list(false)?
                 .iter()
                 .any(|bookmark| bookmark.name == generated_name)
             {
-                commander.set_bookmark_commit(&generated_name, &self.commit_id)?;
+                self.commander
+                    .set_bookmark_commit(&generated_name, &self.commit_id)?;
             } else {
-                commander.create_bookmark_commit(&generated_name, &self.commit_id)?;
+                self.commander
+                    .create_bookmark_commit(&generated_name, &self.commit_id)?;
             }
             Ok(())
         } else {
@@ -247,11 +255,7 @@ impl Component for BookmarkSetPopup<'_> {
     }
 
     /// Handle input. Returns bool of if to close
-    fn input(
-        &mut self,
-        commander: &mut Commander,
-        event: Event,
-    ) -> anyhow::Result<crate::ComponentInputResult> {
+    fn input(&mut self, event: Event) -> anyhow::Result<crate::ComponentInputResult> {
         if let Some(creating) = self.creating.as_mut() {
             if let Event::Key(key) = event {
                 match key.code {
@@ -264,7 +268,7 @@ impl Component for BookmarkSetPopup<'_> {
                             return Ok(ComponentInputResult::Handled);
                         }
 
-                        self.create_bookmark(commander, name)?;
+                        self.create_bookmark(name)?;
                         self.tx.send(true)?;
                         return Ok(ComponentInputResult::HandledAction(
                             ComponentAction::SetPopup(None),
@@ -298,7 +302,7 @@ impl Component for BookmarkSetPopup<'_> {
                     self.scroll((self.list_height as isize / 2).saturating_neg());
                 }
                 KeyCode::Char('g') => {
-                    self.generate_bookmark(commander)?;
+                    self.generate_bookmark()?;
                     self.tx.send(true)?;
                     return Ok(ComponentInputResult::HandledAction(
                         ComponentAction::SetPopup(None),
@@ -318,21 +322,23 @@ impl Component for BookmarkSetPopup<'_> {
                                 self.on_creating();
                             }
                             BookmarkSetOption::GeneratedName(_, _) => {
-                                self.generate_bookmark(commander)?;
+                                self.generate_bookmark()?;
                                 self.tx.send(true)?;
                                 return Ok(ComponentInputResult::HandledAction(
                                     ComponentAction::SetPopup(None),
                                 ));
                             }
                             BookmarkSetOption::Bookmark(bookmark) => {
-                                commander.set_bookmark_commit(&bookmark.name, &self.commit_id)?;
+                                self.commander
+                                    .set_bookmark_commit(&bookmark.name, &self.commit_id)?;
                                 self.tx.send(true)?;
                                 return Ok(ComponentInputResult::HandledAction(
                                     ComponentAction::SetPopup(None),
                                 ));
                             }
                             BookmarkSetOption::Error(_) => {
-                                self.options = generate_options(commander, self.change_id.as_ref());
+                                self.options =
+                                    generate_options(&mut self.commander, self.change_id.as_ref());
                             }
                         }
                     }

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -59,6 +59,8 @@ const EDIT_POPUP_ID: u16 = 4;
 
 /// Bookmarks tab. Shows bookmarks in main panel and selected bookmark current change in details panel.
 pub struct BookmarksTab<'a> {
+    commander: Commander,
+
     bookmarks_output: Result<Vec<BookmarkLine>, CommandError>,
     bookmarks_list_state: ListState,
     bookmarks_height: u16,
@@ -122,7 +124,7 @@ fn get_current_bookmark_index(
 
 impl BookmarksTab<'_> {
     #[instrument(level = "info", name = "Initializing bookmarks tab", parent = None, skip(commander))]
-    pub fn new(commander: &mut Commander) -> Result<Self> {
+    pub fn new(commander: Commander) -> Result<Self> {
         let diff_format = commander.env.jj_config.diff_format();
 
         let show_all = false;
@@ -149,8 +151,11 @@ impl BookmarksTab<'_> {
         });
 
         let (popup_tx, popup_rx) = std::sync::mpsc::channel();
+        let config = commander.env.jj_config.clone();
 
         Ok(Self {
+            commander,
+
             bookmarks_output,
             bookmark,
             bookmarks_list_state,
@@ -178,7 +183,7 @@ impl BookmarksTab<'_> {
 
             diff_format,
 
-            config: commander.env.jj_config.clone(),
+            config,
         })
     }
 
@@ -186,16 +191,16 @@ impl BookmarksTab<'_> {
         get_current_bookmark_index(self.bookmark.as_ref(), &self.bookmarks_output)
     }
 
-    pub fn refresh_bookmarks(&mut self, commander: &mut Commander) {
-        self.bookmarks_output = commander.get_bookmarks(self.show_all);
+    pub fn refresh_bookmarks(&mut self) {
+        self.bookmarks_output = self.commander.get_bookmarks(self.show_all);
     }
 
-    pub fn refresh_bookmark(&mut self, commander: &mut Commander) {
+    pub fn refresh_bookmark(&mut self) {
         let inner_width = self.bookmark_panel.columns() as usize;
-        commander.limit_width(inner_width);
+        self.commander.limit_width(inner_width);
         self.bookmark_output = self.bookmark.as_ref().and_then(|bookmark| match bookmark {
             BookmarkLine::Parsed { bookmark, .. } => Some(
-                commander
+                self.commander
                     .get_bookmark_show(bookmark, &self.diff_format, true)
                     .map(|diff| tabs_to_spaces(&diff)),
             ),
@@ -205,7 +210,7 @@ impl BookmarksTab<'_> {
         self.bookmark_panel.scroll_to(0);
     }
 
-    fn scroll_bookmarks(&mut self, commander: &mut Commander, scroll: isize) {
+    fn scroll_bookmarks(&mut self, scroll: isize) {
         let bookmarks = Vec::new();
         let bookmarks = self.bookmarks_output.as_ref().unwrap_or(&bookmarks);
         let current_bookmark_index = self.get_current_bookmark_index();
@@ -221,19 +226,19 @@ impl BookmarksTab<'_> {
 
         if let Some(next_bookmark) = next_bookmark {
             self.bookmark = Some(next_bookmark);
-            self.refresh_bookmark(commander);
+            self.refresh_bookmark();
         }
     }
 }
 
 impl Component for BookmarksTab<'_> {
-    fn focus(&mut self, commander: &mut Commander) -> Result<()> {
-        self.refresh_bookmarks(commander);
-        self.refresh_bookmark(commander);
+    fn focus(&mut self) -> Result<()> {
+        self.refresh_bookmarks();
+        self.refresh_bookmark();
         Ok(())
     }
 
-    fn update(&mut self, commander: &mut Commander) -> Result<Option<ComponentAction>> {
+    fn update(&mut self) -> Result<Option<ComponentAction>> {
         // Check for popup action
         if let Ok(res) = self.popup_rx.try_recv()
             && res.1.unwrap_or(false)
@@ -241,15 +246,15 @@ impl Component for BookmarksTab<'_> {
             match res.0 {
                 DELETE_BRANCH_POPUP_ID => {
                     if let Some(delete) = self.delete.as_ref() {
-                        match commander.delete_bookmark(&delete.name) {
+                        match self.commander.delete_bookmark(&delete.name) {
                             Ok(_) => {
-                                self.refresh_bookmarks(commander);
+                                self.refresh_bookmarks();
                                 let bookmarks = Vec::new();
                                 let bookmarks =
                                     self.bookmarks_output.as_ref().unwrap_or(&bookmarks);
                                 self.bookmark =
                                     bookmarks.first().map(|bookmark| bookmark.to_owned());
-                                self.refresh_bookmark(commander);
+                                self.refresh_bookmark();
                             }
                             Err(err) => {
                                 return Ok(Some(ComponentAction::SetPopup(Some(Box::new(
@@ -265,15 +270,15 @@ impl Component for BookmarksTab<'_> {
                 }
                 FORGET_BRANCH_POPUP_ID => {
                     if let Some(forget) = self.forget.as_ref() {
-                        match commander.forget_bookmark(&forget.name) {
+                        match self.commander.forget_bookmark(&forget.name) {
                             Ok(_) => {
-                                self.refresh_bookmarks(commander);
+                                self.refresh_bookmarks();
                                 let bookmarks = Vec::new();
                                 let bookmarks =
                                     self.bookmarks_output.as_ref().unwrap_or(&bookmarks);
                                 self.bookmark =
                                     bookmarks.first().map(|bookmark| bookmark.to_owned());
-                                self.refresh_bookmark(commander);
+                                self.refresh_bookmark();
                             }
                             Err(err) => {
                                 return Ok(Some(ComponentAction::SetPopup(Some(Box::new(
@@ -289,8 +294,8 @@ impl Component for BookmarksTab<'_> {
                 }
                 NEW_POPUP_ID => {
                     if let Some(BookmarkLine::Parsed { bookmark, .. }) = self.bookmark.as_ref() {
-                        commander.run_new([bookmark.to_string().as_str()])?;
-                        let head = commander.get_current_head()?;
+                        self.commander.run_new([bookmark.to_string().as_str()])?;
+                        let head = self.commander.get_current_head()?;
                         if self.describe_after_new {
                             self.describe_after_new_change = Some(head.change_id);
                             self.describe_after_new = false;
@@ -304,8 +309,9 @@ impl Component for BookmarksTab<'_> {
                 }
                 EDIT_POPUP_ID => {
                     if let Some(BookmarkLine::Parsed { bookmark, .. }) = self.bookmark.as_ref() {
-                        commander.run_edit(&bookmark.to_string(), self.edit_ignore_immutable)?;
-                        let head = commander.get_current_head()?;
+                        self.commander
+                            .run_edit(&bookmark.to_string(), self.edit_ignore_immutable)?;
+                        let head = self.commander.get_current_head()?;
                         return Ok(Some(ComponentAction::ViewLog(head)));
                     }
                 }
@@ -613,7 +619,7 @@ impl Component for BookmarksTab<'_> {
         Ok(())
     }
 
-    fn input(&mut self, commander: &mut Commander, event: Event) -> Result<ComponentInputResult> {
+    fn input(&mut self, event: Event) -> Result<ComponentInputResult> {
         if let Some(create) = self.create.as_mut() {
             if let Event::Key(key) = event {
                 match key.code {
@@ -629,13 +635,13 @@ impl Component for BookmarksTab<'_> {
                             return Ok(ComponentInputResult::Handled);
                         }
 
-                        if let Err(err) = commander.create_bookmark(&name) {
+                        if let Err(err) = self.commander.create_bookmark(&name) {
                             create.error = Some(anyhow::Error::new(err));
                             return Ok(ComponentInputResult::Handled);
                         }
 
                         self.create = None;
-                        self.refresh_bookmarks(commander);
+                        self.refresh_bookmarks();
 
                         // Select new bookmark
                         if let Some(bookmark) =
@@ -654,7 +660,7 @@ impl Component for BookmarksTab<'_> {
                             self.bookmark = Some(bookmark.clone());
                         }
 
-                        self.refresh_bookmark(commander);
+                        self.refresh_bookmark();
 
                         return Ok(ComponentInputResult::Handled);
                     }
@@ -686,12 +692,12 @@ impl Component for BookmarksTab<'_> {
 
                         let old = rename.name.clone();
 
-                        if let Err(err) = commander.rename_bookmark(&old, &new) {
+                        if let Err(err) = self.commander.rename_bookmark(&old, &new) {
                             rename.error = Some(anyhow::Error::new(err));
                             return Ok(ComponentInputResult::Handled);
                         }
                         self.rename = None;
-                        self.refresh_bookmarks(commander);
+                        self.refresh_bookmarks();
 
                         // Select new bookmark
                         if let Some(bookmark) =
@@ -710,7 +716,7 @@ impl Component for BookmarksTab<'_> {
                             self.bookmark = Some(bookmark.clone());
                         }
 
-                        self.refresh_bookmark(commander);
+                        self.refresh_bookmark();
 
                         return Ok(ComponentInputResult::Handled);
                     }
@@ -733,14 +739,14 @@ impl Component for BookmarksTab<'_> {
                 match key.code {
                     KeyCode::Char('s') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                         // TODO: Handle error
-                        commander.run_describe(
+                        self.commander.run_describe(
                             describe_after_new_change.as_str(),
                             &describe_textarea.lines().join("\n"),
                         )?;
                         self.describe_textarea = None;
                         self.describe_after_new_change = None;
                         return Ok(ComponentInputResult::HandledAction(
-                            ComponentAction::ViewLog(commander.get_current_head()?),
+                            ComponentAction::ViewLog(self.commander.get_current_head()?),
                         ));
                     }
                     KeyCode::Esc => {
@@ -774,28 +780,25 @@ impl Component for BookmarksTab<'_> {
             }
 
             match key.code {
-                KeyCode::Char('j') | KeyCode::Down => self.scroll_bookmarks(commander, 1),
-                KeyCode::Char('k') | KeyCode::Up => self.scroll_bookmarks(commander, -1),
+                KeyCode::Char('j') | KeyCode::Down => self.scroll_bookmarks(1),
+                KeyCode::Char('k') | KeyCode::Up => self.scroll_bookmarks(-1),
                 KeyCode::Char('J') => {
-                    self.scroll_bookmarks(commander, self.bookmarks_height as isize / 2);
+                    self.scroll_bookmarks(self.bookmarks_height as isize / 2);
                 }
                 KeyCode::Char('K') => {
-                    self.scroll_bookmarks(
-                        commander,
-                        (self.bookmarks_height as isize / 2).saturating_neg(),
-                    );
+                    self.scroll_bookmarks((self.bookmarks_height as isize / 2).saturating_neg());
                 }
                 KeyCode::Char('w') => {
                     self.diff_format = self.diff_format.get_next(self.config.diff_tool());
-                    self.refresh_bookmark(commander);
+                    self.refresh_bookmark();
                 }
                 KeyCode::Char('R') | KeyCode::F(5) => {
-                    self.refresh_bookmarks(commander);
-                    self.refresh_bookmark(commander);
+                    self.refresh_bookmarks();
+                    self.refresh_bookmark();
                 }
                 KeyCode::Char('a') => {
                     self.show_all = !self.show_all;
-                    self.refresh_bookmarks(commander);
+                    self.refresh_bookmarks();
                 }
                 KeyCode::Char('c') => {
                     let textarea = TextArea::default();
@@ -863,9 +866,9 @@ impl Component for BookmarksTab<'_> {
                         && bookmark.remote.is_some()
                         && bookmark.present
                     {
-                        commander.track_bookmark(bookmark)?;
-                        self.refresh_bookmarks(commander);
-                        self.refresh_bookmark(commander);
+                        self.commander.track_bookmark(bookmark)?;
+                        self.refresh_bookmarks();
+                        self.refresh_bookmark();
                     }
                 }
                 KeyCode::Char('T') => {
@@ -873,9 +876,9 @@ impl Component for BookmarksTab<'_> {
                         && bookmark.remote.is_some()
                         && bookmark.present
                     {
-                        commander.untrack_bookmark(bookmark)?;
-                        self.refresh_bookmarks(commander);
-                        self.refresh_bookmark(commander);
+                        self.commander.untrack_bookmark(bookmark)?;
+                        self.refresh_bookmarks();
+                        self.refresh_bookmark();
                     }
                 }
                 KeyCode::Char('n') | KeyCode::Char('N') => {
@@ -903,7 +906,9 @@ impl Component for BookmarksTab<'_> {
                     if let Some(BookmarkLine::Parsed { bookmark, .. }) = self.bookmark.as_ref() {
                         let ignore_immutable = key.code == KeyCode::Char('E');
                         if bookmark.present {
-                            if commander.check_revision_immutable(&bookmark.to_string())?
+                            if self
+                                .commander
+                                .check_revision_immutable(&bookmark.to_string())?
                                 && !ignore_immutable
                             {
                                 return Ok(ComponentInputResult::HandledAction(
@@ -941,7 +946,7 @@ impl Component for BookmarksTab<'_> {
                         && bookmark.present
                     {
                         return Ok(ComponentInputResult::HandledAction(
-                            ComponentAction::ViewLog(commander.get_bookmark_head(bookmark)?),
+                            ComponentAction::ViewLog(self.commander.get_bookmark_head(bookmark)?),
                         ));
                     }
                 }

--- a/src/ui/command_popup.rs
+++ b/src/ui/command_popup.rs
@@ -26,12 +26,14 @@ use crate::ui::message_popup::MessagePopup;
 use crate::ui::utils::centered_rect_line_height;
 
 pub struct CommandPopup<'a> {
+    commander: Commander,
     command_textarea: TextArea<'a>,
 }
 
 impl CommandPopup<'_> {
-    pub fn new() -> Self {
+    pub fn new(commander: Commander) -> Self {
         Self {
+            commander,
             command_textarea: TextArea::new(vec![]),
         }
     }
@@ -73,11 +75,8 @@ impl Component for CommandPopup<'_> {
         Ok(())
     }
 
-    fn input(
-        &mut self,
-        commander: &mut Commander,
-        event: Event,
-    ) -> anyhow::Result<ComponentInputResult> {
+    fn input(&mut self, event: Event) -> anyhow::Result<ComponentInputResult> {
+        let commander = &self.commander;
         if let Event::Key(key) = event {
             match key.code {
                 KeyCode::Enter => {

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -27,6 +27,8 @@ use crate::ui::utils::tabs_to_spaces;
 
 /// Files tab. Shows files in selected change in main panel and selected file diff in details panel
 pub struct FilesTab {
+    commander: Commander,
+
     head: Head,
     is_current_head: bool,
 
@@ -60,7 +62,7 @@ fn get_current_file_index(
 
 impl FilesTab {
     #[instrument(level = "info", name = "Initializing files tab", parent = None, skip(commander))]
-    pub fn new(commander: &mut Commander, head: &Head) -> Result<Self> {
+    pub fn new(commander: Commander, head: &Head) -> Result<Self> {
         let head = head.clone();
         let is_current_head = head == commander.get_current_head()?;
 
@@ -86,8 +88,11 @@ impl FilesTab {
             current_file.as_ref(),
             files_output.as_ref(),
         ));
+        let config = commander.env.jj_config.clone();
 
         Ok(Self {
+            commander,
+
             head,
             is_current_head,
 
@@ -102,22 +107,22 @@ impl FilesTab {
             diff_format,
             diff_panel: DetailsPanel::new(),
 
-            config: commander.env.jj_config.clone(),
+            config,
         })
     }
 
-    pub fn set_head(&mut self, commander: &mut Commander, head: &Head) -> Result<()> {
+    pub fn set_head(&mut self, head: &Head) -> Result<()> {
         self.head = head.clone();
-        self.is_current_head = self.head == commander.get_current_head()?;
+        self.is_current_head = self.head == self.commander.get_current_head()?;
 
-        self.refresh_files(commander)?;
+        self.refresh_files()?;
         self.file = self
             .files_output
             .as_ref()
             .ok()
             .and_then(|files_output| files_output.first())
             .map(|file| file.to_owned());
-        self.refresh_diff(commander)?;
+        self.refresh_diff()?;
 
         Ok(())
     }
@@ -126,20 +131,21 @@ impl FilesTab {
         get_current_file_index(self.file.as_ref(), self.files_output.as_ref())
     }
 
-    pub fn refresh_files(&mut self, commander: &mut Commander) -> Result<()> {
-        self.files_output = commander.get_files(&self.head);
-        self.conflicts_output = commander.get_conflicts(&self.head.commit_id)?;
+    pub fn refresh_files(&mut self) -> Result<()> {
+        self.files_output = self.commander.get_files(&self.head);
+        self.conflicts_output = self.commander.get_conflicts(&self.head.commit_id)?;
         Ok(())
     }
 
-    pub fn refresh_diff(&mut self, commander: &mut Commander) -> Result<()> {
+    pub fn refresh_diff(&mut self) -> Result<()> {
         let inner_width = self.diff_panel.columns() as usize;
-        commander.limit_width(inner_width);
+        self.commander.limit_width(inner_width);
         self.diff_output = self
             .file
             .as_ref()
             .map(|current_file| {
-                commander.get_file_diff(&self.head, current_file, &self.diff_format, true)
+                self.commander
+                    .get_file_diff(&self.head, current_file, &self.diff_format, true)
             })
             .map_or(Ok(None), |r| {
                 r.map(|diff| diff.map(|diff| tabs_to_spaces(&diff)))
@@ -148,23 +154,23 @@ impl FilesTab {
         Ok(())
     }
 
-    pub fn untrack_file(&mut self, commander: &mut Commander) -> Result<()> {
+    pub fn untrack_file(&self) -> Result<()> {
         self.file
             .as_ref()
-            .map(|current_file| commander.untrack_file(current_file))
+            .map(|current_file| self.commander.untrack_file(current_file))
             .transpose()?;
         Ok(())
     }
 
-    pub fn restore_file(&mut self, commander: &mut Commander) -> Result<()> {
+    pub fn restore_file(&mut self) -> Result<()> {
         self.file
             .as_ref()
-            .map(|current_file| commander.restore_file(current_file))
+            .map(|current_file| self.commander.restore_file(current_file))
             .transpose()?;
         Ok(())
     }
 
-    fn scroll_files(&mut self, commander: &mut Commander, scroll: isize) -> Result<()> {
+    fn scroll_files(&mut self, scroll: isize) -> Result<()> {
         if let Ok(files) = self.files_output.as_ref() {
             let current_file_index = self.get_current_file_index();
             let next_file = match current_file_index {
@@ -178,7 +184,7 @@ impl FilesTab {
             .map(|x| x.to_owned());
             if let Some(next_file) = next_file {
                 self.file = Some(next_file.to_owned());
-                self.refresh_diff(commander)?;
+                self.refresh_diff()?;
             }
         }
         Ok(())
@@ -186,11 +192,11 @@ impl FilesTab {
 }
 
 impl Component for FilesTab {
-    fn focus(&mut self, commander: &mut Commander) -> Result<()> {
-        self.is_current_head = self.head == commander.get_current_head()?;
-        self.head = commander.get_head_latest(&self.head)?;
-        self.refresh_files(commander)?;
-        self.refresh_diff(commander)?;
+    fn focus(&mut self) -> Result<()> {
+        self.is_current_head = self.head == self.commander.get_current_head()?;
+        self.head = self.commander.get_head_latest(&self.head)?;
+        self.refresh_files()?;
+        self.refresh_diff()?;
         Ok(())
     }
 
@@ -326,7 +332,8 @@ impl Component for FilesTab {
         Ok(())
     }
 
-    fn input(&mut self, commander: &mut Commander, event: Event) -> Result<ComponentInputResult> {
+    fn input(&mut self, event: Event) -> Result<ComponentInputResult> {
+        let commander = self.commander.clone();
         if let Event::Key(key) = event {
             if key.kind != KeyEventKind::Press {
                 return Ok(ComponentInputResult::Handled);
@@ -337,24 +344,21 @@ impl Component for FilesTab {
             }
 
             match key.code {
-                KeyCode::Char('j') | KeyCode::Down => self.scroll_files(commander, 1)?,
-                KeyCode::Char('k') | KeyCode::Up => self.scroll_files(commander, -1)?,
+                KeyCode::Char('j') | KeyCode::Down => self.scroll_files(1)?,
+                KeyCode::Char('k') | KeyCode::Up => self.scroll_files(-1)?,
                 KeyCode::Char('J') => {
-                    self.scroll_files(commander, self.files_height as isize / 2)?;
+                    self.scroll_files(self.files_height as isize / 2)?;
                 }
                 KeyCode::Char('K') => {
-                    self.scroll_files(
-                        commander,
-                        (self.files_height as isize / 2).saturating_neg(),
-                    )?;
+                    self.scroll_files((self.files_height as isize / 2).saturating_neg())?;
                 }
                 KeyCode::Char('w') => {
                     self.diff_format = self.diff_format.get_next(self.config.diff_tool());
-                    self.refresh_diff(commander)?;
+                    self.refresh_diff()?;
                 }
                 KeyCode::Char('x') => {
                     // this works even for deleted files because jj doesn't return error in that case
-                    if self.untrack_file(commander).is_err() {
+                    if self.untrack_file().is_err() {
                         return Ok(ComponentInputResult::HandledAction(
                             ComponentAction::SetPopup(Some(Box::new(MessagePopup {
                                 title: "Can't untrack file".into(),
@@ -363,10 +367,10 @@ impl Component for FilesTab {
                             }))),
                         ));
                     }
-                    self.set_head(commander, &commander.get_current_head()?)?;
+                    self.set_head(&commander.get_current_head()?)?;
                 }
                 KeyCode::Char('r') => {
-                    if let Err(err) = self.restore_file(commander) {
+                    if let Err(err) = self.restore_file() {
                         return Ok(ComponentInputResult::HandledAction(
                             ComponentAction::SetPopup(Some(Box::new(MessagePopup {
                                 title: "Can't restore file".into(),
@@ -375,16 +379,16 @@ impl Component for FilesTab {
                             }))),
                         ));
                     }
-                    self.set_head(commander, &commander.get_current_head()?)?;
+                    self.set_head(&commander.get_current_head()?)?;
                 }
                 KeyCode::Char('R') | KeyCode::F(5) => {
                     self.head = commander.get_head_latest(&self.head)?;
-                    self.refresh_files(commander)?;
-                    self.refresh_diff(commander)?;
+                    self.refresh_files()?;
+                    self.refresh_diff()?;
                 }
                 KeyCode::Char('@') => {
                     let head = &commander.get_current_head()?;
-                    self.set_head(commander, head)?;
+                    self.set_head(head)?;
                 }
                 KeyCode::Char('?') => {
                     return Ok(ComponentInputResult::HandledAction(

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -86,11 +86,7 @@ impl Component for HelpPopup {
         Ok(())
     }
 
-    fn input(
-        &mut self,
-        _commander: &mut crate::commander::Commander,
-        event: Event,
-    ) -> anyhow::Result<crate::ComponentInputResult> {
+    fn input(&mut self, event: Event) -> anyhow::Result<crate::ComponentInputResult> {
         if let Event::Key(key) = event
             && key.kind == event::KeyEventKind::Press
         {

--- a/src/ui/loader_popup.rs
+++ b/src/ui/loader_popup.rs
@@ -23,7 +23,6 @@ use throbber_widgets_tui::ThrobberState;
 
 use crate::ComponentInputResult;
 use crate::commander::CommandError;
-use crate::commander::Commander;
 use crate::ui::Component;
 use crate::ui::ComponentAction;
 use crate::ui::message_popup::MessagePopup;
@@ -69,7 +68,7 @@ impl Component for LoaderPopup {
     ///
     /// This updates the animation and also polls the running operation to see if the popup may be
     /// closed. In case of an error, that will be displayed in a new popup.
-    fn update(&mut self, _commander: &mut Commander) -> Result<Option<ComponentAction>> {
+    fn update(&mut self) -> Result<Option<ComponentAction>> {
         if self.last_animation_update.elapsed() >= Duration::from_millis(100) {
             self.throbber_state.calc_next();
             self.last_animation_update = Instant::now();
@@ -130,7 +129,7 @@ impl Component for LoaderPopup {
     /// Process input
     ///
     /// As of now, all input is ignored as we don't supporting cancelling operations yet.
-    fn input(&mut self, _commander: &mut Commander, _event: Event) -> Result<ComponentInputResult> {
+    fn input(&mut self, _event: Event) -> Result<ComponentInputResult> {
         // Block all input while loading
         Ok(ComponentInputResult::Handled)
     }

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -51,6 +51,9 @@ const SQUASH_POPUP_ID: u16 = 4;
 
 /// Log tab. Shows `jj log` in main panel and shows selected change details of in details panel.
 pub struct LogTab<'a> {
+    /// Local Commander
+    commander: Commander,
+
     /// The revset filter to apply to jj log
     log_revset_textarea: Option<TextArea<'a>>,
 
@@ -124,7 +127,8 @@ The main functions are:
 */
 impl<'a> LogTab<'a> {
     #[instrument(level = "info", name = "Initializing log tab", parent = None, skip(commander))]
-    pub fn new(commander: &mut Commander) -> Result<Self> {
+    pub fn new(mut commander: Commander) -> Result<Self> {
+        let log_panel = LogPanel::new(commander.clone())?;
         let diff_format = commander.env.jj_config.diff_format();
 
         let head = commander.get_current_head()?;
@@ -135,7 +139,7 @@ impl<'a> LogTab<'a> {
         let mut commit_show_cache = CommitShowCache::new();
 
         let _new_content = commit_show_cache.get_or_insert(&head_key, || {
-            Self::compute_head_content(commander, NO_WIDTH, &head, &diff_format)
+            Self::compute_head_content(&mut commander, NO_WIDTH, &head, &diff_format)
         });
 
         let (popup_tx, popup_rx) = std::sync::mpsc::channel();
@@ -150,11 +154,14 @@ impl<'a> LogTab<'a> {
         {
             keybinds.extend_from_config(&new_keybinds);
         }
+        let config = commander.env.jj_config.clone();
 
         Ok(Self {
+            commander,
+
             log_revset_textarea: None,
 
-            log_panel: LogPanel::new(commander)?,
+            log_panel,
 
             head,
             head_panel: DetailsPanel::new(),
@@ -182,33 +189,33 @@ impl<'a> LogTab<'a> {
 
             edit_ignore_immutable: false,
 
-            config: commander.env.jj_config.clone(),
+            config,
             keybinds,
         })
     }
 
     /// Set cursor and update log panel and diff panel
-    pub fn set_head(&mut self, commander: &mut Commander, head: Head) {
+    pub fn set_head(&mut self, head: Head) {
         self.log_panel.set_head(head);
-        self.refresh_log_output(commander);
+        self.refresh_log_output();
     }
 
     /// Update the log panel and diff panel. This will also refresh
     /// the diff cache.
-    fn refresh_log_output(&mut self, commander: &mut Commander) {
-        self.log_panel.refresh_log_output(commander);
+    fn refresh_log_output(&mut self) {
+        self.log_panel.refresh_log_output();
         self.update_cache_active_commits();
-        self.sync_head_output(commander);
+        self.sync_head_output();
     }
 
     /// Extract selection from log panel and update change details panel
-    fn sync_head_output(&mut self, commander: &mut Commander) {
+    fn sync_head_output(&mut self) {
         self.head = self.log_panel.head.clone();
-        self.refresh_head_output(commander);
+        self.refresh_head_output();
     }
 
     /// Refesh the diff of the currently selected change
-    fn refresh_head_output(&mut self, commander: &mut Commander) {
+    fn refresh_head_output(&mut self) {
         // If the key matches, then we can use the cached value.
         // This is not entierly true. A reconfiguration of jj could
         // generate different output for some keys. We probably need
@@ -218,7 +225,12 @@ impl<'a> LogTab<'a> {
         let inner_width = self.head_panel.columns() as usize;
         let key = CommitShowKey::new(self.head.clone(), self.diff_format.clone(), inner_width);
         let _new_content = self.commit_show_cache.get_or_insert(&key, || {
-            Self::compute_head_content(commander, inner_width, &self.head, &self.diff_format)
+            Self::compute_head_content(
+                &mut self.commander,
+                inner_width,
+                &self.head,
+                &self.diff_format,
+            )
         });
 
         let content_changed = self.head_key != key;
@@ -321,14 +333,15 @@ impl<'a> LogTab<'a> {
     }
 
     // Execute new command, after self.popup returned
-    fn execute_new(&mut self, commander: &mut Commander) -> Result<Option<ComponentAction>> {
+    fn execute_new(&mut self) -> Result<Option<ComponentAction>> {
         let commit_ids = self.log_panel.extract_and_clear_head_marks();
         if commit_ids.is_empty() {
-            commander.run_new([self.head.commit_id.as_str()])?;
+            self.commander.run_new([self.head.commit_id.as_str()])?;
         } else {
-            commander.run_new(commit_ids.iter().map(CommitId::as_str))?;
+            self.commander
+                .run_new(commit_ids.iter().map(CommitId::as_str))?;
         }
-        self.set_head(commander, commander.get_current_head()?);
+        self.set_head(self.commander.get_current_head()?);
         if self.describe_after_new {
             self.describe_after_new = false;
             let textarea = TextArea::default();
@@ -381,7 +394,7 @@ impl<'a> LogTab<'a> {
     }
 
     // Execute abandon command, after self.popup returned
-    fn execute_abandon(&mut self, commander: &mut Commander) -> Result<Option<ComponentAction>> {
+    fn execute_abandon(&mut self) -> Result<Option<ComponentAction>> {
         // If none marked, mark current head
         if self.log_panel.marked_heads.is_empty() {
             self.log_panel.toggle_head_mark();
@@ -390,15 +403,15 @@ impl<'a> LogTab<'a> {
         let old_selection = self.head.clone();
         let mut selection = self.head.clone();
         while self.log_panel.is_head_marked(&selection) {
-            selection = commander.get_commit_parent(&selection.commit_id)?;
+            selection = self.commander.get_commit_parent(&selection.commit_id)?;
         }
         // Abandon marked commmits
         let commit_id_list = self.log_panel.extract_and_clear_head_marks();
-        commander.run_abandon(&commit_id_list)?;
+        self.commander.run_abandon(&commit_id_list)?;
         // Update selection to latest version, in case abandon triggered a rebase.
-        let new_selection = commander.get_head_latest(&selection)?;
+        let new_selection = self.commander.get_head_latest(&selection)?;
         // Update log panel and diff panel
-        self.set_head(commander, new_selection.clone());
+        self.set_head(new_selection.clone());
         // If selection was moved, tell the application
         if new_selection != old_selection {
             Ok(Some(ComponentAction::ChangeHead(self.head.clone())))
@@ -407,35 +420,34 @@ impl<'a> LogTab<'a> {
         }
     }
 
-    fn handle_event(
-        &mut self,
-        commander: &mut Commander,
-        log_tab_event: LogTabEvent,
-    ) -> Result<ComponentInputResult> {
+    fn handle_event(&mut self, log_tab_event: LogTabEvent) -> Result<ComponentInputResult> {
+        let mut commander = self.commander.clone();
+        let commander = &mut commander;
         match log_tab_event {
             LogTabEvent::ScrollDown
             | LogTabEvent::ScrollUp
             | LogTabEvent::ScrollDownHalf
             | LogTabEvent::ScrollUpHalf
             | LogTabEvent::ToggleHeadMark => {
-                self.log_panel.handle_event(commander, log_tab_event)?;
-                self.sync_head_output(commander);
+                self.log_panel.handle_event(log_tab_event)?;
+                self.sync_head_output();
             }
             LogTabEvent::FocusCurrent => {
-                self.set_head(commander, commander.get_current_head()?);
+                self.set_head(commander.get_current_head()?);
             }
             LogTabEvent::ToggleDiffFormat => {
                 self.diff_format = self.diff_format.get_next(self.config.diff_tool());
-                self.refresh_head_output(commander);
+                self.refresh_head_output();
             }
+
             LogTabEvent::Refresh => {
                 self.mark_cache_as_dirty();
-                self.refresh_log_output(commander);
+                self.refresh_log_output();
             }
 
             LogTabEvent::Duplicate => {
                 let _ = commander.run_duplicate(&self.head.change_id.to_string());
-                self.refresh_log_output(commander);
+                self.refresh_log_output();
             }
 
             LogTabEvent::CreateNew { describe } => {
@@ -567,7 +579,7 @@ impl<'a> LogTab<'a> {
                 return Ok(ComponentInputResult::HandledAction(
                     ComponentAction::SetPopup(Some(Box::new(BookmarkSetPopup::new(
                         self.config.clone(),
-                        commander,
+                        commander.clone(),
                         Some(self.head.change_id.clone()),
                         self.head.commit_id.clone(),
                         self.bookmark_set_popup_tx.clone(),
@@ -651,33 +663,34 @@ impl<'a> LogTab<'a> {
 }
 
 impl Component for LogTab<'_> {
-    fn focus(&mut self, commander: &mut Commander) -> Result<()> {
-        let latest_head = commander.get_head_latest(&self.head)?;
-        self.set_head(commander, latest_head);
+    fn focus(&mut self) -> Result<()> {
+        let latest_head = self.commander.get_head_latest(&self.head)?;
+        self.set_head(latest_head);
         Ok(())
     }
 
-    fn update(&mut self, commander: &mut Commander) -> Result<Option<ComponentAction>> {
+    fn update(&mut self) -> Result<Option<ComponentAction>> {
         // Check for popup action
         if let Ok(res) = self.popup_rx.try_recv()
             && res.1.unwrap_or(false)
         {
             match res.0 {
                 NEW_POPUP_ID => {
-                    return self.execute_new(commander);
+                    return self.execute_new();
                 }
                 EDIT_POPUP_ID => {
-                    commander.run_edit(self.head.commit_id.as_str(), self.edit_ignore_immutable)?;
-                    self.refresh_log_output(commander);
+                    self.commander
+                        .run_edit(self.head.commit_id.as_str(), self.edit_ignore_immutable)?;
+                    self.refresh_log_output();
                     return Ok(Some(ComponentAction::ChangeHead(self.head.clone())));
                 }
                 ABANDON_POPUP_ID => {
-                    return self.execute_abandon(commander);
+                    return self.execute_abandon();
                 }
                 SQUASH_POPUP_ID => {
-                    commander
+                    self.commander
                         .run_squash(self.head.commit_id.as_str(), self.squash_ignore_immutable)?;
-                    self.set_head(commander, commander.get_current_head()?);
+                    self.set_head(self.commander.get_current_head()?);
                     return Ok(Some(ComponentAction::ChangeHead(self.head.clone())));
                 }
                 _ => {}
@@ -685,7 +698,7 @@ impl Component for LogTab<'_> {
         }
 
         if let Ok(true) = self.bookmark_set_popup_rx.try_recv() {
-            self.refresh_log_output(commander);
+            self.refresh_log_output()
         }
 
         Ok(None)
@@ -814,7 +827,8 @@ impl Component for LogTab<'_> {
         Ok(())
     }
 
-    fn input(&mut self, commander: &mut Commander, event: Event) -> Result<ComponentInputResult> {
+    fn input(&mut self, event: Event) -> Result<ComponentInputResult> {
+        let commander = &self.commander;
         if let Some(describe_textarea) = self.describe_textarea.as_mut() {
             if let Event::Key(key) = event {
                 match self.keybinds.match_event(key) {
@@ -824,7 +838,7 @@ impl Component for LogTab<'_> {
                             self.head.commit_id.as_str(),
                             &describe_textarea.lines().join("\n"),
                         )?;
-                        self.set_head(commander, commander.get_head_latest(&self.head)?);
+                        self.set_head(commander.get_head_latest(&self.head)?);
                         self.describe_textarea = None;
                         return Ok(ComponentInputResult::Handled);
                     }
@@ -849,7 +863,7 @@ impl Component for LogTab<'_> {
                         } else {
                             Some(log_revset)
                         };
-                        self.refresh_log_output(commander);
+                        self.refresh_log_output();
                         self.log_revset_textarea = None;
                         return Ok(ComponentInputResult::Handled);
                     }
@@ -865,7 +879,7 @@ impl Component for LogTab<'_> {
         }
 
         if let Some(rebase_popup) = &mut self.rebase_popup {
-            let handled = rebase_popup.handle_input(commander, event.clone());
+            let handled = rebase_popup.handle_input(&mut self.commander, event.clone());
             if handled.is_err() {
                 // Close popup and show error message
                 self.rebase_popup = None;
@@ -913,20 +927,20 @@ impl Component for LogTab<'_> {
                 return Ok(ComponentInputResult::Handled);
             }
 
-            let input_result = self.log_panel.input(commander, event)?;
+            let input_result = self.log_panel.input(event)?;
             if input_result.is_handled() {
-                self.sync_head_output(commander);
+                self.sync_head_output();
                 return Ok(input_result);
             }
 
             let log_tab_event = self.keybinds.match_event(key);
-            return self.handle_event(commander, log_tab_event);
+            return self.handle_event(log_tab_event);
         }
 
         if let Event::Mouse(mouse_event) = event {
-            let input_result = self.log_panel.input(commander, event.clone())?;
+            let input_result = self.log_panel.input(event.clone())?;
             if input_result.is_handled() {
-                self.sync_head_output(commander);
+                self.sync_head_output();
                 return Ok(input_result);
             }
             if self.head_panel.input_mouse(mouse_event) {

--- a/src/ui/message_popup.rs
+++ b/src/ui/message_popup.rs
@@ -14,7 +14,6 @@ use ratatui::widgets::Borders;
 use tui_confirm_dialog::PopupMessage;
 
 use crate::ComponentInputResult;
-use crate::commander::Commander;
 use crate::ui::Component;
 
 pub struct MessagePopup<'a> {
@@ -49,7 +48,7 @@ impl Component for MessagePopup<'_> {
         Ok(())
     }
 
-    fn input(&mut self, _commander: &mut Commander, _event: Event) -> Result<ComponentInputResult> {
+    fn input(&mut self, _event: Event) -> Result<ComponentInputResult> {
         Ok(ComponentInputResult::NotHandled)
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -29,7 +29,6 @@ use tracing::instrument;
 use crate::ComponentInputResult;
 use crate::app::App;
 use crate::app::Tab;
-use crate::commander::Commander;
 use crate::commander::log::Head;
 
 pub enum ComponentAction {
@@ -43,17 +42,17 @@ pub enum ComponentAction {
 
 pub trait Component {
     // Called when switching to tab
-    fn focus(&mut self, _commander: &mut Commander) -> Result<()> {
+    fn focus(&mut self) -> Result<()> {
         Ok(())
     }
 
-    fn update(&mut self, _commander: &mut Commander) -> Result<Option<ComponentAction>> {
+    fn update(&mut self) -> Result<Option<ComponentAction>> {
         Ok(None)
     }
 
     fn draw(&mut self, f: &mut Frame<'_>, area: Rect) -> Result<()>;
 
-    fn input(&mut self, commander: &mut Commander, event: Event) -> Result<ComponentInputResult>;
+    fn input(&mut self, event: Event) -> Result<ComponentInputResult>;
 }
 
 #[instrument(level = "trace", name = "draw", skip(f, app))]

--- a/src/ui/panel/log_panel.rs
+++ b/src/ui/panel/log_panel.rs
@@ -67,6 +67,9 @@ pub struct LogPanel<'a> {
 
     /// Configuration of colours
     config: JjConfig,
+
+    /// Interface to jj
+    commander: Commander,
 }
 
 const LEFT_MARGIN_BLANK: char = ' ';
@@ -105,7 +108,7 @@ fn get_head_index(head: &Head, log_output: &Result<LogOutput, CommandError>) -> 
 }
 
 impl<'a> LogPanel<'a> {
-    pub fn new(commander: &mut Commander) -> Result<Self> {
+    pub fn new(commander: Commander) -> Result<Self> {
         let log_revset = commander.env.default_revset.clone();
         let log_output = commander.get_log(&log_revset);
         let head = commander.get_current_head()?;
@@ -144,6 +147,7 @@ impl<'a> LogPanel<'a> {
             panel_rect: Rect::ZERO,
 
             config: commander.env.jj_config.clone(),
+            commander,
         })
     }
 
@@ -152,8 +156,8 @@ impl<'a> LogPanel<'a> {
     //
 
     /// Run jj log and store output for display
-    pub fn refresh_log_output(&mut self, commander: &mut Commander) {
-        self.log_output = commander.get_log(&self.log_revset);
+    pub fn refresh_log_output(&mut self) {
+        self.log_output = self.commander.get_log(&self.log_revset);
         self.log_output_text = match self.log_output.as_ref() {
             Ok(log_output) => log_output
                 .graph
@@ -268,7 +272,7 @@ impl<'a> LogPanel<'a> {
     /// Move selection relative to the current position.
     /// The scroll is relative to head-index, not line-index.
     /// This will update self.head
-    fn scroll_relative(&mut self, _commander: &mut Commander, scroll: isize) {
+    fn scroll_relative(&mut self, scroll: isize) {
         let log_output = match self.log_output.as_ref() {
             Ok(log_output) => log_output,
             Err(_) => return,
@@ -324,26 +328,19 @@ impl<'a> LogPanel<'a> {
     //  Event handling
     //
 
-    pub fn handle_event(
-        &mut self,
-        commander: &mut Commander,
-        log_tab_event: LogTabEvent,
-    ) -> Result<ComponentInputResult> {
+    pub fn handle_event(&mut self, log_tab_event: LogTabEvent) -> Result<ComponentInputResult> {
         match log_tab_event {
             LogTabEvent::ScrollDown => {
-                self.scroll_relative(commander, 1);
+                self.scroll_relative(1);
             }
             LogTabEvent::ScrollUp => {
-                self.scroll_relative(commander, -1);
+                self.scroll_relative(-1);
             }
             LogTabEvent::ScrollDownHalf => {
-                self.scroll_relative(commander, self.visible_heads() as isize / 2);
+                self.scroll_relative(self.visible_heads() as isize / 2);
             }
             LogTabEvent::ScrollUpHalf => {
-                self.scroll_relative(
-                    commander,
-                    (self.visible_heads() as isize / 2).saturating_neg(),
-                );
+                self.scroll_relative((self.visible_heads() as isize / 2).saturating_neg());
             }
             LogTabEvent::ToggleHeadMark => {
                 self.toggle_head_mark();
@@ -358,11 +355,11 @@ impl<'a> LogPanel<'a> {
 
 impl Component for LogPanel<'_> {
     // Called when switching to tab
-    fn focus(&mut self, _commander: &mut Commander) -> Result<()> {
+    fn focus(&mut self) -> Result<()> {
         Ok(())
     }
 
-    fn update(&mut self, _commander: &mut Commander) -> Result<Option<ComponentAction>> {
+    fn update(&mut self) -> Result<Option<ComponentAction>> {
         Ok(None)
     }
 
@@ -405,7 +402,7 @@ impl Component for LogPanel<'_> {
         Ok(())
     }
 
-    fn input(&mut self, commander: &mut Commander, event: Event) -> Result<ComponentInputResult> {
+    fn input(&mut self, event: Event) -> Result<ComponentInputResult> {
         if let Event::Mouse(mouse_event) = event {
             // Determine if mouse event is inside log-view
             let mouse_pos = Position::new(mouse_event.column, mouse_event.row);
@@ -416,11 +413,11 @@ impl Component for LogPanel<'_> {
             // Execute command dependent on panel and event kind
             match mouse_event.kind {
                 MouseEventKind::ScrollUp => {
-                    self.handle_event(commander, LogTabEvent::ScrollUp)?;
+                    self.handle_event(LogTabEvent::ScrollUp)?;
                     return Ok(ComponentInputResult::Handled);
                 }
                 MouseEventKind::ScrollDown => {
-                    self.handle_event(commander, LogTabEvent::ScrollDown)?;
+                    self.handle_event(LogTabEvent::ScrollDown)?;
                     return Ok(ComponentInputResult::Handled);
                 }
                 MouseEventKind::Up(_) => {

--- a/src/ui/rebase_popup.rs
+++ b/src/ui/rebase_popup.rs
@@ -211,7 +211,7 @@ impl Component for RebasePopup {
         Ok(())
     }
 
-    fn input(&mut self, _commander: &mut Commander, _event: Event) -> Result<ComponentInputResult> {
+    fn input(&mut self, _event: Event) -> Result<ComponentInputResult> {
         unreachable!();
         //return Ok(ComponentInputResult::Handled);
     }


### PR DESCRIPTION
<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
- Fix a leftover of code copied from a tutorial.
- Clean up of internal API - keep a local copy of Commander to keep it out of function arguments.
- Restructure event loop, so the event queue is emptied before the next frame is drawn.

Closes #16 - the UI can now keep up with a mouse wheel scrolling the diff panel at full speed.