### PR TITLE
Add jump to start/end of log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix Describe dialog width at git recommendation for commit message
 - Log tab diff is cached
 - Process multiple events per frame
+- Go to top and bottom of visible log
 
 ### Fixed
 

--- a/src/keybinds/log_tab.rs
+++ b/src/keybinds/log_tab.rs
@@ -26,6 +26,8 @@ pub enum LogTabEvent {
     ScrollUp,
     ScrollDownHalf,
     ScrollUpHalf,
+    ScrollToBottom,
+    ScrollToTop,
 
     FocusCurrent,
     ToggleHeadMark,
@@ -78,6 +80,8 @@ impl Default for LogTabKeybinds {
             LogTabEvent::ScrollUp => "up",
             LogTabEvent::ScrollDownHalf => "shift+j",
             LogTabEvent::ScrollUpHalf => "shift+k",
+            LogTabEvent::ScrollToBottom => "ctrl+end",
+            LogTabEvent::ScrollToTop => "ctrl+home",
             LogTabEvent::FocusCurrent => "@",
             LogTabEvent::ToggleHeadMark => "space",
             // todo: move to DetailsKeybindings

--- a/src/keybinds/mod.rs
+++ b/src/keybinds/mod.rs
@@ -109,6 +109,8 @@ impl FromStr for Shortcut {
                 "right" => key = Some(KeyCode::Right),
                 "up" => key = Some(KeyCode::Up),
                 "down" => key = Some(KeyCode::Down),
+                "home" => key = Some(KeyCode::Home),
+                "end" => key = Some(KeyCode::End),
                 s if s.starts_with('f') && s.chars().count() > 1 => {
                     let s = s.trim_start_matches('f');
                     match s.parse::<u8>() {

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -417,6 +417,8 @@ impl<'a> LogTab<'a> {
             | LogTabEvent::ScrollUp
             | LogTabEvent::ScrollDownHalf
             | LogTabEvent::ScrollUpHalf
+            | LogTabEvent::ScrollToBottom
+            | LogTabEvent::ScrollToTop
             | LogTabEvent::ToggleHeadMark => {
                 self.log_panel.handle_event(commander, log_tab_event)?;
                 self.sync_head_output(commander);

--- a/src/ui/panel/log_panel.rs
+++ b/src/ui/panel/log_panel.rs
@@ -345,6 +345,12 @@ impl<'a> LogPanel<'a> {
                     (self.visible_heads() as isize / 2).saturating_neg(),
                 );
             }
+            LogTabEvent::ScrollToBottom => {
+                self.scroll_relative(commander, isize::MAX);
+            }
+            LogTabEvent::ScrollToTop => {
+                self.scroll_relative(commander, -isize::MAX);
+            }
             LogTabEvent::ToggleHeadMark => {
                 self.toggle_head_mark();
             }


### PR DESCRIPTION
The shortcut ctrl+home and ctrl+end are standard for word procesing to navigate to the top and bottom of a document.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
