### PR TITLE
commander: Make --ignore-working-copy a JjCommand modifier

### DIFF
--- a/src/commander/bookmarks.rs
+++ b/src/commander/bookmarks.rs
@@ -181,11 +181,13 @@ impl Commander {
         let bookmark_arg = &bookmark.to_string();
         let mut args = vec!["show", bookmark_arg];
         args.append(&mut diff_format.get_args());
+
+        let mut command = self.jj(args).color();
         if ignore_working_copy {
-            args.push("--ignore-working-copy");
+            command = command.ignore_working_copy();
         }
 
-        Ok(self.jj(args).color().run()?.remove_end_line())
+        Ok(command.run()?.remove_end_line())
     }
 
     #[instrument(level = "trace", skip(self))]

--- a/src/commander/files.rs
+++ b/src/commander/files.rs
@@ -154,11 +154,13 @@ impl Commander {
         let fileset = Self::get_file_revset(path);
         let mut args = vec!["diff", "-r", head.commit_id.as_str(), &fileset];
         args.append(&mut diff_format.get_args());
+
+        let mut command = self.jj(args).color();
         if ignore_working_copy {
-            args.push("--ignore-working-copy");
+            command = command.ignore_working_copy();
         }
 
-        self.jj(args).color().run().map(Some)
+        command.run().map(Some)
     }
 
     #[instrument(level = "trace", skip(self))]

--- a/src/commander/log.rs
+++ b/src/commander/log.rs
@@ -186,11 +186,13 @@ impl Commander {
     ) -> JjCommand<'_> {
         let mut args = vec!["show", commit_id.as_str()];
         args.append(&mut diff_format.get_args());
+
+        let mut command = self.jj(args);
         if ignore_working_copy {
-            args.push("--ignore-working-copy");
+            command = command.ignore_working_copy();
         }
 
-        self.jj(args)
+        command
     }
 
     /// Get the current head.

--- a/src/commander/mod.rs
+++ b/src/commander/mod.rs
@@ -165,6 +165,7 @@ impl Commander {
             args: args.into_iter().map(|s| s.as_ref().to_owned()).collect(),
             color: false,
             quiet: true,
+            ignore_working_copy: false,
             stdin: None,
             env_var,
         }
@@ -222,6 +223,9 @@ pub struct JjCommand<'a> {
     color: bool,
     /// Whether to pass `--quiet`. On by default.
     quiet: bool,
+    /// Whether to pass `--ignore-working-copy`. Off by default, so a
+    /// command sees the files as they are now.
+    ignore_working_copy: bool,
     /// Data to feed the command on standard input, if any.
     stdin: Option<String>,
     /// Environment variables for this command.
@@ -242,6 +246,17 @@ impl JjCommand<'_> {
     /// messages) is included. Quiet is on by default.
     pub fn verbose(mut self) -> Self {
         self.quiet = false;
+        self
+    }
+
+    /// Pass `--ignore-working-copy`, so the command reads the repo as it
+    /// stands without snapshotting the files first.
+    ///
+    /// Off by default. Use it where a stale answer beats an operation of
+    /// our own: reads that are meant to leave the repo where the caller
+    /// found it.
+    pub fn ignore_working_copy(mut self) -> Self {
+        self.ignore_working_copy = true;
         self
     }
 
@@ -334,6 +349,10 @@ impl JjCommand<'_> {
             !self.commander.force_no_color && self.color,
             self.quiet,
         ));
+
+        if self.ignore_working_copy {
+            command.arg("--ignore-working-copy");
+        }
 
         if let Some(jj_config_toml) = &self.commander.jj_config_toml {
             for cfg in jj_config_toml {


### PR DESCRIPTION
The flag is currently pushed onto each command's argument vector by hand, so every caller that wants it has to own a `Vec` of arguments and remember where the flag goes, while --no-pager, --color and --quiet are already applied centrally when the command is built. Give it a builder method alongside color() and verbose() so it is set the same way as the other per-command options.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
