### PR TITLE
Fix a copied file in the files list not being colored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Describing a commit with a message starting with a dash no longer fails
+- A copied file in the files list is now colored like the other changes
 
 ## [0.8.0] - 2026-04-19
 

--- a/src/commander/files.rs
+++ b/src/commander/files.rs
@@ -31,6 +31,7 @@ pub enum DiffType {
     Modified,
     Deleted,
     Renamed,
+    Copied,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -45,6 +46,7 @@ impl DiffType {
             "M" => Some(DiffType::Modified),
             "D" => Some(DiffType::Deleted),
             "R" => Some(DiffType::Renamed),
+            "C" => Some(DiffType::Copied),
             _ => None,
         }
     }
@@ -54,6 +56,7 @@ impl DiffType {
             DiffType::Added => Color::Green,
             DiffType::Modified => Color::Cyan,
             DiffType::Renamed => Color::Cyan,
+            DiffType::Copied => Color::Cyan,
             DiffType::Deleted => Color::Red,
         }
     }
@@ -216,6 +219,16 @@ mod tests {
 
     use super::*;
     use crate::commander::tests::TestRepo;
+
+    #[test]
+    fn every_status_jj_lists_has_a_diff_type() {
+        assert_eq!(DiffType::parse("A"), Some(DiffType::Added));
+        assert_eq!(DiffType::parse("M"), Some(DiffType::Modified));
+        assert_eq!(DiffType::parse("D"), Some(DiffType::Deleted));
+        assert_eq!(DiffType::parse("R"), Some(DiffType::Renamed));
+        assert_eq!(DiffType::parse("C"), Some(DiffType::Copied));
+        assert_eq!(DiffType::parse("?"), None);
+    }
 
     #[test]
     fn get_files() -> Result<()> {


### PR DESCRIPTION
`jj diff --summary` marks a file jj recognized as a copy with `C`, next to the `A`/`M`/`D`/`R` the files list already knows. `DiffType::parse()` has no arm for it, so such a file is listed with no diff type at all, which is what the tab colors a line by -- leaving the entry in the default foreground while every other entry is colored.

Copies read as renames that kept the source, so they get the same color.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
