### PR TITLE
Multiple events per draw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for copying the Change ID/revision of the current log tab entry using y/Y
 - Fix Describe dialog width at git recommendation for commit message
 - Log tab diff is cached
+- Process multiple events per frame
 
 ### Fixed
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,6 @@ use std::fs::OpenOptions;
 use std::fs::canonicalize;
 use std::io::ErrorKind;
 use std::io::{self};
-use std::ops::Sub;
 use std::process::Command;
 use std::time::Duration;
 use std::time::Instant;
@@ -20,10 +19,7 @@ use ratatui::crossterm::event::DisableFocusChange;
 use ratatui::crossterm::event::DisableMouseCapture;
 use ratatui::crossterm::event::EnableFocusChange;
 use ratatui::crossterm::event::EnableMouseCapture;
-use ratatui::crossterm::event::Event;
 use ratatui::crossterm::event::KeyboardEnhancementFlags;
-use ratatui::crossterm::event::MouseEvent;
-use ratatui::crossterm::event::MouseEventKind;
 use ratatui::crossterm::event::PopKeyboardEnhancementFlags;
 use ratatui::crossterm::event::PushKeyboardEnhancementFlags;
 use ratatui::crossterm::event::{self};
@@ -153,60 +149,48 @@ fn main() -> Result<()> {
 }
 
 fn run_app(terminal: &mut DefaultTerminal, app: &mut App, commander: &mut Commander) -> Result<()> {
-    // Duration::MAX overflows the timespec struct used by kevent/kqueue on macOS,
-    // causing EINVAL (os error 22). Use a safe large value instead.
-    const FOREVER: Duration = Duration::from_secs(24 * 3600);
-    let mut wait_duration = Duration::ZERO;
     loop {
-        // Input
-        let should_stop = input_to_app(app, wait_duration, commander)?;
-
-        if should_stop {
-            return Ok(());
-        }
-
         app.update(commander)?;
         terminal.draw(|f| {
             let _ = ui(f, app);
         })?;
 
-        // Allow popups like the fetch animation to update every 100ms, if there is no popup, just
-        // wait for an incoming event
-        wait_duration = if app.popup.is_none() {
-            FOREVER
-        } else {
-            Duration::from_millis(100)
-        };
+        let should_stop = input_to_app(app, commander)?;
+
+        if should_stop {
+            return Ok(());
+        }
     }
 }
 
 /// Let app process all input events in queue before returning
+/// to draw the next frame.
 /// Return true if application should stop
-fn input_to_app(app: &mut App, wait_duration: Duration, commander: &mut Commander) -> Result<bool> {
-    let input_time_out = Instant::now() + wait_duration;
-    let event = loop {
-        let start_of_loop = Instant::now();
-        let remaining_wait_period = input_time_out.sub(start_of_loop);
+fn input_to_app(app: &mut App, commander: &mut Commander) -> Result<bool> {
+    // Duration::MAX overflows the timespec struct used by kevent/kqueue on macOS,
+    // causing EINVAL (os error 22). Use a safe large value instead.
+    const FOREVER: Duration = Duration::from_secs(24 * 3600);
 
-        // Return if no event arrives within the specified period
-        if !event::poll(remaining_wait_period)? {
-            return Ok(false);
-        }
-
-        // Process one event
-        match event::read()? {
-            event::Event::FocusLost => continue,
-            Event::Mouse(MouseEvent {
-                kind: MouseEventKind::Moved,
-                ..
-            }) => continue,
-            event => break event,
-        }
+    // Allow popups like the fetch animation to update every 100ms.
+    let wait_duration = if app.popup.is_some() {
+        Duration::from_millis(100)
+    } else {
+        FOREVER
     };
-
+    // If no event arrives, return and draw next frame.
+    let event_arrived = event::poll(wait_duration)?;
     app.stats.start_time = Instant::now();
-    let should_stop = app.input(event, commander)?;
+    if !event_arrived {
+        return Ok(false);
+    }
 
+    // Handle all pending events in the queue.
+    // Stop if an event requested the app to stop.
+    let mut should_stop: bool = false;
+    while event::poll(Duration::ZERO)? && !should_stop {
+        let event = event::read()?;
+        should_stop = app.input(event, commander)?;
+    }
     Ok(should_stop)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use std::fs::OpenOptions;
 use std::fs::canonicalize;
 use std::io::ErrorKind;
 use std::io::{self};
+use std::ops::Sub;
 use std::process::Command;
 use std::time::Duration;
 use std::time::Instant;
@@ -157,20 +158,11 @@ fn run_app(terminal: &mut DefaultTerminal, app: &mut App, commander: &mut Comman
     const FOREVER: Duration = Duration::from_secs(24 * 3600);
     let mut wait_duration = Duration::ZERO;
     loop {
-        if event::poll(wait_duration)? {
-            match event::read()? {
-                event::Event::FocusLost => continue,
-                Event::Mouse(MouseEvent {
-                    kind: MouseEventKind::Moved,
-                    ..
-                }) => continue,
-                event => {
-                    app.stats.start_time = Instant::now();
-                    if app.input(event, commander)? {
-                        return Ok(());
-                    }
-                }
-            }
+        // Input
+        let should_stop = input_to_app(app, wait_duration, commander)?;
+
+        if should_stop {
+            return Ok(());
         }
 
         app.update(commander)?;
@@ -186,6 +178,36 @@ fn run_app(terminal: &mut DefaultTerminal, app: &mut App, commander: &mut Comman
             Duration::from_millis(100)
         };
     }
+}
+
+/// Let app process all input events in queue before returning
+/// Return true if application should stop
+fn input_to_app(app: &mut App, wait_duration: Duration, commander: &mut Commander) -> Result<bool> {
+    let input_time_out = Instant::now() + wait_duration;
+    let event = loop {
+        let start_of_loop = Instant::now();
+        let remaining_wait_period = input_time_out.sub(start_of_loop);
+
+        // Return if no event arrives within the specified period
+        if !event::poll(remaining_wait_period)? {
+            return Ok(false);
+        }
+
+        // Process one event
+        match event::read()? {
+            event::Event::FocusLost => continue,
+            Event::Mouse(MouseEvent {
+                kind: MouseEventKind::Moved,
+                ..
+            }) => continue,
+            event => break event,
+        }
+    };
+
+    app.stats.start_time = Instant::now();
+    let should_stop = app.input(event, commander)?;
+
+    Ok(should_stop)
 }
 
 fn setup_terminal() -> Result<DefaultTerminal> {


### PR DESCRIPTION
Restructure event loop, so the event queue is emptied before the next frame is drawn.

Closes https://github.com/blazingjj/blazingjj/issues/16 - the UI can now keep up with a mouse wheel scrolling the diff panel at full speed.