### PR TITLE
Disallow merge commits in PRs

### DIFF
--- a/.github/workflows/block-merge-commits.yaml
+++ b/.github/workflows/block-merge-commits.yaml
@@ -1,0 +1,21 @@
+---
+
+name: Block merge commits in PRs
+
+'on':
+  pull_request:
+
+permissions:
+  pull-requests: read
+
+jobs:
+  merge-commit-check:
+    name: Block Merge Commits
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Block Merge Commits
+        uses: Morishiri/block-merge-commits-action@v1.0.1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Merges should only happen for PRs, there should be no criss-cross history.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
