### PR TITLE
Let a popup say whether it did anything as it closes

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -191,7 +191,14 @@ impl<'a> App<'a> {
                 self.get_files_tab()?.set_head(&head)?;
             }
             AppAction::SetPopup(popup) => {
-                self.popup = popup;
+                self.popup = Some(popup);
+            }
+            AppAction::PopupDone => {
+                self.popup = None;
+                self.handle_action(AppAction::RefreshTab())?;
+            }
+            AppAction::PopupCanceled => {
+                self.popup = None;
             }
             AppAction::Multiple(app_actions) => {
                 for app_action in app_actions.into_iter() {

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -260,8 +260,9 @@ impl Component for BookmarksTab<'_> {
                                 self.refresh_bookmark();
                             }
                             Err(err) => {
-                                return Ok(Some(AppAction::SetPopup(Some(Box::new(
-                                    MessagePopup::new("Delete error", err.to_string()),
+                                return Ok(Some(AppAction::SetPopup(Box::new(MessagePopup::new(
+                                    "Delete error",
+                                    err.to_string(),
                                 )))));
                             }
                         }
@@ -280,8 +281,9 @@ impl Component for BookmarksTab<'_> {
                                 self.refresh_bookmark();
                             }
                             Err(err) => {
-                                return Ok(Some(AppAction::SetPopup(Some(Box::new(
-                                    MessagePopup::new("Forget error", err.to_string()),
+                                return Ok(Some(AppAction::SetPopup(Box::new(MessagePopup::new(
+                                    "Forget error",
+                                    err.to_string(),
                                 )))));
                             }
                         }
@@ -899,10 +901,10 @@ impl Component for BookmarksTab<'_> {
                                 && !ignore_immutable
                             {
                                 return Ok(ComponentInputResult::HandledAction(
-                                    AppAction::SetPopup(Some(Box::new(MessagePopup::new(
+                                    AppAction::SetPopup(Box::new(MessagePopup::new(
                                         "Edit",
                                         "The change cannot be edited because it is immutable.",
-                                    )))),
+                                    ))),
                                 ));
                             }
 
@@ -934,7 +936,7 @@ impl Component for BookmarksTab<'_> {
                 }
                 KeyCode::Char('?') => {
                     return Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
-                        Some(Box::new(HelpPopup::new(
+                        Box::new(HelpPopup::new(
                             vec![
                                 ("j/k".to_owned(), "scroll down/up".to_owned()),
                                 ("J/K".to_owned(), "scroll down by ½ page".to_owned()),
@@ -961,7 +963,7 @@ impl Component for BookmarksTab<'_> {
                                 ("w".to_owned(), "toggle diff format".to_owned()),
                                 ("W".to_owned(), "toggle wrapping".to_owned()),
                             ],
-                        ))),
+                        )),
                     )));
                 }
                 _ => return Ok(ComponentInputResult::NotHandled),

--- a/src/ui/dialog/bookmark_set.rs
+++ b/src/ui/dialog/bookmark_set.rs
@@ -51,7 +51,6 @@ pub struct BookmarkSetPopup<'a> {
     list_height: u16,
     config: JjConfig,
     creating: Option<TextArea<'a>>,
-    tx: std::sync::mpsc::Sender<bool>,
 }
 
 fn generate_options(change_id: Option<&ChangeId>) -> Vec<BookmarkSetOption> {
@@ -95,12 +94,7 @@ fn generate_name(change_id: &ChangeId) -> String {
 }
 
 impl BookmarkSetPopup<'_> {
-    pub fn new(
-        config: JjConfig,
-        change_id: Option<ChangeId>,
-        commit_id: CommitId,
-        tx: std::sync::mpsc::Sender<bool>,
-    ) -> Self {
+    pub fn new(config: JjConfig, change_id: Option<ChangeId>, commit_id: CommitId) -> Self {
         Self {
             options: generate_options(change_id.as_ref()),
             change_id,
@@ -109,7 +103,6 @@ impl BookmarkSetPopup<'_> {
             config,
             commit_id,
             creating: None,
-            tx,
         }
     }
 
@@ -257,15 +250,12 @@ impl Component for BookmarkSetPopup<'_> {
                         }
 
                         self.create_bookmark(name)?;
-                        self.tx.send(true)?;
-                        return Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
-                            None,
-                        )));
+                        return Ok(ComponentInputResult::HandledAction(AppAction::PopupDone));
                     }
                     KeyCode::Esc => {
-                        return Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
-                            None,
-                        )));
+                        return Ok(ComponentInputResult::HandledAction(
+                            AppAction::PopupCanceled,
+                        ));
                     }
                     _ => {}
                 }
