### PR TITLE
Squash into parent when trying to squash into self

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Command popup output now preserves ANSI color
 - Drag to resize pane divider in all tabs
 
+### Changed
+
+- Pressing `s` on the working copy now offers to squash into the parent (when there is exactly one)
+
 ## [0.8.0] - 2026-04-19
 
 ### Added

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -85,6 +85,7 @@ pub struct LogTab<'a> {
     rebase_popup: Option<RebasePopup>,
 
     squash_ignore_immutable: bool,
+    squash_target: Option<Head>,
 
     edit_ignore_immutable: bool,
 
@@ -173,6 +174,7 @@ impl<'a> LogTab<'a> {
             rebase_popup: None,
 
             squash_ignore_immutable: false,
+            squash_target: None,
 
             edit_ignore_immutable: false,
 
@@ -439,15 +441,28 @@ impl<'a> LogTab<'a> {
                 ));
             }
             LogTabEvent::Squash { ignore_immutable } => {
-                if self.head.change_id == new_commander().get_current_head()?.change_id {
-                    return Ok(ComponentInputResult::HandledAction(
-                        ComponentAction::SetPopup(Some(Box::new(MessagePopup::new(
-                            "Squash",
-                            "Cannot squash onto current change",
-                        )))),
-                    ));
-                }
-                if self.head.immutable && !ignore_immutable {
+                let current_head = new_commander().get_current_head()?;
+                let target = if self.head.change_id == current_head.change_id {
+                    match new_commander().get_commit_parent(&current_head.commit_id) {
+                        Ok(parent) => {
+                            self.squash_target = Some(parent.clone());
+                            parent
+                        }
+                        Err(_) => {
+                            return Ok(ComponentInputResult::HandledAction(
+                                ComponentAction::SetPopup(Some(Box::new(MessagePopup::new(
+                                    "Squash",
+                                    "Cannot squash onto current change",
+                                )))),
+                            ));
+                        }
+                    }
+                } else {
+                    self.squash_target = None;
+                    self.head.clone()
+                };
+
+                if target.immutable && !ignore_immutable {
                     return Ok(ComponentInputResult::HandledAction(
                         ComponentAction::SetPopup(Some(Box::new(MessagePopup::new(
                             "Squash",
@@ -456,9 +471,14 @@ impl<'a> LogTab<'a> {
                     ));
                 }
 
+                let description = if self.squash_target.is_some() {
+                    "Are you sure you want to squash @ into its parent?"
+                } else {
+                    "Are you sure you want to squash @ into this change?"
+                };
                 let mut lines = vec![
-                    Line::from("Are you sure you want to squash @ into this change?"),
-                    Line::from(format!("Squash into {}", self.head.change_id.as_str())),
+                    Line::from(description),
+                    Line::from(format!("Squash into {}", target.change_id.as_str())),
                 ];
                 if ignore_immutable {
                     lines.push(Line::from("This change is immutable."));
@@ -658,8 +678,12 @@ impl Component for LogTab<'_> {
                     return self.execute_abandon();
                 }
                 SQUASH_POPUP_ID => {
-                    new_commander()
-                        .run_squash(self.head.commit_id.as_str(), self.squash_ignore_immutable)?;
+                    let target_id = self
+                        .squash_target
+                        .take()
+                        .unwrap_or_else(|| self.head.clone())
+                        .commit_id;
+                    new_commander().run_squash(target_id.as_str(), self.squash_ignore_immutable)?;
                     self.set_head(new_commander().get_current_head()?);
                     return Ok(Some(ComponentAction::ChangeHead(self.head.clone())));
                 }


### PR DESCRIPTION
When squash is triggered with the working copy selected and it has exactly one parent, offer to squash into that parent rather than showing an error. The confirm dialog explicitly says "into its parent" so the behaviour is not surprising. Merge commits (multiple parents) still show the original error.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
