### PR TITLE
Fix crossterm version to one that supports the osc52 feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ ansi-to-tui = "8.0.1"
 anyhow = "1.0.100"
 chrono = "0.4.42"
 clap = { version = "4.5.53", features = ["derive", "env"] }
-crossterm = { version = "*", features = ["osc52"] } # Just stick with ratatui's required version, but enable osc52
+crossterm = { version = "0.29.0", features = ["osc52"] }
 insta = { version = "1.45.0", features = ["filters"] }
 itertools = "0.14.0"
 ratatui = { version = "0.30.0", features = [


### PR DESCRIPTION
Ratatui has an optional dependency on crossterm 0.28.0 which doesn't support the osc52 feature. We don't use that feature, and I don't see why crossterm 0.28.0 makes it into our dependency tree, but it breaks `cargo metadata` when using the unversioned dependency on crossterm in Cargo.toml, preventing the publication of a new release.

Fixing the dependency on 0.29.0 resolves this.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