@@ -291,10 +281,7 @@ impl Component for BookmarkSetPopup<'_> {
                 }
                 KeyCode::Char('g') => {
                     self.generate_bookmark()?;
-                    self.tx.send(true)?;
-                    return Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
-                        None,
-                    )));
+                    return Ok(ComponentInputResult::HandledAction(AppAction::PopupDone));
                 }
                 KeyCode::Char('c') => {
                     self.on_creating();
@@ -311,17 +298,15 @@ impl Component for BookmarkSetPopup<'_> {
                             }
                             BookmarkSetOption::GeneratedName(_, _) => {
                                 self.generate_bookmark()?;
-                                self.tx.send(true)?;
                                 return Ok(ComponentInputResult::HandledAction(
-                                    AppAction::SetPopup(None),
+                                    AppAction::PopupDone,
                                 ));
                             }
                             BookmarkSetOption::Bookmark(bookmark) => {
                                 new_commander()
                                     .set_bookmark_commit(&bookmark.name, &self.commit_id)?;
-                                self.tx.send(true)?;
                                 return Ok(ComponentInputResult::HandledAction(
-                                    AppAction::SetPopup(None),
+                                    AppAction::PopupDone,
                                 ));
                             }
                             BookmarkSetOption::Error(_) => {
@@ -331,10 +316,9 @@ impl Component for BookmarkSetPopup<'_> {
                     }
                 }
                 KeyCode::Char('q') | KeyCode::Esc => {
-                    self.tx.send(false)?;
-                    return Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
-                        None,
-                    )));
+                    return Ok(ComponentInputResult::HandledAction(
+                        AppAction::PopupCanceled,
+                    ));
                 }
                 _ => return Ok(ComponentInputResult::NotHandled),
             }

--- a/src/ui/dialog/command.rs
+++ b/src/ui/dialog/command.rs
@@ -81,9 +81,9 @@ impl Component for CommandPopup<'_> {
                     let mut command_input = command_input.as_str();
 
                     if command_input.trim().is_empty() {
-                        return Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
-                            None,
-                        )));
+                        return Ok(ComponentInputResult::HandledAction(
+                            AppAction::PopupCanceled,
+                        ));
                     }
 
                     if command_input == "jj" {
@@ -107,25 +107,23 @@ impl Component for CommandPopup<'_> {
                     };
 
                     if output_str.trim().is_empty() {
-                        return Ok(ComponentInputResult::HandledAction(AppAction::Multiple(
-                            vec![AppAction::SetPopup(None), AppAction::RefreshTab()],
-                        )));
+                        return Ok(ComponentInputResult::HandledAction(AppAction::PopupDone));
                     }
 
                     return Ok(ComponentInputResult::HandledAction(AppAction::Multiple(
                         vec![
-                            AppAction::SetPopup(Some(Box::new(
+                            AppAction::SetPopup(Box::new(
                                 MessagePopup::new(format!("jj {command_input}"), output_str)
                                     .text_align(Alignment::Left),
-                            ))),
+                            )),
                             AppAction::RefreshTab(),
                         ],
                     )));
                 }
                 KeyCode::Esc => {
-                    return Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
-                        None,
-                    )));
+                    return Ok(ComponentInputResult::HandledAction(
+                        AppAction::PopupCanceled,
+                    ));
                 }
                 _ => {}
             }

