### PR TITLE
Add drag-to-resize pane divider to all tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Keybinding for jj absorb (`A`)
+- Drag to resize pane divider in all tabs
 
 ## [0.8.0] - 2026-04-19
 

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -30,6 +30,7 @@ use crate::ui::help_popup::HelpPopup;
 use crate::ui::message_popup::MessagePopup;
 use crate::ui::panel::DetailsPanel;
 use crate::ui::panel::TextContent;
+use crate::ui::utils::PaneDivider;
 use crate::ui::utils::centered_rect;
 use crate::ui::utils::centered_rect_line_height;
 use crate::ui::utils::tabs_to_spaces;
@@ -89,6 +90,7 @@ pub struct BookmarksTab<'a> {
     diff_format: DiffFormat,
 
     config: JjConfig,
+    pane_divider: PaneDivider,
 }
 
 fn get_current_bookmark_index(
@@ -151,6 +153,9 @@ impl BookmarksTab<'_> {
 
         let (popup_tx, popup_rx) = std::sync::mpsc::channel();
 
+        let config = get_env().jj_config.clone();
+        let pane_divider = PaneDivider::new(config.layout_percent());
+
         Ok(Self {
             bookmarks_output,
             bookmark,
@@ -179,7 +184,8 @@ impl BookmarksTab<'_> {
 
             diff_format,
 
-            config: get_env().jj_config.clone(),
+            config,
+            pane_divider,
         })
     }
 
