### PR TITLE
Fix describing a commit with a message starting with a dash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Pressing `s` on the working copy now offers to squash into the parent (when there is exactly one)
 
+### Fixed
+
+- Describing a commit with a message starting with a dash no longer fails
+
 ## [0.8.0] - 2026-04-19
 
 ### Added

--- a/src/commander/bookmarks.rs
+++ b/src/commander/bookmarks.rs
@@ -100,8 +100,8 @@ impl Commander {
         }
         args.push("--sort");
         args.push("committer-date-");
-        let bookmarks_colored = self.execute_jj_command(
-            [
+        let bookmarks_colored = self
+            .jj([
                 vec![
                     "bookmark",
                     "list",
@@ -116,26 +116,22 @@ impl Commander {
                 ],
                 args.clone(),
             ]
-            .concat(),
-            true,
-            true,
-        )?;
+            .concat())
+            .color()
+            .run()?;
 
         let bookmarks: Vec<BookmarkLine> = self
-            .execute_jj_command(
-                [
-                    vec![
-                        "bookmark",
-                        "list",
-                        "-T",
-                        &format!(r#"{BRANCH_TEMPLATE} ++ "\n""#),
-                    ],
-                    args,
-                ]
-                .concat(),
-                false,
-                true,
-            )?
+            .jj([
+                vec![
+                    "bookmark",
+                    "list",
+                    "-T",
+                    &format!(r#"{BRANCH_TEMPLATE} ++ "\n""#),
+                ],
+                args,
+            ]
+            .concat())
+            .run()?
             .lines()
             .zip(bookmarks_colored.lines())
             .map(|(line, line_colored)| match parse_bookmark(line) {
@@ -163,7 +159,8 @@ impl Commander {
         }
 
         let bookmarks: Vec<Bookmark> = self
-            .execute_jj_command(args, false, true)?
+            .jj(args)
+            .run()?
             .lines()
             .filter_map(parse_bookmark)
             .sorted_by(|a, b| b.timestamp.cmp(&a.timestamp))
@@ -188,23 +185,21 @@ impl Commander {
             args.push("--ignore-working-copy");
         }
 
-        Ok(self.execute_jj_command(args, true, true)?.remove_end_line())
+        Ok(self.jj(args).color().run()?.remove_end_line())
     }
 
     #[instrument(level = "trace", skip(self))]
     pub fn generate_bookmark_name(&self, change_id: &ChangeId) -> Result<String, CommandError> {
-        self.execute_jj_command(
-            [
-                "show",
-                "--no-patch",
-                "--template",
-                self.env.jj_config.bookmark_template().as_str(),
-                "-r",
-                change_id.as_str(),
-            ],
-            false,
-            false,
-        )
+        self.jj([
+            "show",
+            "--no-patch",
+            "--template",
+            self.env.jj_config.bookmark_template().as_str(),
+            "-r",
+            change_id.as_str(),
+        ])
+        .verbose()
+        .run()
     }
 }
 

--- a/src/commander/files.rs
+++ b/src/commander/files.rs
@@ -70,11 +70,8 @@ impl Commander {
     #[instrument(level = "trace", skip(self))]
     pub fn get_files(&self, head: &Head) -> Result<Vec<File>, CommandError> {
         Ok(self
-            .execute_jj_command(
-                vec!["diff", "-r", head.commit_id.as_str(), "--summary"],
-                false,
-                true,
-            )?
+            .jj(["diff", "-r", head.commit_id.as_str(), "--summary"])
+            .run()?
             .lines()
             .map(|line| {
                 let captured = FILES_REGEX.captures(line);
@@ -100,11 +97,9 @@ impl Commander {
     /// Maps to `jj diff --summary -r <revision>`
     #[instrument(level = "trace", skip(self))]
     pub fn get_conflicts(&self, commit_id: &CommitId) -> Result<Vec<Conflict>> {
-        let output = self.execute_jj_command(
-            vec!["resolve", "--list", "-r", commit_id.as_str()],
-            false,
-            true,
-        );
+        let output = self
+            .jj(["resolve", "--list", "-r", commit_id.as_str()])
+            .run();
 
         match output {
             Ok(output) => Ok(output
@@ -160,7 +155,7 @@ impl Commander {
             args.push("--ignore-working-copy");
         }
 
-        self.execute_jj_command(args, true, true).map(Some)
+        self.jj(args).color().run().map(Some)
     }
 
     #[instrument(level = "trace", skip(self))]
@@ -181,11 +176,7 @@ impl Commander {
         };
 
         let fileset = Self::get_file_revset(path);
-        Ok(Some(self.execute_jj_command(
-            vec!["file", "untrack", &fileset],
-            false,
-            true,
-        )?))
+        Ok(Some(self.jj(["file", "untrack", &fileset]).run()?))
     }
 
     #[instrument(level = "trace", skip(self))]
@@ -206,11 +197,7 @@ impl Commander {
         };
 
         let fileset = Self::get_file_revset(path);
-        Ok(Some(self.execute_jj_command(
-            vec!["restore", &fileset],
-            false,
-            true,
-        )?))
+        Ok(Some(self.jj(["restore", &fileset]).run()?))
     }
 
     fn get_file_revset(path: &str) -> String {
@@ -259,7 +246,7 @@ mod tests {
         }
 
         // Commit
-        test_repo.commander.execute_void_jj_command(vec!["new"])?;
+        test_repo.commander.jj(["new"]).run_void()?;
 
         // Modify file
         {
@@ -327,7 +314,7 @@ mod tests {
         }
 
         // Commit
-        test_repo.commander.execute_void_jj_command(vec!["new"])?;
+        test_repo.commander.jj(["new"]).run_void()?;
 
         // Modify file
         {
@@ -354,7 +341,7 @@ mod tests {
         }
 
         // Commit
-        test_repo.commander.execute_void_jj_command(vec!["new"])?;
+        test_repo.commander.jj(["new"]).run_void()?;
 
         // Rename file
         {
@@ -384,7 +371,7 @@ mod tests {
         }
 
         // Commit
-        test_repo.commander.execute_void_jj_command(vec!["new"])?;
+        test_repo.commander.jj(["new"]).run_void()?;
 
         // Delete file
         {
@@ -430,13 +417,16 @@ mod tests {
         let head2 = test_repo.commander.get_current_head()?;
         fs::write(&file_path, b"BBB")?;
 
-        test_repo.commander.execute_void_jj_command([
-            "rebase",
-            "-s",
-            head2.change_id.as_str(),
-            "-d",
-            head1.change_id.as_str(),
-        ])?;
+        test_repo
+            .commander
+            .jj([
+                "rebase",
+                "-s",
+                head2.change_id.as_str(),
+                "-d",
+                head1.change_id.as_str(),
+            ])
+            .run_void()?;
 
         let head = test_repo.commander.get_current_head()?;
 

--- a/src/commander/jj.rs
+++ b/src/commander/jj.rs
@@ -19,13 +19,13 @@ impl Commander {
     #[instrument(level = "trace", skip(self, revisions))]
     pub fn run_new<'a, T: IntoIterator<Item = &'a str>>(&self, revisions: T) -> Result<()> {
         let args = ["new"].into_iter().chain::<T>(revisions);
-        self.execute_void_jj_command(args)
-            .context("Failed executing jj new")
+        self.jj(args).run_void().context("Failed executing jj new")
     }
 
     /// Duplicate a change. Maps to `jj duplicate`
     pub fn run_duplicate(&self, revision: &str) -> Result<()> {
-        self.execute_void_jj_command(vec!["duplicate", revision])
+        self.jj(["duplicate", revision])
+            .run_void()
             .context("Failed executing jj duplicate")
     }
 
@@ -37,8 +37,7 @@ impl Commander {
             args.push("--ignore-immutable");
         }
 
-        self.execute_void_jj_command(args)
-            .context("Failed executing jj edit")
+        self.jj(args).run_void().context("Failed executing jj edit")
     }
 
     /// Abandon change. Maps to `jj abandon <revision>`
@@ -47,52 +46,58 @@ impl Commander {
         let args = ["abandon"]
             .into_iter()
             .chain(commit_ids.iter().map(CommitId::as_str));
-        self.execute_void_jj_command(args)
+        self.jj(args)
+            .run_void()
             .context("Failed executing jj abandon")
     }
 
     /// Describe change. Maps to `jj describe <revision> -m <message>`
     #[instrument(level = "trace", skip(self))]
     pub fn run_describe(&self, revision: &str, message: &str) -> Result<()> {
-        self.execute_void_jj_command(vec!["describe", revision, "-m", message])
+        self.jj(["describe", revision, "-m", message])
+            .run_void()
             .context("Failed executing jj describe")
     }
 
     /// Rebase changes. Maps to `jj rebase -s <rev> -d <rev>` or similar
     #[instrument(level = "trace", skip(self))]
     pub fn run_rebase(
-        &mut self,
+        &self,
         src_mode: &str,
         src_rev: &str,
         tgt_mode: &str,
         tgt_rev: &str,
     ) -> Result<()> {
-        Ok(self.execute_void_jj_command(vec!["rebase", src_mode, src_rev, tgt_mode, tgt_rev])?)
+        Ok(self
+            .jj(["rebase", src_mode, src_rev, tgt_mode, tgt_rev])
+            .run_void()?)
     }
 
     /// Squash changes. Maps to `jj squash -u --into <revision>`
     #[instrument(level = "trace", skip(self))]
-    pub fn run_squash(&mut self, revision: &str, ignore_immutable: bool) -> Result<()> {
+    pub fn run_squash(&self, revision: &str, ignore_immutable: bool) -> Result<()> {
         let mut args = vec!["squash", "-u", "--into", revision];
         if ignore_immutable {
             args.push("--ignore-immutable");
         }
 
-        self.execute_void_jj_command(args)
+        self.jj(args)
+            .run_void()
             .context("Failed executing jj squash")
     }
 
     /// Absorb a change's diff into its mutable ancestors. Maps to `jj absorb --from <revision>`
     #[instrument(level = "trace", skip(self))]
-    pub fn run_absorb(&mut self, revision: &str) -> Result<()> {
-        self.execute_void_jj_command(vec!["absorb", "--from", revision])
+    pub fn run_absorb(&self, revision: &str) -> Result<()> {
+        self.jj(["absorb", "--from", revision])
+            .run_void()
             .context("Failed executing jj absorb")
     }
 
     /// Create bookmark. Maps to `jj bookmark create <name>`
     #[instrument(level = "trace", skip(self))]
     pub fn create_bookmark(&self, name: &str) -> Result<Bookmark, CommandError> {
-        self.execute_void_jj_command(vec!["bookmark", "create", name])?;
+        self.jj(["bookmark", "create", name]).run_void()?;
         // jj only creates local bookmarks
         Ok(Bookmark {
             name: name.to_owned(),
@@ -109,7 +114,8 @@ impl Commander {
         name: &str,
         commit_id: &CommitId,
     ) -> Result<Bookmark, CommandError> {
-        self.execute_void_jj_command(vec!["bookmark", "create", name, "-r", commit_id.as_str()])?;
+        self.jj(["bookmark", "create", name, "-r", commit_id.as_str()])
+            .run_void()?;
         // jj only creates local bookmarks
         Ok(Bookmark {
             name: name.to_owned(),
@@ -127,7 +133,7 @@ impl Commander {
         commit_id: &CommitId,
     ) -> Result<(), CommandError> {
         // TODO: Maybe don't do --allow-backwards by default?
-        self.execute_void_jj_command(vec![
+        self.jj([
             "bookmark",
             "set",
             name,
@@ -135,36 +141,39 @@ impl Commander {
             commit_id.as_str(),
             "--allow-backwards",
         ])
+        .run_void()
     }
 
     /// Rename bookmark. Maps to `jj bookmark rename <old> <new>`
     #[instrument(level = "trace", skip(self))]
     pub fn rename_bookmark(&self, old: &str, new: &str) -> Result<(), CommandError> {
-        self.execute_void_jj_command(vec!["bookmark", "rename", old, new])
+        self.jj(["bookmark", "rename", old, new]).run_void()
     }
 
     /// Delete bookmark. Maps to `jj bookmark delete <name>`
     #[instrument(level = "trace", skip(self))]
     pub fn delete_bookmark(&self, name: &str) -> Result<(), CommandError> {
-        self.execute_void_jj_command(vec!["bookmark", "delete", name])
+        self.jj(["bookmark", "delete", name]).run_void()
     }
 
     /// Forget bookmark. Maps to `jj bookmark forget <name>`
     #[instrument(level = "trace", skip(self))]
     pub fn forget_bookmark(&self, name: &str) -> Result<(), CommandError> {
-        self.execute_void_jj_command(vec!["bookmark", "forget", name])
+        self.jj(["bookmark", "forget", name]).run_void()
     }
 
     /// Track bookmark. Maps to `jj bookmark track <bookmark>@<remote>`
     #[instrument(level = "trace", skip(self))]
     pub fn track_bookmark(&self, bookmark: &Bookmark) -> Result<(), CommandError> {
-        self.execute_void_jj_command(vec!["bookmark", "track", &bookmark.to_string()])
+        self.jj(["bookmark", "track", &bookmark.to_string()])
+            .run_void()
     }
 
     /// Untrack bookmark. Maps to `jj bookmark untrack <bookmark>@<remote>`
     #[instrument(level = "trace", skip(self))]
     pub fn untrack_bookmark(&self, bookmark: &Bookmark) -> Result<(), CommandError> {
-        self.execute_void_jj_command(vec!["bookmark", "untrack", &bookmark.to_string()])
+        self.jj(["bookmark", "untrack", &bookmark.to_string()])
+            .run_void()
     }
 
     /// Git push. Maps to `jj git push`
@@ -186,7 +195,7 @@ impl Commander {
             args.push(commit_id.as_str());
         }
 
-        self.execute_jj_command(args, true, true)
+        self.jj(args).color().run()
     }
 
     /// Git fetch. Maps to `jj git fetch`
@@ -197,7 +206,7 @@ impl Commander {
             args.push("--all-remotes");
         }
 
-        self.execute_jj_command(args, true, true)
+        self.jj(args).color().run()
     }
 }
 
@@ -295,8 +304,9 @@ mod tests {
             .commander
             .create_bookmark_commit("test", &head.commit_id)?;
 
-        let log = test_repo.commander.execute_jj_command(
-            [
+        let log = test_repo
+            .commander
+            .jj([
                 "log",
                 "--limit",
                 "1",
@@ -305,10 +315,8 @@ mod tests {
                 "commit_id",
                 "-r",
                 &bookmark.name,
-            ],
-            false,
-            true,
-        )?;
+            ])
+            .run()?;
 
         assert_eq!(head.commit_id.to_string(), log);
 
@@ -327,8 +335,9 @@ mod tests {
 
         let bookmark = test_repo.commander.create_bookmark("test")?;
 
-        let log = test_repo.commander.execute_jj_command(
-            [
+        let log = test_repo
+            .commander
+            .jj([
                 "log",
                 "--limit",
                 "1",
@@ -337,10 +346,8 @@ mod tests {
                 "commit_id",
                 "-r",
                 &bookmark.name,
-            ],
-            false,
-            true,
-        )?;
+            ])
+            .run()?;
 
         assert_eq!(new_head.commit_id.to_string(), log);
 
@@ -348,8 +355,9 @@ mod tests {
             .commander
             .set_bookmark_commit(&bookmark.name, &old_head.commit_id)?;
 
-        let log = test_repo.commander.execute_jj_command(
-            [
+        let log = test_repo
+            .commander
+            .jj([
                 "log",
                 "--limit",
                 "1",
@@ -358,10 +366,8 @@ mod tests {
                 "commit_id",
                 "-r",
                 &bookmark.name,
-            ],
-            false,
-            true,
-        )?;
+            ])
+            .run()?;
 
         assert_eq!(old_head.commit_id.to_string(), log);
 

--- a/src/commander/jj.rs
+++ b/src/commander/jj.rs
@@ -51,10 +51,14 @@ impl Commander {
             .context("Failed executing jj abandon")
     }
 
-    /// Describe change. Maps to `jj describe <revision> -m <message>`
+    /// Describe change. Maps to `jj describe <revision> --stdin`
+    ///
+    /// The message is passed on stdin rather than via `-m`, since jj would
+    /// otherwise mistake a message starting with a dash for a flag.
     #[instrument(level = "trace", skip(self))]
     pub fn run_describe(&self, revision: &str, message: &str) -> Result<()> {
-        self.jj(["describe", revision, "-m", message])
+        self.jj(["describe", revision, "--stdin"])
+            .stdin(message)
             .run_void()
             .context("Failed executing jj describe")
     }
@@ -267,6 +271,22 @@ mod tests {
 
         let head = test_repo.commander.get_current_head()?.commit_id;
         assert_eq!(test_repo.commander.get_commit_description(&head)?, "AAA");
+
+        Ok(())
+    }
+
+    #[test]
+    fn run_describe_leading_dash() -> Result<()> {
+        let test_repo = TestRepo::new()?;
+
+        // A message starting with a dash must not be mistaken for a flag.
+        let head = test_repo.commander.get_current_head()?;
+        test_repo
+            .commander
+            .run_describe(head.commit_id.as_str(), "-AAA")?;
+
+        let head = test_repo.commander.get_current_head()?.commit_id;
+        assert_eq!(test_repo.commander.get_commit_description(&head)?, "-AAA");
 
         Ok(())
     }

--- a/src/commander/log.rs
+++ b/src/commander/log.rs
@@ -91,28 +91,22 @@ fn parse_head(text: &str) -> Result<Head> {
 
 impl Commander {
     fn execute_jj_log(&self, revset: &str, template: &str) -> Result<String, CommandError> {
-        self.execute_jj_command(
-            ["log", "--no-graph", "--template", template, "-r", revset],
-            false,
-            true,
-        )
+        self.jj(["log", "--no-graph", "--template", template, "-r", revset])
+            .run()
     }
 
     fn execute_jj_log_one(&self, revset: &str, template: &str) -> Result<String, CommandError> {
-        self.execute_jj_command(
-            [
-                "log",
-                "--no-graph",
-                "--template",
-                template,
-                "-r",
-                revset,
-                "--limit",
-                "1",
-            ],
-            false,
-            true,
-        )
+        self.jj([
+            "log",
+            "--no-graph",
+            "--template",
+            template,
+            "-r",
+            revset,
+            "--limit",
+            "1",
+        ])
+        .run()
     }
 
     /// Get log. Returns human readable log and mapping to log line to head.
@@ -127,15 +121,14 @@ impl Commander {
         }
 
         // Force builtin_log_compact which uses 2 lines per change
-        let graph = self.execute_jj_command(
-            [
+        let graph = self
+            .jj([
                 vec!["log", "--template", "builtin_log_compact"],
                 args.clone(),
             ]
-            .concat(),
-            true,
-            true,
-        )?;
+            .concat())
+            .color()
+            .run()?;
 
         // Extract the log one more time, but this time use a template
         // where each line begins with Head information. Since jj has
@@ -143,22 +136,17 @@ impl Commander {
         // The number of lines in graph and the number of items in graph_heads
         // should be identical.
         let graph_heads: Vec<Option<Head>> = self
-            .execute_jj_command(
-                [
-                    vec![
-                        "log",
-                        "--template",
-                        // Match builtin_log_compact with 2 lines per change
-                        &format!(
-                            r#"{HEAD_TEMPLATE} ++ " " ++ bookmarks ++"\n" ++ {HEAD_TEMPLATE}"#
-                        ),
-                    ],
-                    args,
-                ]
-                .concat(),
-                false,
-                true,
-            )?
+            .jj([
+                vec![
+                    "log",
+                    "--template",
+                    // Match builtin_log_compact with 2 lines per change
+                    &format!(r#"{HEAD_TEMPLATE} ++ " " ++ bookmarks ++"\n" ++ {HEAD_TEMPLATE}"#),
+                ],
+                args,
+            ]
+            .concat())
+            .run()?
             .lines()
             .map(|line| parse_head(line).ok())
             .collect();
@@ -187,7 +175,7 @@ impl Commander {
             args.push("--ignore-working-copy");
         }
 
-        Ok(self.execute_jj_command(args, true, true)?.remove_end_line())
+        Ok(self.jj(args).color().run()?.remove_end_line())
     }
 
     /// Get the current head.
@@ -230,18 +218,15 @@ impl Commander {
         // there's a new commit for the head
         for latest_head in latest_heads.iter() {
             let parent_commits: Vec<ChangeId> = self
-                .execute_jj_command(
-                    vec![
-                        "obslog",
-                        "--no-graph",
-                        "--template",
-                        r#"commit.change_id() ++ "\n""#,
-                        "-r",
-                        latest_head.commit_id.as_str(),
-                    ],
-                    false,
-                    true,
-                )
+                .jj([
+                    "obslog",
+                    "--no-graph",
+                    "--template",
+                    r#"commit.change_id() ++ "\n""#,
+                    "-r",
+                    latest_head.commit_id.as_str(),
+                ])
+                .run()
                 .context("Failed getting latest head parent commits")?
                 .lines()
                 .map(|line| ChangeId(line.to_owned()))

--- a/src/commander/mod.rs
+++ b/src/commander/mod.rs
@@ -9,14 +9,16 @@ Since the number of jj commands are quite high and some are quite complex,
 the implementation is found in multiple source files. This is why you
 will find multiple "impl Commander" sections in Commander, one for each source file.
 
-This module implements the low level functions used by the
-command implementation functions:
+A [Commander] is a reusable handle to a repository: it carries the
+ambient context (the repo root, the jj binary, test overrides) and
+exposes one method per jj operation. Each operation builds a single
+invocation with [Commander::jj], which returns a [JjCommand] builder:
 
 * [Commander::new] - Create a new instance
 * [Commander::check_jj_version] - Check jj works with blazingjj
-* [Commander::execute_command] - Execute any command and log the result
-* [Commander::execute_jj_command] - Execute a jj command.
-* [Commander::execute_void_jj_command] - Execute a jj command and discard the output.
+* [Commander::jj] - Start building a single jj invocation
+* [JjCommand::run] - Execute the command and return its output
+* [JjCommand::run_void] - Execute the command and discard the output
 
 */
 
@@ -27,11 +29,11 @@ pub mod jj;
 pub mod log;
 
 use std::ffi::OsStr;
+use std::ffi::OsString;
 use std::io;
 use std::process::Command;
+use std::process::Stdio;
 use std::string::FromUtf8Error;
-use std::sync::Arc;
-use std::sync::Mutex;
 
 use ansi_to_tui::IntoText;
 use anyhow::Context;
@@ -93,14 +95,20 @@ impl CommandError {
     }
 }
 
-/// Struct used to interact with the jj cli using commanders.
+/// Reusable handle to a repository.
 ///
-/// Handles arguments and recording of history.
-#[derive(Debug)]
+/// Holds the ambient context shared by every jj invocation (the repo
+/// root, the jj binary, test overrides) and exposes one method per
+/// operation. A commander can be reused for any number of commands;
+/// per-command options (color, quiet, stdin, ...) live on the
+/// [JjCommand] returned by [Commander::jj], not here.
+#[derive(Clone, Debug)]
 pub struct Commander {
     pub env: Env,
-    /// Environment variables.
-    env_var: Arc<Mutex<Vec<(String, String)>>>,
+    /// Terminal width passed to jj as `COLUMNS`, if set. Applies to every
+    /// command this commander runs, since it describes the output device
+    /// rather than any single command.
+    columns: Option<usize>,
 
     // Used for testing
     pub jj_config_toml: Option<Vec<String>>,
@@ -117,90 +125,44 @@ impl Commander {
     pub fn new(env: &Env) -> Self {
         Self {
             env: env.clone(),
-            env_var: Arc::new(Mutex::new(Vec::new())),
+            columns: None,
             jj_config_toml: None,
             force_no_color: false,
         }
     }
 
-    /// Tell jj to limit the with of output of secondary programs, like diff tools
-    /// Will ignore too narrow width requests.
-    /// You should call this before calling a jj command.
+    /// Tell jj to limit the width of output of secondary programs, like diff
+    /// tools, by setting `COLUMNS` on every command this commander runs.
+    /// Too narrow width requests are ignored, as they produce garbage output.
     pub fn limit_width(&mut self, columns: usize) {
-        // A request for too few columns is ignored.
-        // It will produce garbage output.
         const MIN_SETTABLE_WIDTH: usize = 20;
         if columns >= MIN_SETTABLE_WIDTH {
-            self.set_env("COLUMNS", &format!("{columns}"));
+            self.columns = Some(columns);
         }
     }
 
-    /// Set an environment variable for the next execute_command.
-    pub fn set_env(&mut self, var: &str, value: &str) {
-        self.env_var
-            .lock()
-            .unwrap()
-            .push((var.into(), value.into()))
-    }
-
-    /// Execute a command and record to history.
-    /// Environment variables can be set with set_env.
-    /// They are cleared after execution.
-    fn execute_command(&self, command: &mut Command) -> Result<String, CommandError> {
-        // Set current directory to root
-        command.current_dir(&self.env.root);
-
-        // Set environment variables and clear them for the next command
-        command.envs(self.env_var.lock().unwrap().iter().cloned());
-        self.env_var.lock().unwrap().clear();
-
-        let output = command.output();
-        let output = output?;
-
-        if !output.status.success() {
-            // Return JjError if non-zero status code
-            return Err(CommandError::Status(
-                String::from_utf8_lossy(&output.stderr).to_string(),
-                output.status.code(),
-            ));
-        }
-
-        Ok(String::from_utf8(output.stdout)?)
-    }
-
-    /// Execute a jj command with color/quiet arguments.
-    pub fn execute_jj_command<I, S>(
-        &self,
-        args: I,
-        color: bool,
-        quiet: bool,
-    ) -> Result<String, CommandError>
+    /// Start building a single jj invocation with the given arguments.
+    ///
+    /// The returned [JjCommand] carries the per-command options (color,
+    /// quiet, ...) and is executed with [JjCommand::run] or
+    /// [JjCommand::run_void].
+    pub fn jj<I, S>(&self, args: I) -> JjCommand<'_>
     where
         I: IntoIterator<Item = S>,
         S: AsRef<OsStr>,
     {
-        let mut command = Command::new(&self.env.jj_bin);
-        command.args(args);
-        command.args(get_output_args(!self.force_no_color && color, quiet));
-
-        if let Some(jj_config_toml) = &self.jj_config_toml {
-            for cfg in jj_config_toml {
-                command.args(["--config", cfg]);
-            }
+        let mut env_var = Vec::new();
+        if let Some(columns) = self.columns {
+            env_var.push(("COLUMNS".to_owned(), columns.to_string()));
         }
 
-        self.execute_command(&mut command)
-    }
-
-    /// Execute a jj command without using the output.
-    pub fn execute_void_jj_command<I, S>(&self, args: I) -> Result<(), CommandError>
-    where
-        I: IntoIterator<Item = S>,
-        S: AsRef<OsStr>,
-    {
-        // Since no result is used, enable color for command log
-        self.execute_jj_command(args, true, true)?;
-        Ok(())
+        JjCommand {
+            commander: self,
+            args: args.into_iter().map(|s| s.as_ref().to_owned()).collect(),
+            color: false,
+            quiet: true,
+            env_var,
+        }
     }
 
     /// Check that the version of jj is recent enough to work with blazingjj
@@ -209,9 +171,10 @@ impl Commander {
     #[instrument(level = "trace", skip(self))]
     pub fn check_jj_version(&self) -> Result<()> {
         // Ask jj about its version
-        let (color, quiet) = (false, false);
         let found_version = self
-            .execute_jj_command(vec!["version"], color, quiet)
+            .jj(["version"])
+            .verbose()
+            .run()
             .context("Run jj version")?;
 
         // Extract version number
@@ -237,6 +200,94 @@ impl Commander {
             ),
             Ok(_) => Ok(()), // found >= min, so jj is recent enough
         }
+    }
+}
+
+/// A single jj invocation, built from a [Commander] via [Commander::jj].
+///
+/// Carries the arguments and the per-command options. Configuration
+/// methods consume and return the builder so they can be chained; the
+/// command is run exactly once with [Self::run] or [Self::run_void].
+pub struct JjCommand<'a> {
+    commander: &'a Commander,
+    args: Vec<OsString>,
+    /// Whether the command should emit ANSI color. Off by default so output
+    /// is safe to parse; enable with [Self::color] for output shown to the
+    /// user.
+    color: bool,
+    /// Whether to pass `--quiet`. On by default.
+    quiet: bool,
+    /// Environment variables for this command.
+    env_var: Vec<(String, String)>,
+}
+
+impl JjCommand<'_> {
+    /// Enable ANSI color in the command's output.
+    ///
+    /// Off by default, so parsed output stays free of escape codes; enable it
+    /// for output shown directly to the user (diffs, logs, the command log).
+    pub fn color(mut self) -> Self {
+        self.color = true;
+        self
+    }
+
+    /// Don't pass `--quiet`, so jj's informational output (snapshot and hint
+    /// messages) is included. Quiet is on by default.
+    pub fn verbose(mut self) -> Self {
+        self.quiet = false;
+        self
+    }
+
+    /// Execute the command and return its standard output.
+    pub fn run(self) -> Result<String, CommandError> {
+        let stdout = self.execute(Stdio::piped())?;
+        Ok(String::from_utf8(stdout)?)
+    }
+
+    /// Execute the command, discarding its output.
+    pub fn run_void(self) -> Result<(), CommandError> {
+        // The output isn't used, so don't bother capturing or decoding it.
+        // Color stays enabled so a failure's stderr reaches the user with its
+        // formatting intact.
+        self.color().execute(Stdio::null())?;
+        Ok(())
+    }
+
+    /// Configure and run the command, returning the captured standard output.
+    ///
+    /// `stdout` selects how the child's standard output is handled: piped to
+    /// be captured and returned, or null to be discarded. Standard error is
+    /// always captured so it can be surfaced on failure.
+    fn execute(self, stdout: Stdio) -> Result<Vec<u8>, CommandError> {
+        let mut command = Command::new(&self.commander.env.jj_bin);
+        command.args(&self.args);
+        command.args(get_output_args(
+            !self.commander.force_no_color && self.color,
+            self.quiet,
+        ));
+
+        if let Some(jj_config_toml) = &self.commander.jj_config_toml {
+            for cfg in jj_config_toml {
+                command.args(["--config", cfg]);
+            }
+        }
+
+        command.current_dir(&self.commander.env.root);
+        command.envs(self.env_var.iter().cloned());
+        command.stdout(stdout);
+        command.stderr(Stdio::piped());
+
+        let output = command.spawn()?.wait_with_output()?;
+
+        if !output.status.success() {
+            // Return JjError if non-zero status code
+            return Err(CommandError::Status(
+                String::from_utf8_lossy(&output.stderr).to_string(),
+                output.status.code(),
+            ));
+        }
+
+        Ok(output.stdout)
     }
 }
 
@@ -314,7 +365,7 @@ pub mod tests {
             commander.jj_config_toml = Some(jj_config_toml);
             commander.force_no_color = true;
 
-            commander.execute_void_jj_command(vec!["git", "init", "--colocate"])?;
+            commander.jj(["git", "init", "--colocate"]).run_void()?;
 
             Ok(Self {
                 directory,
@@ -329,9 +380,7 @@ pub mod tests {
 
         let test_repo = TestRepo::new()?;
 
-        test_repo
-            .commander
-            .execute_jj_command(vec!["status"], true, true)?;
+        test_repo.commander.jj(["status"]).color().run()?;
 
         Ok(())
     }

--- a/src/commander/mod.rs
+++ b/src/commander/mod.rs
@@ -31,6 +31,7 @@ pub mod log;
 use std::ffi::OsStr;
 use std::ffi::OsString;
 use std::io;
+use std::io::Write;
 use std::process::Command;
 use std::process::Stdio;
 use std::string::FromUtf8Error;
@@ -161,6 +162,7 @@ impl Commander {
             args: args.into_iter().map(|s| s.as_ref().to_owned()).collect(),
             color: false,
             quiet: true,
+            stdin: None,
             env_var,
         }
     }
@@ -217,6 +219,8 @@ pub struct JjCommand<'a> {
     color: bool,
     /// Whether to pass `--quiet`. On by default.
     quiet: bool,
+    /// Data to feed the command on standard input, if any.
+    stdin: Option<String>,
     /// Environment variables for this command.
     env_var: Vec<(String, String)>,
 }
@@ -235,6 +239,16 @@ impl JjCommand<'_> {
     /// messages) is included. Quiet is on by default.
     pub fn verbose(mut self) -> Self {
         self.quiet = false;
+        self
+    }
+
+    /// Feed `stdin` to the command on standard input.
+    ///
+    /// Useful for commands like `jj describe --stdin`, where passing the value
+    /// as an argument would be misinterpreted (e.g. a message starting with a
+    /// dash being parsed as a flag).
+    pub fn stdin(mut self, stdin: &str) -> Self {
+        self.stdin = Some(stdin.to_owned());
         self
     }
 
@@ -277,7 +291,29 @@ impl JjCommand<'_> {
         command.stdout(stdout);
         command.stderr(Stdio::piped());
 
-        let output = command.spawn()?.wait_with_output()?;
+        let output = match self.stdin {
+            Some(input) => {
+                command.stdin(Stdio::piped());
+                let mut child = command.spawn()?;
+                let mut stdin = child.stdin.take().expect("stdin was piped");
+                // Write on a separate thread while we drain the child's output,
+                // so neither side deadlocks on a full pipe buffer. Dropping the
+                // handle closes the pipe, signalling EOF to the child.
+                let writer = std::thread::spawn(move || stdin.write_all(input.as_bytes()));
+                let output = child.wait_with_output()?;
+                // Ignore a broken pipe (child exited early); the status check
+                // below surfaces the real error.
+                writer
+                    .join()
+                    .expect("stdin writer thread panicked")
+                    .or_else(|err| match err.kind() {
+                        io::ErrorKind::BrokenPipe => Ok(()),
+                        _ => Err(err),
+                    })?;
+                output
+            }
+            None => command.spawn()?.wait_with_output()?,
+        };
 
         if !output.status.success() {
             // Return JjError if non-zero status code

--- a/src/ui/dialog/command.rs
+++ b/src/ui/dialog/command.rs
@@ -94,7 +94,7 @@ impl Component for CommandPopup<'_> {
                     let res: Result<String> = split(command_input)
                         .context("Failed to split command input")
                         .and_then(|command| {
-                            Ok(new_commander().execute_jj_command(command, true, false)?)
+                            Ok(new_commander().jj(command).color().verbose().run()?)
                         });
                     let output_str = match res {
                         Ok(output) => output,


### PR DESCRIPTION
jj's describe command doesn't properly handle messages starting with a dash, mistaking them for an option or flag, causing the operation to fail. Passing the message via stdin instead works around that issue.

The new stdin path writes input from a separate thread while draining the child's output, so neither side deadlocks on a full pipe buffer. Unlikely to happen for a commit message, but protects us from unexpected deadlocks should we ever use it for different inputs.

Fixes #92

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