--- a/src/ui/dialog/loader.rs
+++ b/src/ui/dialog/loader.rs
@@ -79,17 +79,17 @@ impl Component for LoaderPopup {
 
         let action = match result {
             Ok(output) if !output.is_empty() => AppAction::Multiple(vec![
-                AppAction::SetPopup(Some(Box::new(MessagePopup::new(
+                AppAction::SetPopup(Box::new(MessagePopup::new(
                     format!("{} message", self.operation_name),
                     output,
-                )))),
+                ))),
                 AppAction::RefreshTab(),
             ]),
-            Ok(_) => AppAction::Multiple(vec![AppAction::SetPopup(None), AppAction::RefreshTab()]),
-            Err(err) => AppAction::SetPopup(Some(Box::new(MessagePopup::new(
+            Ok(_) => AppAction::PopupDone,
+            Err(err) => AppAction::SetPopup(Box::new(MessagePopup::new(
                 format!("{} error", self.operation_name),
                 err.to_string(),
-            )))),
+            ))),
         };
 
         Ok(Some(action))

--- a/src/ui/dialog/mod.rs
+++ b/src/ui/dialog/mod.rs
@@ -2,9 +2,10 @@
 previously known as popups.
 
 A Component can launch a dialog by sending
-[`AppAction::SetPopup(Some(<popup instance>))`](crate::ui::AppAction).
+[`AppAction::SetPopup(<popup instance>)`](crate::ui::AppAction).
 Once launched, a dialog will receive all input events from the App,
-until it is closed.
+until it sends [`AppAction::PopupDone`](crate::ui::AppAction) or
+[`AppAction::PopupCanceled`](crate::ui::AppAction).
 */
 
 mod bookmark_set;

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -355,10 +355,10 @@ impl Component for FilesTab {
                     // this works even for deleted files because jj doesn't return error in that case
                     if self.untrack_file().is_err() {
                         return Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
-                            Some(Box::new(MessagePopup::new(
+                            Box::new(MessagePopup::new(
                                 "Can't untrack file",
                                 "Make sure that file is ignored",
-                            ))),
+                            )),
                         )));
                     }
                     self.set_head(&new_commander().get_current_head()?)?;
@@ -366,10 +366,7 @@ impl Component for FilesTab {
                 KeyCode::Char('r') => {
                     if let Err(err) = self.restore_file() {
                         return Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
-                            Some(Box::new(MessagePopup::new(
-                                "Can't restore file",
-                                err.to_string(),
-                            ))),
+                            Box::new(MessagePopup::new("Can't restore file", err.to_string())),
                         )));
                     }
                     self.set_head(&new_commander().get_current_head()?)?;
@@ -385,7 +382,7 @@ impl Component for FilesTab {
                 }
                 KeyCode::Char('?') => {
                     return Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
-                        Some(Box::new(HelpPopup::new(
+                        Box::new(HelpPopup::new(
                             vec![
                                 ("j/k".to_owned(), "scroll down/up".to_owned()),
                                 ("J/K".to_owned(), "scroll down by ½ page".to_owned()),
@@ -406,7 +403,7 @@ impl Component for FilesTab {
                                 ("w".to_owned(), "toggle diff format".to_owned()),
                                 ("W".to_owned(), "toggle wrapping".to_owned()),
                             ],
-                        ))),
+                        )),
                     )));
                 }
                 _ => return Ok(ComponentInputResult::NotHandled),

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -94,9 +94,6 @@ pub struct LogTab<'a> {
     popup_tx: std::sync::mpsc::Sender<Listener>,
     popup_rx: std::sync::mpsc::Receiver<Listener>,
 
-    bookmark_set_popup_tx: std::sync::mpsc::Sender<bool>,
-    bookmark_set_popup_rx: std::sync::mpsc::Receiver<bool>,
-
     describe_textarea: Option<TextArea<'a>>,
     describe_after_new: bool,
 
@@ -171,7 +168,6 @@ impl<'a> LogTab<'a> {
         let commit_show_cache = CommitShowCache::new();
 
         let (popup_tx, popup_rx) = std::sync::mpsc::channel();
-        let (bookmark_set_popup_tx, bookmark_set_popup_rx) = std::sync::mpsc::channel();
 
         let mut keybinds = LogTabKeybinds::default();
         if let Some(keybinds_config) = get_env().jj_config.keybinds() {
@@ -200,9 +196,6 @@ impl<'a> LogTab<'a> {
             popup: ConfirmDialogState::default(),
             popup_tx,
             popup_rx,
-
-            bookmark_set_popup_tx,
-            bookmark_set_popup_rx,
 
             describe_textarea: None,
             describe_after_new: false,
@@ -480,10 +473,10 @@ impl<'a> LogTab<'a> {
         // Cannot abandon immutable changes
         if self.head.immutable {
             return Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
-                Some(Box::new(MessagePopup::new(
+                Box::new(MessagePopup::new(
                     "Abandon",
                     "The change cannot be abandoned because it is immutable.",
-                ))),
+                )),
             )));
         }
 
@@ -592,10 +585,10 @@ impl<'a> LogTab<'a> {
                         }
                         Err(_) => {
                             return Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
-                                Some(Box::new(MessagePopup::new(
+                                Box::new(MessagePopup::new(
                                     "Squash",
                                     "Cannot squash onto current change",
-                                ))),
+                                )),
                             )));
                         }
                     }