@@ -324,13 +330,7 @@ impl Component for BookmarksTab<'_> {
         f: &mut ratatui::prelude::Frame<'_>,
         area: ratatui::prelude::Rect,
     ) -> Result<()> {
-        let chunks = Layout::default()
-            .direction(self.config.layout().into())
-            .constraints([
-                Constraint::Percentage(self.config.layout_percent()),
-                Constraint::Percentage(100 - self.config.layout_percent()),
-            ])
-            .split(area);
+        let chunks = self.pane_divider.split(area, self.config.layout());
 
         // Draw bookmarks
         {
@@ -982,6 +982,9 @@ impl Component for BookmarksTab<'_> {
         }
 
         if let Event::Mouse(mouse) = event {
+            if self.pane_divider.handle_mouse(mouse, self.config.layout()) {
+                return Ok(ComponentInputResult::Handled);
+            }
             if self.bookmark_panel.input_mouse(mouse) {
                 return Ok(ComponentInputResult::Handled);
             }

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -24,6 +24,7 @@ use crate::ui::help_popup::HelpPopup;
 use crate::ui::message_popup::MessagePopup;
 use crate::ui::panel::DetailsPanel;
 use crate::ui::panel::TextContent;
+use crate::ui::utils::PaneDivider;
 use crate::ui::utils::tabs_to_spaces;
 
 /// Files tab. Shows files in selected change in main panel and selected file diff in details panel
@@ -42,6 +43,7 @@ pub struct FilesTab {
     diff_format: DiffFormat,
 
     config: JjConfig,
+    pane_divider: PaneDivider,
 }
 
 fn get_current_file_index(
@@ -88,6 +90,9 @@ impl FilesTab {
             files_output.as_ref(),
         ));
 
+        let config = get_env().jj_config.clone();
+        let pane_divider = PaneDivider::new(config.layout_percent());
+
         Ok(Self {
             head,
             is_current_head,
@@ -103,7 +108,8 @@ impl FilesTab {
             diff_format,
             diff_panel: DetailsPanel::new(),
 
-            config: get_env().jj_config.clone(),
+            config,
+            pane_divider,
         })
     }
 
@@ -201,13 +207,7 @@ impl Component for FilesTab {
         f: &mut ratatui::prelude::Frame<'_>,
         area: ratatui::prelude::Rect,
     ) -> Result<()> {
-        let chunks = Layout::default()
-            .direction(self.config.layout().into())
-            .constraints([
-                Constraint::Percentage(self.config.layout_percent()),
-                Constraint::Percentage(100 - self.config.layout_percent()),
-            ])
-            .split(area);
+        let chunks = self.pane_divider.split(area, self.config.layout());
 
         // Draw files
         {
@@ -416,6 +416,9 @@ impl Component for FilesTab {
         }
 
         if let Event::Mouse(mouse) = event {
+            if self.pane_divider.handle_mouse(mouse, self.config.layout()) {
+                return Ok(ComponentInputResult::Handled);
+            }
             if self.diff_panel.input_mouse(mouse) {
                 return Ok(ComponentInputResult::Handled);
             }

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -8,7 +8,6 @@ use ratatui::crossterm::clipboard::CopyToClipboard;
 use ratatui::crossterm::event::Event;
 use ratatui::crossterm::event::KeyEventKind;
 use ratatui::crossterm::execute;
-use ratatui::layout::Rect;
 use ratatui::prelude::*;
 use ratatui::widgets::*;
 use ratatui_textarea::CursorMove;
@@ -41,6 +40,7 @@ use crate::ui::panel::DetailsPanel;
 use crate::ui::panel::LargeStringContent;
 use crate::ui::panel::LogPanel;
 use crate::ui::rebase_popup::RebasePopup;
+use crate::ui::utils::PaneDivider;
 use crate::ui::utils::centered_rect_fixed;
 use crate::ui::utils::centered_rect_line_height;
 use crate::ui::utils::tabs_to_spaces;
@@ -71,9 +71,6 @@ pub struct LogTab<'a> {
     /// so if these differ, we need to update `self.head`
     head: Head,
 
-    // Location of panels on screen. [0] = log, [1] = details
-    panel_rect: [Rect; 2],
-
     diff_format: DiffFormat,
 
     popup: ConfirmDialogState,
@@ -93,6 +90,7 @@ pub struct LogTab<'a> {
     edit_ignore_immutable: bool,
 
     config: JjConfig,
+    pane_divider: PaneDivider,
     keybinds: LogTabKeybinds,
 }
 
@@ -151,6 +149,9 @@ impl<'a> LogTab<'a> {
             keybinds.extend_from_config(&new_keybinds);
         }
 
+        let config = get_env().jj_config.clone();
+        let pane_divider = PaneDivider::new(config.layout_percent());
+
         Ok(Self {
             log_revset_textarea: None,
 
@@ -161,8 +162,6 @@ impl<'a> LogTab<'a> {
             head_key,
 
             commit_show_cache,
-
-            panel_rect: [Rect::ZERO, Rect::ZERO],
 
             diff_format,
 
@@ -182,7 +181,8 @@ impl<'a> LogTab<'a> {
 
             edit_ignore_immutable: false,
 
-            config: get_env().jj_config.clone(),
+            config,
+            pane_divider,
             keybinds,
         })
     }
@@ -698,14 +698,7 @@ impl Component for LogTab<'_> {
         f: &mut ratatui::prelude::Frame<'_>,
         area: ratatui::prelude::Rect,
     ) -> Result<()> {
-        let chunks = Layout::default()
-            .direction(self.config.layout().into())
-            .constraints([
-                Constraint::Percentage(self.config.layout_percent()),
-                Constraint::Percentage(100 - self.config.layout_percent()),
-            ])
-            .split(area);
-        self.panel_rect = [chunks[0], chunks[1]];
+        let chunks = self.pane_divider.split(area, self.config.layout());
 
         // Draw log
         self.log_panel.draw(f, chunks[0])?;
@@ -926,6 +919,12 @@ impl Component for LogTab<'_> {
         }
 
         if let Event::Mouse(mouse_event) = event {
+            if self
+                .pane_divider
+                .handle_mouse(mouse_event, self.config.layout())
+            {
+                return Ok(ComponentInputResult::Handled);
+            }
             let input_result = self.log_panel.input(event.clone())?;
             if input_result.is_handled() {
                 self.sync_head_output();

--- a/src/ui/utils.rs
+++ b/src/ui/utils.rs
@@ -1,9 +1,123 @@
 mod large_string;
 pub use large_string::LargeString;
+use ratatui::crossterm::event::MouseButton;
+use ratatui::crossterm::event::MouseEvent;
+use ratatui::crossterm::event::MouseEventKind;
 use ratatui::layout::Constraint;
 use ratatui::layout::Direction;
 use ratatui::layout::Layout;
 use ratatui::layout::Rect;
+
+use crate::env::JJLayout;
+
+/// Tracks the split position between two panes and handles drag-to-resize mouse events.
+pub struct PaneDivider {
+    init_percent: u16,
+    size: Option<u16>,
+    dragging: bool,
+    rects: [Rect; 2],
+}
+
+impl PaneDivider {
+    pub fn new(percent: u16) -> Self {
+        Self {
+            init_percent: percent.min(100),
+            size: None,
+            dragging: false,
+            rects: [Rect::ZERO, Rect::ZERO],
+        }
+    }
+
+    /// Split `area` into two panes at the current divider position and remember
+    /// the resulting rects for hit-testing in `handle_mouse`.
+    pub fn split(&mut self, area: Rect, layout: JJLayout) -> [Rect; 2] {
+        let total = match layout {
+            JJLayout::Horizontal => area.width,
+            JJLayout::Vertical => area.height,
+        };
+        let size = match self.size {
+            None => {
+                let s = ((total as u32 * self.init_percent as u32) / 100) as u16;
+                self.size = Some(s);
+                s
+            }
+            Some(s) => s,
+        };
+        let size = size.min(total);
+
+        let chunks = Layout::default()
+            .direction(layout.into())
+            .constraints([Constraint::Length(size), Constraint::Fill(1)])
+            .split(area);
+        self.rects = [chunks[0], chunks[1]];
+        self.rects
+    }
+
+    /// Handle a mouse event. Returns true if the event was consumed.
+    pub fn handle_mouse(&mut self, mouse: MouseEvent, layout: JJLayout) -> bool {
+        match mouse.kind {
+            MouseEventKind::Down(MouseButton::Left) => {
+                self.dragging = false;
+                if self.on_border(mouse.column, mouse.row, layout) {
+                    self.dragging = true;
+                    self.update_size(mouse.column, mouse.row, layout);
+                    true
+                } else {
+                    false
+                }
+            }
+            MouseEventKind::Drag(MouseButton::Left) if self.dragging => {
+                self.update_size(mouse.column, mouse.row, layout);
+                true
+            }
+            MouseEventKind::Up(MouseButton::Left) if self.dragging => {
+                self.dragging = false;
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn on_border(&self, col: u16, row: u16, layout: JJLayout) -> bool {
+        let [r0, r1] = self.rects;
+        match layout {
+            JJLayout::Horizontal => {
+                let in_row = row >= r0.top() && row < r0.bottom();
+                // Right border of r0 and left border of r1 are adjacent columns.
+                let on_col = col == r0.right().saturating_sub(1) || col == r1.left();
+                in_row && on_col
+            }
+            JJLayout::Vertical => {
+                let in_col = col >= r0.left() && col < r0.right();
+                let on_row = row == r0.bottom().saturating_sub(1) || row == r1.top();
+                in_col && on_row
+            }
+        }
+    }
+
+    fn update_size(&mut self, col: u16, row: u16, layout: JJLayout) {
+        let [r0, r1] = self.rects;
+        let (pos, total) = match layout {
+            JJLayout::Horizontal => (
+                col.saturating_sub(r0.left()),
+                r1.right().saturating_sub(r0.left()),
+            ),
+            JJLayout::Vertical => (
+                row.saturating_sub(r0.top()),
+                r1.bottom().saturating_sub(r0.top()),
+            ),
+        };
+        // pos is a 0-based cell index, so it tops out at total-1; snap to
+        // total when the mouse reaches the far edge so the first pane can
+        // expand to full size. Enforce a minimum of 1 so the pane stays visible.
+        let size = if pos >= total.saturating_sub(1) {
+            total
+        } else {
+            pos.max(1)
+        };
+        self.size = Some(size);
+    }
+}
 
 pub fn centered_rect(r: Rect, percent_x: u16, percent_y: u16) -> Rect {
     let popup_layout = Layout::default()


### PR DESCRIPTION
Each tab uses a fixed layout_percent from config with no way for the user to adjust the split at runtime. PaneDivider tracks the position and handles mouse drag events so the user can resize panes interactively.
