### PR TITLE
Rename Component::focus() to Component::refresh()

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -115,7 +115,7 @@ impl<'a> App<'a> {
     pub fn set_tab(&mut self, tab: Tab) -> Result<()> {
         info!("Setting tab to {}", tab);
         self.current_tab = tab;
-        self.get_or_init_current_tab()?.focus()?;
+        self.get_or_init_current_tab()?.refresh()?;
         Ok(())
     }
 
@@ -350,7 +350,7 @@ impl<'a> App<'a> {
                 }
             };
         } else if event == event::Event::FocusGained {
-            self.get_or_init_current_tab()?.focus()?;
+            self.get_or_init_current_tab()?.refresh()?;
         } else {
             match self.get_or_init_current_tab()?.input(event.clone())? {
                 ComponentInputResult::HandledAction(app_action) => {

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -235,7 +235,7 @@ impl BookmarksTab<'_> {
 }
 
 impl Component for BookmarksTab<'_> {
-    fn focus(&mut self) -> Result<()> {
+    fn refresh(&mut self) -> Result<()> {
         self.refresh_bookmarks();
         self.refresh_bookmark();
         Ok(())

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -194,7 +194,7 @@ impl FilesTab {
 }
 
 impl Component for FilesTab {
-    fn focus(&mut self) -> Result<()> {
+    fn refresh(&mut self) -> Result<()> {
         self.is_current_head = self.head == new_commander().get_current_head()?;
         self.head = new_commander().get_head_latest(&self.head)?;
         self.refresh_files()?;

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -795,7 +795,7 @@ impl<'a> LogTab<'a> {
 }
 
 impl Component for LogTab<'_> {
-    fn focus(&mut self) -> Result<()> {
+    fn refresh(&mut self) -> Result<()> {
         let latest_head = new_commander().get_head_latest(&self.head)?;
         self.set_head(latest_head);
         Ok(())

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -46,8 +46,8 @@ impl ComponentInputResult {
     }
 }
 pub trait Component {
-    // Called when switching to tab
-    fn focus(&mut self) -> Result<()> {
+    /// Read whatever this component shows afresh from the repo.
+    fn refresh(&mut self) -> Result<()> {
         Ok(())
     }
 

--- a/src/ui/panel/log_panel.rs
+++ b/src/ui/panel/log_panel.rs
@@ -352,11 +352,6 @@ impl<'a> LogPanel<'a> {
 }
 
 impl Component for LogPanel<'_> {
-    // Called when switching to tab
-    fn focus(&mut self) -> Result<()> {
-        Ok(())
-    }
-
     fn update(&mut self) -> Result<Option<AppAction>> {
         Ok(None)
     }


### PR DESCRIPTION
The method runs on a tab switch and on regaining window focus, so its name picks one of its two callers instead of saying what it does, which is to read the repo again. LogPanel's override goes with it, restating the default on a type that is never switched to.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
