### PR TITLE
Stop a command's refresh jumping the log to the working copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Describing a commit with a message starting with a dash no longer fails
 - A copied file in the files list is now colored like the other changes
+- Running a command from the log tab no longer moves the selection to the
+  working copy
 
 ## [0.8.0] - 2026-04-19
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -199,15 +199,7 @@ impl<'a> App<'a> {
                 }
             }
             AppAction::RefreshTab() => {
-                // Moving the selection refreshes the log tab on its own,
-                // so going through set_tab as well would run `jj log`
-                // twice.
-                if self.current_tab == Tab::Log {
-                    let head = new_commander().get_current_head()?;
-                    self.get_log_tab()?.set_head(head);
-                } else {
-                    self.set_tab(self.current_tab)?;
-                }
+                self.set_tab(self.current_tab)?;
             }
         }
 


### PR DESCRIPTION
A popup that has run a command asks for the current tab to be re-read, and on the log tab that has meant moving the selection to `@` first, on the grounds that going through set_tab() like the other tabs would run `jj log` a second time. It would not: LogTab::refresh() resolves a head and hands it to set_head() just as that branch does, only against the change we are on rather than `@`. Keeping that change is what we want anyway: it is still the one you care about after a fetch or a rebase, and refreshing follows it through whatever the command did to it.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
