### PR TITLE
Update tests for jj 0.42

### DIFF
--- a/src/commander/snapshots/blazingjj__commander__files__tests__get_file_diff-3.snap
+++ b/src/commander/snapshots/blazingjj__commander__files__tests__get_file_diff-3.snap
@@ -1,7 +1,7 @@
 ---
 source: src/commander/files.rs
-expression: "test_repo.commander.get_file_diff(&head, &file, &DiffFormat::ColorWords)?"
+expression: "test_repo.commander.get_file_diff(&head, &file, &DiffFormat::ColorWords,\ntrue)?"
 ---
 Some(
-    "Modified regular file README:\n   1    1: AAABBB\n",
+    "Modified regular file README:\n   1     : AAA\n        1: BBB\n",
 )


### PR DESCRIPTION
jj no longer produces the inline color-words format when color is disabled (because it's just a mix of old and new text without any means to differentiate the two). Update the test snapshot to the new format.