@@ -606,10 +599,10 @@ impl<'a> LogTab<'a> {
 
                 if target.immutable && !ignore_immutable {
                     return Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
-                        Some(Box::new(MessagePopup::new(
+                        Box::new(MessagePopup::new(
                             "Squash",
                             "Cannot squash onto immutable change",
-                        ))),
+                        )),
                     )));
                 }
 
@@ -640,10 +633,10 @@ impl<'a> LogTab<'a> {
             LogTabEvent::EditChange { ignore_immutable } => {
                 if self.head.immutable && !ignore_immutable {
                     return Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
-                        Some(Box::new(MessagePopup::new(
+                        Box::new(MessagePopup::new(
                             " Edit ",
                             "The change cannot be edited because it is immutable.",
-                        ))),
+                        )),
                     )));
                 }
 
@@ -679,10 +672,10 @@ impl<'a> LogTab<'a> {
             LogTabEvent::Describe => {
                 if self.head.immutable {
                     return Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
-                        Some(Box::new(MessagePopup::new(
+                        Box::new(MessagePopup::new(
                             "Describe",
                             "The change cannot be described because it is immutable.",
-                        ))),
+                        )),
                     )));
                 } else {
                     let mut textarea = TextArea::new(
@@ -713,12 +706,11 @@ impl<'a> LogTab<'a> {
             }
             LogTabEvent::SetBookmark => {
                 return Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
-                    Some(Box::new(BookmarkSetPopup::new(
+                    Box::new(BookmarkSetPopup::new(
                         self.config.clone(),
                         Some(self.head.change_id.clone()),
                         self.head.commit_id.clone(),
-                        self.bookmark_set_popup_tx.clone(),
-                    ))),
+                    )),
                 )));
             }
             LogTabEvent::OpenFiles => {
@@ -753,7 +745,7 @@ impl<'a> LogTab<'a> {
                 });
 
                 return Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
-                    Some(Box::new(loader)),
+                    Box::new(loader),
                 )));
             }
             LogTabEvent::Fetch { all_remotes } => {
@@ -762,12 +754,12 @@ impl<'a> LogTab<'a> {
                 });
 
                 return Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
-                    Some(Box::new(loader)),
+                    Box::new(loader),
                 )));
             }
             LogTabEvent::OpenHelp => {
                 return Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
-                    Some(Box::new(HelpPopup::new(
+                    Box::new(HelpPopup::new(
                         self.keybinds.make_main_panel_help(),
                         vec![
                             ("Ctrl+e/Ctrl+y".to_owned(), "scroll down/up".to_owned()),
@@ -782,7 +774,7 @@ impl<'a> LogTab<'a> {
                             ("w".to_owned(), "toggle diff format".to_owned()),
                             ("W".to_owned(), "toggle wrapping".to_owned()),
                         ],
-                    ))),
+                    )),
                 )));
             }
             LogTabEvent::Save
@@ -831,10 +823,6 @@ impl Component for LogTab<'_> {
                 }
                 _ => {}
             }
-        }
-
-        if let Ok(true) = self.bookmark_set_popup_rx.try_recv() {
-            self.refresh_log_output();
         }
 
         Ok(None)
@@ -1031,7 +1019,7 @@ impl Component for LogTab<'_> {
                 self.rebase_popup = None;
                 let msg = handled.err().unwrap();
                 return Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
-                    Some(Box::new(MessagePopup::new("Error", msg.to_string()))),
+                    Box::new(MessagePopup::new("Error", msg.to_string())),
                 )));
             }
             if handled.ok() == Some(true) {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -20,7 +20,12 @@ pub enum AppAction {
     ViewFiles(Head),
     ViewLog(Head),
     ChangeHead(Head),
-    SetPopup(Option<Box<dyn Component>>),
+    /// Put this popup up, in place of whatever is up now.
+    SetPopup(Box<dyn Component>),
+    /// Take the popup down, what it was there to do having been done.
+    PopupDone,
+    /// Take the popup down, nothing having been done.
+    PopupCanceled,
     Multiple(Vec<AppAction>),
     RefreshTab(),
 }


### PR DESCRIPTION
A popup closes itself by asking for `SetPopup(None)`, which tells the app nothing about whether it ran a command, so every caller that wants the view re-read afterwards has to ask for that too. The command and loader popups pair the close with a `RefreshTab()`, and the bookmark set popup instead reports back over a channel of its own that the log tab polls in its update(). Have `SetPopup` always take a popup and give a popup `PopupDone` and `PopupCanceled` to close itself with, the former implying the re-read, which leaves the channel with nothing to carry. Closing the bookmark set popup now re-reads the whole tab rather than just its log output.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
