### PR TITLE
Stop running jj log twice when refreshing the log tab

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -199,11 +199,15 @@ impl<'a> App<'a> {
                 }
             }
             AppAction::RefreshTab() => {
-                self.set_tab(self.current_tab)?;
+                // Moving the selection refreshes the log tab on its own,
+                // so going through set_tab as well would run `jj log`
+                // twice.
                 if self.current_tab == Tab::Log {
-                    let head = new_commander().get_current_head()?.clone();
+                    let head = new_commander().get_current_head()?;
                     self.get_log_tab()?.set_head(head);
-                };
+                } else {
+                    self.set_tab(self.current_tab)?;
+                }
             }
         }
 


### PR DESCRIPTION
`AppAction::RefreshTab` refreshes the current tab through `set_tab()`, which reaches `LogTab::focus()`, and then moves the selection to the current change, which refreshes the tab a second time. Both runs do the full `jj log`, which is the expensive part: on a large repo with a wide revset it takes seconds.