### PR TITLE
fix(macos): prevent os error 22 crash by capping event poll timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix Describe dialog width at git recommendation for commit message
 - Log tab diff is cached
 
+### Fixed
+
+- prevent (macos) os error 22 crash by capping event poll timeout
 
 ## [0.7.1] - 2026-01-16
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,7 +152,10 @@ fn main() -> Result<()> {
 }
 
 fn run_app(terminal: &mut DefaultTerminal, app: &mut App, commander: &mut Commander) -> Result<()> {
-    let mut wait_duration = Duration::from_millis(0);
+    // Duration::MAX overflows the timespec struct used by kevent/kqueue on macOS,
+    // causing EINVAL (os error 22). Use a safe large value instead.
+    const FOREVER: Duration = Duration::from_secs(24 * 3600);
+    let mut wait_duration = Duration::ZERO;
     loop {
         if event::poll(wait_duration)? {
             match event::read()? {
@@ -178,7 +181,7 @@ fn run_app(terminal: &mut DefaultTerminal, app: &mut App, commander: &mut Comman
         // Allow popups like the fetch animation to update every 100ms, if there is no popup, just
         // wait for an incoming event
         wait_duration = if app.popup.is_none() {
-            Duration::MAX
+            FOREVER
         } else {
             Duration::from_millis(100)
         };


### PR DESCRIPTION
**Description**
This PR fixes an immediate crash (Error: Invalid argument (os error 22)) that occurs upon startup on macOS.

Closes #62

**Root Cause**
When no popup is active, the event loop at src/main.rs:181 sets the poll timeout to Duration::MAX.

When this Duration is passed down through crossterm → mio to the macOS kevent() syscall, it is converted into a timespec struct. On macOS, tv_sec is an i64. Because Duration::MAX uses u64::MAX for seconds, this conversion causes an integer overflow, resulting in a negative value. The macOS kernel rejects this invalid timespec immediately with EINVAL (os error 22), crashing the application right after the first frame is drawn.

(Note: This is macOS-specific due to its use of kqueue/kevent. Linux uses epoll, which handles the large timeout differently).

**The Fix**
Replaced Duration::MAX with a safely bounded 24-hour constant (FOREVER).
This effectively maintains the intended "wait forever" behavior for the TUI (since any keypress or terminal resize will instantly wake the poll anyway) while keeping the value safely within the bounds of macOS's timespec struct.


```rust
const FOREVER: Duration = Duration::from_secs(24 * 3600);
wait_duration = FOREVER;
```