### PR TITLE
Move shared keybindings into a global event layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The keybinds config section is now kebab-cased: `[blazingjj.keybinds.log_tab]` must be
   changed to `[blazingjj.keybinds.log-tab]`
+- The keybindings shared by all tabs are now configured under `[blazingjj.keybinds]`:
+  `focus-current`, `refresh` and `open-help` move there from
+  `[blazingjj.keybinds.log-tab]`, which also loses its `scroll-*` overrides
 
 ### Added
 
 - Keybinding for jj absorb (`A`)
-- Top-level scroll keybindings (`scroll-down`, `scroll-up`, `scroll-down-half`,
-  `scroll-up-half` under `[blazingjj.keybinds]`) that apply as defaults to all
-  scroll-capable components and can be overridden per-component
+- Global keybindings under `[blazingjj.keybinds]` (`scroll-down`, `scroll-up`,
+  `scroll-down-half`, `scroll-up-half`, `focus-current`, `refresh`, `open-help`,
+  `next-tab`, `prev-tab`, `command-popup`, `quit`) that work the same in every
+  tab; the scroll ones also apply as defaults to the popups, which can override
+  them per-component
+- The help popup now lists the global keybindings alongside the main and details panel ones
 - Message popup now supports scrolling with a scrollbar
 - Command popup output now preserves ANSI color
 - Drag to resize pane divider in all tabs

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -11,10 +11,11 @@ save = false
 
 In below examples default values are used.
 
-### Top-level scroll bindings
+### Global
 
-These apply as defaults to all scroll-capable components and can be overridden
-in each component's own section.
+These work in every tab. The scroll bindings also apply as defaults to the
+popups, which can override them in their own section. Selecting a tab by its
+number in the tab bar (`1`, `2`, `3`) is not configurable.
 
 ```toml
 [blazingjj.keybinds]
@@ -22,11 +23,21 @@ scroll-down = ["j", "down"]
 scroll-up = ["k", "up"]
 scroll-down-half = "shift+j"
 scroll-up-half = "shift+k"
+
+focus-current = "@"
+refresh = ["shift+r", "f5"]
+open-help = "?"
+
+next-tab = "l"
+prev-tab = "h"
+
+command-popup = ":"
+quit = ["q", "ctrl+c", "esc"]
 ```
 
 ### Message popup
 
-Overrides top-level scroll bindings. `scroll-down-page` and `scroll-up-page`
+Overrides the global scroll bindings. `scroll-down-page` and `scroll-up-page`
 are only configurable here.
 
 ```toml
@@ -48,15 +59,8 @@ cancel = "esc"
 
 close-popup = "q"
 
-scroll-down = ["j", "down"]
-scroll-up = ["k", "up"]
-scroll-down-half = "shift+j"
-scroll-up-half = "shift+k"
-
-focus-current = "@"
 toggle-diff-format = "w"
 
-refresh = ["shift+r", "f5"]
 create-new = "n"
 create-new-describe = "shift+n"
 duplicate = "shift+d"
@@ -79,6 +83,4 @@ push-all = "shift+p"
 push-all-new = "ctrl+shift+p"
 fetch = "f"
 fetch-all = "shift+f"
-
-open-help = "?"
 ```

--- a/src/app.rs
+++ b/src/app.rs
@@ -9,7 +9,6 @@ use anyhow::Result;
 use anyhow::anyhow;
 use ratatui::crossterm::event::Event as TermEvent;
 use ratatui::crossterm::event::KeyCode;
-use ratatui::crossterm::event::KeyModifiers;
 use ratatui::crossterm::event::{self};
 use ratatui::layout::Constraint;
 use ratatui::layout::Direction;
@@ -27,11 +26,15 @@ use crate::commander::new_commander;
 use crate::env::get_env;
 use crate::event::AppEvent;
 use crate::event::EventSource;
+use crate::keybinds::GlobalEvent;
+use crate::keybinds::GlobalKeybinds;
 use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
+use crate::ui::Scroll;
 use crate::ui::bookmarks_tab::BookmarksTab;
 use crate::ui::dialog::CommandPopup;
+use crate::ui::dialog::HelpPopup;
 use crate::ui::files_tab::FilesTab;
 use crate::ui::log_tab::LogTab;
 
@@ -68,6 +71,7 @@ pub struct App<'a> {
     pub bookmarks: Option<BookmarksTab<'a>>,
     pub popup: Option<Box<dyn Component>>,
     pub stats: Stats,
+    global_keybinds: GlobalKeybinds,
 
     // event handling
     running: Arc<AtomicBool>,
@@ -78,6 +82,10 @@ impl<'a> App<'a> {
     pub fn new() -> Result<App<'a>> {
         let running = Arc::from(AtomicBool::new(true));
         let event_source = EventSource::new(running.clone());
+        let mut global_keybinds = GlobalKeybinds::default();
+        if let Some(keybinds_config) = get_env().jj_config.keybinds() {
+            global_keybinds.extend_from_config(keybinds_config);
+        }
         Ok(App {
             current_tab: Tab::Log,
             log: None,
@@ -87,6 +95,7 @@ impl<'a> App<'a> {
             stats: Stats {
                 start_time: Instant::now(),
             },
+            global_keybinds,
 
             running,
             event_source,
@@ -110,6 +119,18 @@ impl<'a> App<'a> {
             (current_index as i64 + Tab::VALUES.len() as i64 + offset) as usize % Tab::VALUES.len();
         let new_tab: Tab = Tab::VALUES[new_index];
         self.set_tab(new_tab)
+    }
+
+    fn open_help(&mut self) -> Result<()> {
+        let global_help = self.global_keybinds.make_help();
+        let tab = self.get_or_init_current_tab()?;
+        let popup = HelpPopup::new(
+            tab.make_main_panel_help(),
+            tab.make_details_panel_help(),
+            global_help,
+        );
+        self.popup = Some(Box::new(popup));
+        Ok(())
     }
 
     pub fn set_tab(&mut self, tab: Tab) -> Result<()> {
@@ -360,35 +381,43 @@ impl<'a> App<'a> {
                     if let TermEvent::Key(key) = event
                         && key.kind == event::KeyEventKind::Press
                     {
-                        // Close
-                        if key.code == KeyCode::Char('q')
-                            || (key.modifiers.contains(KeyModifiers::CONTROL)
-                                && (key.code == KeyCode::Char('c')))
-                            || key.code == KeyCode::Esc
-                        {
-                            self.running.store(false, Ordering::Relaxed);
-                            return Ok(true);
-                        }
-                        //
-                        // Tab switching
-                        else if key.code == KeyCode::Char('l') {
-                            self.set_next_tab_with_offset(1)?;
-                        } else if key.code == KeyCode::Char('h') {
-                            self.set_next_tab_with_offset(-1)?;
-                        } else if let Some((_, tab)) =
-                            Tab::VALUES.iter().enumerate().find(|(i, _)| {
-                                key.code
-                                    == KeyCode::Char(
-                                        char::from_digit((*i as u32) + 1u32, 10)
-                                            .expect("Tab index could not be converted to digit"),
-                                    )
-                            })
-                        {
-                            self.set_tab(*tab)?;
-                        }
-                        // General jj command runner
-                        else if key.code == KeyCode::Char(':') {
-                            self.popup = Some(Box::new(CommandPopup::new()));
+                        match self.global_keybinds.match_event(key) {
+                            GlobalEvent::ScrollDown => {
+                                self.get_or_init_current_tab()?
+                                    .scroll_main_panel(Scroll::Down)?;
+                            }
+                            GlobalEvent::ScrollUp => {
+                                self.get_or_init_current_tab()?
+                                    .scroll_main_panel(Scroll::Up)?;
+                            }
+                            GlobalEvent::ScrollDownHalf => {
+                                self.get_or_init_current_tab()?
+                                    .scroll_main_panel(Scroll::DownHalfPage)?;
+                            }
+                            GlobalEvent::ScrollUpHalf => {
+                                self.get_or_init_current_tab()?
+                                    .scroll_main_panel(Scroll::UpHalfPage)?;
+                            }
+                            GlobalEvent::FocusCurrent => {
+                                self.get_or_init_current_tab()?.focus_current()?;
+                            }
+                            GlobalEvent::Refresh => {
+                                self.get_or_init_current_tab()?.force_refresh()?;
+                            }
+                            GlobalEvent::NextTab => self.set_next_tab_with_offset(1)?,
+                            GlobalEvent::PrevTab => self.set_next_tab_with_offset(-1)?,
+                            GlobalEvent::LogTab => self.set_tab(Tab::Log)?,
+                            GlobalEvent::FilesTab => self.set_tab(Tab::Files)?,
+                            GlobalEvent::BookmarksTab => self.set_tab(Tab::Bookmarks)?,
+                            GlobalEvent::CommandPopup => {
+                                self.popup = Some(Box::new(CommandPopup::new()));
+                            }
+                            GlobalEvent::OpenHelp => self.open_help()?,
+                            GlobalEvent::Quit => {
+                                self.running.store(false, Ordering::Relaxed);
+                                return Ok(true);
+                            }
+                            GlobalEvent::Unbound => {}
                         }
                     }
                 }

--- a/src/keybinds/config.rs
+++ b/src/keybinds/config.rs
@@ -8,6 +8,16 @@ pub struct KeybindsConfig {
     pub scroll_down_half: Option<Keybind>,
     pub scroll_up_half: Option<Keybind>,
 
+    pub focus_current: Option<Keybind>,
+    pub refresh: Option<Keybind>,
+    pub open_help: Option<Keybind>,
+
+    pub next_tab: Option<Keybind>,
+    pub prev_tab: Option<Keybind>,
+
+    pub command_popup: Option<Keybind>,
+    pub quit: Option<Keybind>,
+
     pub log_tab: Option<LogTabKeybindsConfig>,
     pub message_popup: Option<MessagePopupKeybindsConfig>,
 }
@@ -39,15 +49,8 @@ pub struct LogTabKeybindsConfig {
 
     pub close_popup: Option<Keybind>,
 
-    pub scroll_down: Option<Keybind>,
-    pub scroll_up: Option<Keybind>,
-    pub scroll_down_half: Option<Keybind>,
-    pub scroll_up_half: Option<Keybind>,
-
-    pub focus_current: Option<Keybind>,
     pub toggle_diff_format: Option<Keybind>,
 
-    pub refresh: Option<Keybind>,
     pub duplicate: Option<Keybind>,
     pub create_new: Option<Keybind>,
     pub create_new_describe: Option<Keybind>,
@@ -71,6 +74,4 @@ pub struct LogTabKeybindsConfig {
     pub push_all_new: Option<Keybind>,
     pub fetch: Option<Keybind>,
     pub fetch_all: Option<Keybind>,
-
-    pub open_help: Option<Keybind>,
 }

--- a/src/keybinds/global.rs
+++ b/src/keybinds/global.rs
@@ -1,0 +1,278 @@
+use std::str::FromStr;
+
+use ratatui::crossterm::event::KeyEvent;
+
+use super::Shortcut;
+use super::config::KeybindsConfig;
+use super::keybinds_store::KeybindsStore;
+use crate::make_keybinds_help;
+use crate::set_keybinds;
+use crate::update_keybinds;
+
+#[derive(Debug)]
+pub struct GlobalKeybinds {
+    keys: KeybindsStore<GlobalEvent>,
+}
+
+/// Keys that mean the same thing in every tab.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum GlobalEvent {
+    ScrollDown,
+    ScrollUp,
+    ScrollDownHalf,
+    ScrollUpHalf,
+
+    FocusCurrent,
+    Refresh,
+
+    NextTab,
+    PrevTab,
+    // Not configurable: a tab is selected by its number in the tab bar.
+    LogTab,
+    FilesTab,
+    BookmarksTab,
+
+    CommandPopup,
+    OpenHelp,
+    Quit,
+
+    Unbound,
+}
+
+impl Default for GlobalKeybinds {
+    fn default() -> Self {
+        let mut keys = KeybindsStore::<GlobalEvent>::default();
+        set_keybinds!(
+            keys,
+            GlobalEvent::ScrollDown => "j",
+            GlobalEvent::ScrollDown => "down",
+            GlobalEvent::ScrollUp => "k",
+            GlobalEvent::ScrollUp => "up",
+            GlobalEvent::ScrollDownHalf => "shift+j",
+            GlobalEvent::ScrollUpHalf => "shift+k",
+            GlobalEvent::FocusCurrent => "@",
+            GlobalEvent::Refresh => "shift+r",
+            GlobalEvent::Refresh => "f5",
+            GlobalEvent::NextTab => "l",
+            GlobalEvent::PrevTab => "h",
+            GlobalEvent::LogTab => "1",
+            GlobalEvent::FilesTab => "2",
+            GlobalEvent::BookmarksTab => "3",
+            GlobalEvent::CommandPopup => ":",
+            GlobalEvent::OpenHelp => "?",
+            GlobalEvent::Quit => "q",
+            GlobalEvent::Quit => "ctrl+c",
+            GlobalEvent::Quit => "esc",
+        );
+        Self { keys }
+    }
+}
+
+impl GlobalKeybinds {
+    pub fn match_event(&self, event: KeyEvent) -> GlobalEvent {
+        self.keys.match_event(event).unwrap_or(GlobalEvent::Unbound)
+    }
+
+    pub fn extend_from_config(&mut self, config: &KeybindsConfig) {
+        update_keybinds!(
+            self.keys,
+            GlobalEvent::ScrollDown => config.scroll_down,
+            GlobalEvent::ScrollUp => config.scroll_up,
+            GlobalEvent::ScrollDownHalf => config.scroll_down_half,
+            GlobalEvent::ScrollUpHalf => config.scroll_up_half,
+            GlobalEvent::FocusCurrent => config.focus_current,
+            GlobalEvent::Refresh => config.refresh,
+            GlobalEvent::OpenHelp => config.open_help,
+            GlobalEvent::NextTab => config.next_tab,
+            GlobalEvent::PrevTab => config.prev_tab,
+            GlobalEvent::CommandPopup => config.command_popup,
+            GlobalEvent::Quit => config.quit,
+        );
+    }
+
+    pub fn make_help(&self) -> Vec<(String, String)> {
+        make_keybinds_help!(
+            self.keys,
+            GlobalEvent::ScrollDown => "scroll down",
+            GlobalEvent::ScrollUp => "scroll up",
+            GlobalEvent::ScrollDownHalf => "scroll down by ½ page",
+            GlobalEvent::ScrollUpHalf => "scroll up by ½ page",
+            GlobalEvent::FocusCurrent => "go to current change",
+            GlobalEvent::Refresh => "refresh",
+            GlobalEvent::NextTab => "next tab",
+            GlobalEvent::PrevTab => "previous tab",
+            GlobalEvent::LogTab => "log tab",
+            GlobalEvent::FilesTab => "files tab",
+            GlobalEvent::BookmarksTab => "bookmarks tab",
+            GlobalEvent::CommandPopup => "run jj command",
+            GlobalEvent::OpenHelp => "open help",
+            GlobalEvent::Quit => "quit",
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use ratatui::crossterm::event::KeyCode;
+    use ratatui::crossterm::event::KeyModifiers;
+
+    use super::*;
+    use crate::keybinds::Keybind;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::empty())
+    }
+
+    fn shift(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::SHIFT)
+    }
+
+    fn bind(shortcut: &str) -> Keybind {
+        Keybind::Single(Shortcut::from_str(shortcut).expect("shortcut should parse"))
+    }
+
+    #[test]
+    fn test_match_event_defaults() {
+        let keybinds = GlobalKeybinds::default();
+
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::Char('j'))),
+            GlobalEvent::ScrollDown
+        );
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::Down)),
+            GlobalEvent::ScrollDown
+        );
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::Char('@'))),
+            GlobalEvent::FocusCurrent
+        );
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::F(5))),
+            GlobalEvent::Refresh
+        );
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::Char('2'))),
+            GlobalEvent::FilesTab
+        );
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::Char(':'))),
+            GlobalEvent::CommandPopup
+        );
+        assert_eq!(
+            keybinds.match_event(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL)),
+            GlobalEvent::Quit
+        );
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::Char('z'))),
+            GlobalEvent::Unbound
+        );
+    }
+
+    #[test]
+    fn test_shifted_keys_are_distinct() {
+        let keybinds = GlobalKeybinds::default();
+
+        // Terminals report a shifted character in upper case, which the store
+        // normalizes, so the two must still end up as different events.
+        assert_eq!(
+            keybinds.match_event(shift(KeyCode::Char('J'))),
+            GlobalEvent::ScrollDownHalf
+        );
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::Char('j'))),
+            GlobalEvent::ScrollDown
+        );
+    }
+
+    #[test]
+    fn test_extend_from_config_replaces_bindings() {
+        let config = KeybindsConfig {
+            refresh: Some(bind("ctrl+r")),
+            quit: Some(bind("x")),
+            command_popup: Some(bind("ctrl+p")),
+            prev_tab: Some(bind("pageup")),
+            ..Default::default()
+        };
+
+        let mut keybinds = GlobalKeybinds::default();
+        keybinds.extend_from_config(&config);
+
+        // A replaced binding drops every default shortcut for its event.
+        assert_eq!(
+            keybinds.match_event(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL)),
+            GlobalEvent::Refresh
+        );
+        assert_eq!(
+            keybinds.match_event(shift(KeyCode::Char('R'))),
+            GlobalEvent::Unbound
+        );
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::F(5))),
+            GlobalEvent::Unbound
+        );
+
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::Char('x'))),
+            GlobalEvent::Quit
+        );
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::Char('q'))),
+            GlobalEvent::Unbound
+        );
+
+        assert_eq!(
+            keybinds.match_event(KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL)),
+            GlobalEvent::CommandPopup
+        );
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::PageUp)),
+            GlobalEvent::PrevTab
+        );
+
+        // Anything the config leaves out keeps its default.
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::Char('l'))),
+            GlobalEvent::NextTab
+        );
+    }
+
+    #[test]
+    fn test_extend_from_config_disables_bindings() {
+        let config = KeybindsConfig {
+            open_help: Some(Keybind::Enable(false)),
+            ..Default::default()
+        };
+
+        let mut keybinds = GlobalKeybinds::default();
+        keybinds.extend_from_config(&config);
+
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::Char('?'))),
+            GlobalEvent::Unbound
+        );
+        assert!(
+            keybinds
+                .make_help()
+                .contains(&("[disabled]".to_owned(), "open help".to_owned()))
+        );
+    }
+
+    #[test]
+    fn test_make_help_lists_every_default_binding() {
+        let help = GlobalKeybinds::default().make_help();
+
+        assert!(help.iter().all(|(keys, _)| keys != "[disabled]"));
+        let (keys, _) = help
+            .iter()
+            .find(|(_, desc)| desc == "refresh")
+            .expect("refresh should be listed");
+        // `get_shortcuts()` returns them in hash order.
+        assert_eq!(
+            keys.split('/').collect::<HashSet<_>>(),
+            HashSet::from(["Shift+r", "F5"])
+        );
+    }
+}

--- a/src/keybinds/log_tab.rs
+++ b/src/keybinds/log_tab.rs
@@ -23,18 +23,12 @@ pub enum LogTabEvent {
 
     ClosePopup,
 
-    ScrollDown,
-    ScrollUp,
-    ScrollDownHalf,
-    ScrollUpHalf,
     ScrollToBottom,
     ScrollToTop,
 
-    FocusCurrent,
     ToggleHeadMark,
     ToggleDiffFormat,
 
-    Refresh,
     CreateNew {
         describe: bool,
     },
@@ -63,8 +57,6 @@ pub enum LogTabEvent {
         all_remotes: bool,
     },
 
-    OpenHelp,
-
     Unbound,
 }
 
@@ -76,20 +68,11 @@ impl Default for LogTabKeybinds {
             LogTabEvent::Save => "ctrl+s",
             LogTabEvent::Cancel => "esc",
             LogTabEvent::ClosePopup => "q",
-            LogTabEvent::ScrollDown => "j",
-            LogTabEvent::ScrollDown => "down",
-            LogTabEvent::ScrollUp => "k",
-            LogTabEvent::ScrollUp => "up",
-            LogTabEvent::ScrollDownHalf => "shift+j",
-            LogTabEvent::ScrollUpHalf => "shift+k",
             LogTabEvent::ScrollToBottom => "ctrl+end",
             LogTabEvent::ScrollToTop => "ctrl+home",
-            LogTabEvent::FocusCurrent => "@",
             LogTabEvent::ToggleHeadMark => "space",
             // todo: move to DetailsKeybindings
             LogTabEvent::ToggleDiffFormat => "w",
-            LogTabEvent::Refresh => "shift+r",
-            LogTabEvent::Refresh => "f5",
             LogTabEvent::Duplicate => "shift+d",
             LogTabEvent::CreateNew { describe: false } => "n",
             LogTabEvent::CreateNew { describe: true } => "shift+n",
@@ -112,7 +95,6 @@ impl Default for LogTabKeybinds {
             event_push(true, true) => "ctrl+shift+p",
             LogTabEvent::Fetch { all_remotes: false } => "f",
             LogTabEvent::Fetch { all_remotes: true } => "shift+f",
-            LogTabEvent::OpenHelp => "?",
         );
 
         Self { keys }
@@ -128,13 +110,6 @@ impl LogTabKeybinds {
         }
     }
     pub fn extend_from_config(&mut self, config: &KeybindsConfig) {
-        update_keybinds!(
-            self.keys,
-            LogTabEvent::ScrollDown => config.scroll_down,
-            LogTabEvent::ScrollUp => config.scroll_up,
-            LogTabEvent::ScrollDownHalf => config.scroll_down_half,
-            LogTabEvent::ScrollUpHalf => config.scroll_up_half,
-        );
         if let Some(ref log_tab) = config.log_tab {
             self.extend_from_log_tab_config(log_tab);
         }
@@ -146,13 +121,7 @@ impl LogTabKeybinds {
             LogTabEvent::Save => config.save,
             LogTabEvent::Cancel => config.cancel,
             LogTabEvent::ClosePopup => config.close_popup,
-            LogTabEvent::ScrollDown => config.scroll_down,
-            LogTabEvent::ScrollUp => config.scroll_up,
-            LogTabEvent::ScrollDownHalf => config.scroll_down_half,
-            LogTabEvent::ScrollUpHalf => config.scroll_up_half,
-            LogTabEvent::FocusCurrent => config.focus_current,
             LogTabEvent::ToggleDiffFormat => config.toggle_diff_format,
-            LogTabEvent::Refresh => config.refresh,
             LogTabEvent::Duplicate => config.duplicate,
             LogTabEvent::CreateNew { describe: false } => config.create_new,
             LogTabEvent::CreateNew { describe: true } => config.create_new_describe,
@@ -175,18 +144,12 @@ impl LogTabKeybinds {
             event_push(true, true) => config.push_all_new,
             LogTabEvent::Fetch { all_remotes: false } => config.fetch,
             LogTabEvent::Fetch { all_remotes: true } => config.fetch_all,
-            LogTabEvent::OpenHelp => config.open_help,
         );
     }
     pub fn make_main_panel_help(&self) -> Vec<(String, String)> {
         make_keybinds_help!(
             self.keys,
-            LogTabEvent::ScrollDown => "scroll down",
-            LogTabEvent::ScrollUp => "scroll up",
-            LogTabEvent::ScrollDownHalf => "scroll down by ½ page",
-            LogTabEvent::ScrollUpHalf => "scroll up by ½ page",
             LogTabEvent::OpenFiles => "see files",
-            LogTabEvent::FocusCurrent => "current change",
             LogTabEvent::EditRevset => "set revset",
             LogTabEvent::Describe => "describe change",
             LogTabEvent::Duplicate => "duplicate change",

--- a/src/keybinds/mod.rs
+++ b/src/keybinds/mod.rs
@@ -3,6 +3,8 @@ use std::str::FromStr;
 
 pub use config::Keybind;
 pub use config::KeybindsConfig;
+pub use global::GlobalEvent;
+pub use global::GlobalKeybinds;
 pub use log_tab::LogTabEvent;
 pub use log_tab::LogTabKeybinds;
 pub use message_popup::MessagePopupEvent;
@@ -12,6 +14,7 @@ use ratatui::crossterm::event::KeyEvent;
 use ratatui::crossterm::event::KeyModifiers;
 
 mod config;
+mod global;
 mod keybinds_store;
 mod log_tab;
 mod message_popup;

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -26,7 +26,7 @@ use crate::env::get_env;
 use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
-use crate::ui::dialog::HelpPopup;
+use crate::ui::Scroll;
 use crate::ui::dialog::MessagePopup;
 use crate::ui::panel::DetailsPanel;
 use crate::ui::panel::TextContent;
@@ -239,6 +239,47 @@ impl Component for BookmarksTab<'_> {
         self.refresh_bookmarks();
         self.refresh_bookmark();
         Ok(())
+    }
+
+    fn scroll_main_panel(&mut self, scroll: Scroll) -> Result<()> {
+        let half_page = self.bookmarks_height as isize / 2;
+        self.scroll_bookmarks(match scroll {
+            Scroll::Down => 1,
+            Scroll::Up => -1,
+            Scroll::DownHalfPage => half_page,
+            Scroll::UpHalfPage => half_page.saturating_neg(),
+        });
+        Ok(())
+    }
+
+    fn make_main_panel_help(&self) -> Vec<(String, String)> {
+        vec![
+            ("a".to_owned(), "show all remotes".to_owned()),
+            ("c".to_owned(), "create bookmark".to_owned()),
+            ("r".to_owned(), "rename bookmark".to_owned()),
+            ("d/f".to_owned(), "delete/forget bookmark".to_owned()),
+            ("t/T".to_owned(), "track/untrack bookmark".to_owned()),
+            ("Enter".to_owned(), "view in log".to_owned()),
+            ("n".to_owned(), "new from bookmark".to_owned()),
+            ("N".to_owned(), "new and describe".to_owned()),
+            ("e".to_owned(), "edit bookmark".to_owned()),
+        ]
+    }
+
+    fn make_details_panel_help(&self) -> Vec<(String, String)> {
+        vec![
+            ("Ctrl+e/Ctrl+y".to_owned(), "scroll down/up".to_owned()),
+            (
+                "Ctrl+d/Ctrl+u".to_owned(),
+                "scroll down/up by ½ page".to_owned(),
+            ),
+            (
+                "Ctrl+f/Ctrl+b".to_owned(),
+                "scroll down/up by page".to_owned(),
+            ),
+            ("w".to_owned(), "toggle diff format".to_owned()),
+            ("W".to_owned(), "toggle wrapping".to_owned()),
+        ]
     }
 
     fn update(&mut self) -> Result<Option<AppAction>> {
@@ -771,20 +812,8 @@ impl Component for BookmarksTab<'_> {
             }
 
             match key.code {
-                KeyCode::Char('j') | KeyCode::Down => self.scroll_bookmarks(1),
-                KeyCode::Char('k') | KeyCode::Up => self.scroll_bookmarks(-1),
-                KeyCode::Char('J') => {
-                    self.scroll_bookmarks(self.bookmarks_height as isize / 2);
-                }
-                KeyCode::Char('K') => {
-                    self.scroll_bookmarks((self.bookmarks_height as isize / 2).saturating_neg());
-                }
                 KeyCode::Char('w') => {
                     self.diff_format = self.diff_format.get_next(self.config.diff_tool());
-                    self.refresh_bookmark();
-                }
-                KeyCode::Char('R') | KeyCode::F(5) => {
-                    self.refresh_bookmarks();
                     self.refresh_bookmark();
                 }
                 KeyCode::Char('a') => {
@@ -933,38 +962,6 @@ impl Component for BookmarksTab<'_> {
                             new_commander().get_bookmark_head(bookmark)?,
                         )));
                     }
-                }
-                KeyCode::Char('?') => {
-                    return Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
-                        Box::new(HelpPopup::new(
-                            vec![
-                                ("j/k".to_owned(), "scroll down/up".to_owned()),
-                                ("J/K".to_owned(), "scroll down by ½ page".to_owned()),
-                                ("a".to_owned(), "show all remotes".to_owned()),
-                                ("c".to_owned(), "create bookmark".to_owned()),
-                                ("r".to_owned(), "rename bookmark".to_owned()),
-                                ("d/f".to_owned(), "delete/forget bookmark".to_owned()),
-                                ("t/T".to_owned(), "track/untrack bookmark".to_owned()),
-                                ("Enter".to_owned(), "view in log".to_owned()),
-                                ("n".to_owned(), "new from bookmark".to_owned()),
-                                ("N".to_owned(), "new and describe".to_owned()),
-                                ("e".to_owned(), "edit bookmark".to_owned()),
-                            ],
-                            vec![
-                                ("Ctrl+e/Ctrl+y".to_owned(), "scroll down/up".to_owned()),
-                                (
-                                    "Ctrl+d/Ctrl+u".to_owned(),
-                                    "scroll down/up by ½ page".to_owned(),
-                                ),
-                                (
-                                    "Ctrl+f/Ctrl+b".to_owned(),
-                                    "scroll down/up by page".to_owned(),
-                                ),
-                                ("w".to_owned(), "toggle diff format".to_owned()),
-                                ("W".to_owned(), "toggle wrapping".to_owned()),
-                            ],
-                        )),
-                    )));
                 }
                 _ => return Ok(ComponentInputResult::NotHandled),
             };

--- a/src/ui/dialog/help.rs
+++ b/src/ui/dialog/help.rs
@@ -4,6 +4,7 @@ use ratatui::crossterm::event::{self};
 use ratatui::layout::Constraint;
 use ratatui::layout::Direction;
 use ratatui::layout::Layout;
+use ratatui::layout::Rect;
 use ratatui::style::Stylize;
 use ratatui::text::Span;
 use ratatui::widgets::Block;
@@ -16,19 +17,36 @@ use crate::ui::ComponentInputResult;
 use crate::ui::styles::create_popup_block;
 use crate::ui::utils::centered_rect;
 
+/// How far the tables have to scroll for the last item of the longest one to
+/// come into view.
+fn max_scroll(tables: [(usize, Rect); 3]) -> usize {
+    tables
+        .into_iter()
+        // A table spends its first row on its title.
+        .map(|(items, area)| items.saturating_sub(area.height.saturating_sub(1) as usize))
+        .max()
+        .unwrap_or(0)
+}
+
 pub struct HelpPopup {
-    pub left_items: Vec<(String, String)>,
-    pub right_items: Vec<(String, String)>,
-    height: u16,
+    pub main_items: Vec<(String, String)>,
+    pub details_items: Vec<(String, String)>,
+    pub global_items: Vec<(String, String)>,
+    max_scroll: usize,
     scroll: usize,
 }
 
 impl HelpPopup {
-    pub fn new(left_items: Vec<(String, String)>, right_items: Vec<(String, String)>) -> Self {
+    pub fn new(
+        main_items: Vec<(String, String)>,
+        details_items: Vec<(String, String)>,
+        global_items: Vec<(String, String)>,
+    ) -> Self {
         Self {
-            left_items,
-            right_items,
-            height: 0,
+            main_items,
+            details_items,
+            global_items,
+            max_scroll: 0,
             // Can't use TableState as it's broken: https://github.com/ratatui-org/ratatui/issues/1179
             scroll: 0,
         }
@@ -62,7 +80,6 @@ impl Component for HelpPopup {
 
         let block = create_popup_block("Help");
         let block_inner = block.inner(area);
-        self.height = block_inner.height;
         f.render_widget(&block, area);
 
         let chunks = Layout::default()
@@ -74,13 +91,33 @@ impl Component for HelpPopup {
             ])
             .split(block_inner);
 
+        let right_chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(self.details_items.len() as u16 + 1),
+                Constraint::Length(1),
+                Constraint::Fill(1),
+            ])
+            .split(chunks[2]);
+
+        self.max_scroll = max_scroll([
+            (self.main_items.len(), chunks[0]),
+            (self.details_items.len(), right_chunks[0]),
+            (self.global_items.len(), right_chunks[2]),
+        ]);
+        self.scroll = self.scroll.min(self.max_scroll);
+
         f.render_widget(
-            self.create_table(&self.left_items, "Main panel".into()),
+            self.create_table(&self.main_items, "Main panel".into()),
             chunks[0],
         );
         f.render_widget(
-            self.create_table(&self.right_items, "Details panel".into()),
-            chunks[2],
+            self.create_table(&self.details_items, "Details panel".into()),
+            right_chunks[0],
+        );
+        f.render_widget(
+            self.create_table(&self.global_items, "Global".into()),
+            right_chunks[2],
         );
 
         Ok(())
@@ -91,10 +128,7 @@ impl Component for HelpPopup {
             && key.kind == event::KeyEventKind::Press
         {
             match key.code {
-                KeyCode::Char('j') => {
-                    let max = self.left_items.len().max(self.right_items.len());
-                    self.scroll = (self.scroll + 1).min(max.saturating_sub(self.height as usize));
-                }
+                KeyCode::Char('j') => self.scroll = (self.scroll + 1).min(self.max_scroll),
                 KeyCode::Char('k') => self.scroll = self.scroll.saturating_sub(1),
                 _ => return Ok(ComponentInputResult::NotHandled),
             }
@@ -103,5 +137,47 @@ impl Component for HelpPopup {
         }
 
         Ok(ComponentInputResult::NotHandled)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn area(height: u16) -> Rect {
+        Rect::new(0, 0, 40, height)
+    }
+
+    #[test]
+    fn test_no_scroll_when_every_table_fits() {
+        assert_eq!(max_scroll([(3, area(10)), (5, area(6)), (14, area(15))]), 0);
+    }
+
+    #[test]
+    fn test_scroll_follows_the_table_that_overflows_most() {
+        // The global list is 14 items in 9 rows, one of which holds its title.
+        assert_eq!(max_scroll([(3, area(22)), (5, area(6)), (14, area(9))]), 6);
+        // The main panel overflows further than the global list does.
+        assert_eq!(max_scroll([(30, area(22)), (5, area(6)), (14, area(9))]), 9);
+    }
+
+    #[test]
+    fn test_scroll_is_clamped_to_max() {
+        let mut popup = HelpPopup::new(vec![], vec![], vec![]);
+        popup.max_scroll = 2;
+
+        for _ in 0..5 {
+            popup
+                .input(Event::Key(KeyCode::Char('j').into()))
+                .expect("scrolling down should be handled");
+        }
+        assert_eq!(popup.scroll, 2);
+
+        for _ in 0..5 {
+            popup
+                .input(Event::Key(KeyCode::Char('k').into()))
+                .expect("scrolling up should be handled");
+        }
+        assert_eq!(popup.scroll, 0);
     }
 }

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -20,7 +20,7 @@ use crate::env::get_env;
 use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
-use crate::ui::dialog::HelpPopup;
+use crate::ui::Scroll;
 use crate::ui::dialog::MessagePopup;
 use crate::ui::panel::DetailsPanel;
 use crate::ui::panel::TextContent;
@@ -202,6 +202,43 @@ impl Component for FilesTab {
         Ok(())
     }
 
+    fn scroll_main_panel(&mut self, scroll: Scroll) -> Result<()> {
+        let half_page = self.files_height as isize / 2;
+        self.scroll_files(match scroll {
+            Scroll::Down => 1,
+            Scroll::Up => -1,
+            Scroll::DownHalfPage => half_page,
+            Scroll::UpHalfPage => half_page.saturating_neg(),
+        })
+    }
+
+    fn focus_current(&mut self) -> Result<()> {
+        self.set_head(&new_commander().get_current_head()?)
+    }
+
+    fn make_main_panel_help(&self) -> Vec<(String, String)> {
+        vec![
+            ("x".to_owned(), "untrack file".to_owned()),
+            ("r".to_owned(), "restore file".to_owned()),
+        ]
+    }
+
+    fn make_details_panel_help(&self) -> Vec<(String, String)> {
+        vec![
+            ("Ctrl+e/Ctrl+y".to_owned(), "scroll down/up".to_owned()),
+            (
+                "Ctrl+d/Ctrl+u".to_owned(),
+                "scroll down/up by ½ page".to_owned(),
+            ),
+            (
+                "Ctrl+f/Ctrl+b".to_owned(),
+                "scroll down/up by page".to_owned(),
+            ),
+            ("w".to_owned(), "toggle diff format".to_owned()),
+            ("W".to_owned(), "toggle wrapping".to_owned()),
+        ]
+    }
+
     fn draw(
         &mut self,
         f: &mut ratatui::prelude::Frame<'_>,
@@ -339,14 +376,6 @@ impl Component for FilesTab {
             }
 
             match key.code {
-                KeyCode::Char('j') | KeyCode::Down => self.scroll_files(1)?,
-                KeyCode::Char('k') | KeyCode::Up => self.scroll_files(-1)?,
-                KeyCode::Char('J') => {
-                    self.scroll_files(self.files_height as isize / 2)?;
-                }
-                KeyCode::Char('K') => {
-                    self.scroll_files((self.files_height as isize / 2).saturating_neg())?;
-                }
                 KeyCode::Char('w') => {
                     self.diff_format = self.diff_format.get_next(self.config.diff_tool());
                     self.refresh_diff()?;
@@ -370,41 +399,6 @@ impl Component for FilesTab {
                         )));
                     }
                     self.set_head(&new_commander().get_current_head()?)?;
-                }
-                KeyCode::Char('R') | KeyCode::F(5) => {
-                    self.head = new_commander().get_head_latest(&self.head)?;
-                    self.refresh_files()?;
-                    self.refresh_diff()?;
-                }
-                KeyCode::Char('@') => {
-                    let head = &new_commander().get_current_head()?;
-                    self.set_head(head)?;
-                }
-                KeyCode::Char('?') => {
-                    return Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
-                        Box::new(HelpPopup::new(
-                            vec![
-                                ("j/k".to_owned(), "scroll down/up".to_owned()),
-                                ("J/K".to_owned(), "scroll down by ½ page".to_owned()),
-                                ("x".to_owned(), "untrack file".to_owned()),
-                                ("r".to_owned(), "restore file".to_owned()),
-                                ("@".to_owned(), "view current change files".to_owned()),
-                            ],
-                            vec![
-                                ("Ctrl+e/Ctrl+y".to_owned(), "scroll down/up".to_owned()),
-                                (
-                                    "Ctrl+d/Ctrl+u".to_owned(),
-                                    "scroll down/up by ½ page".to_owned(),
-                                ),
-                                (
-                                    "Ctrl+f/Ctrl+b".to_owned(),
-                                    "scroll down/up by page".to_owned(),
-                                ),
-                                ("w".to_owned(), "toggle diff format".to_owned()),
-                                ("W".to_owned(), "toggle wrapping".to_owned()),
-                            ],
-                        )),
-                    )));
                 }
                 _ => return Ok(ComponentInputResult::NotHandled),
             };

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -38,11 +38,11 @@ use crate::keybinds::LogTabKeybinds;
 use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
+use crate::ui::Scroll;
 use crate::ui::commit_show_cache::CommitShowCache;
 use crate::ui::commit_show_cache::CommitShowKey;
 use crate::ui::commit_show_cache::CommitShowValue;
 use crate::ui::dialog::BookmarkSetPopup;
-use crate::ui::dialog::HelpPopup;
 use crate::ui::dialog::LoaderPopup;
 use crate::ui::dialog::MessagePopup;
 use crate::ui::dialog::RebasePopup;
@@ -537,28 +537,16 @@ impl<'a> LogTab<'a> {
 
     fn handle_event(&mut self, log_tab_event: LogTabEvent) -> Result<ComponentInputResult> {
         match log_tab_event {
-            LogTabEvent::ScrollDown
-            | LogTabEvent::ScrollUp
-            | LogTabEvent::ScrollDownHalf
-            | LogTabEvent::ScrollUpHalf
-            | LogTabEvent::ScrollToBottom
+            LogTabEvent::ScrollToBottom
             | LogTabEvent::ScrollToTop
             | LogTabEvent::ToggleHeadMark => {
                 self.log_panel.handle_event(log_tab_event)?;
                 self.sync_head_output();
             }
-            LogTabEvent::FocusCurrent => {
-                self.set_head(new_commander().get_current_head()?);
-            }
             LogTabEvent::ToggleDiffFormat => {
                 self.diff_format = self.diff_format.get_next(self.config.diff_tool());
                 self.refresh_head_output();
             }
-            LogTabEvent::Refresh => {
-                self.mark_cache_as_dirty();
-                self.refresh_log_output();
-            }
-
             LogTabEvent::Duplicate => {
                 let _ = new_commander().run_duplicate(&self.head.change_id.to_string());
                 self.refresh_log_output();
@@ -757,26 +745,6 @@ impl<'a> LogTab<'a> {
                     Box::new(loader),
                 )));
             }
-            LogTabEvent::OpenHelp => {
-                return Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
-                    Box::new(HelpPopup::new(
-                        self.keybinds.make_main_panel_help(),
-                        vec![
-                            ("Ctrl+e/Ctrl+y".to_owned(), "scroll down/up".to_owned()),
-                            (
-                                "Ctrl+d/Ctrl+u".to_owned(),
-                                "scroll down/up by ½ page".to_owned(),
-                            ),
-                            (
-                                "Ctrl+f/Ctrl+b".to_owned(),
-                                "scroll down/up by page".to_owned(),
-                            ),
-                            ("w".to_owned(), "toggle diff format".to_owned()),
-                            ("W".to_owned(), "toggle wrapping".to_owned()),
-                        ],
-                    )),
-                )));
-            }
             LogTabEvent::Save
             | LogTabEvent::Cancel
             | LogTabEvent::ClosePopup
@@ -791,6 +759,48 @@ impl Component for LogTab<'_> {
         let latest_head = new_commander().get_head_latest(&self.head)?;
         self.set_head(latest_head);
         Ok(())
+    }
+
+    fn force_refresh(&mut self) -> Result<()> {
+        self.mark_cache_as_dirty();
+        self.refresh()
+    }
+
+    fn scroll_main_panel(&mut self, scroll: Scroll) -> Result<()> {
+        let half_page = self.log_panel.visible_heads() as isize / 2;
+        self.log_panel.scroll_relative(match scroll {
+            Scroll::Down => 1,
+            Scroll::Up => -1,
+            Scroll::DownHalfPage => half_page,
+            Scroll::UpHalfPage => half_page.saturating_neg(),
+        });
+        self.sync_head_output();
+        Ok(())
+    }
+
+    fn focus_current(&mut self) -> Result<()> {
+        self.set_head(new_commander().get_current_head()?);
+        Ok(())
+    }
+
+    fn make_main_panel_help(&self) -> Vec<(String, String)> {
+        self.keybinds.make_main_panel_help()
+    }
+
+    fn make_details_panel_help(&self) -> Vec<(String, String)> {
+        vec![
+            ("Ctrl+e/Ctrl+y".to_owned(), "scroll down/up".to_owned()),
+            (
+                "Ctrl+d/Ctrl+u".to_owned(),
+                "scroll down/up by ½ page".to_owned(),
+            ),
+            (
+                "Ctrl+f/Ctrl+b".to_owned(),
+                "scroll down/up by page".to_owned(),
+            ),
+            ("w".to_owned(), "toggle diff format".to_owned()),
+            ("W".to_owned(), "toggle wrapping".to_owned()),
+        ]
     }
 
     fn update(&mut self) -> Result<Option<AppAction>> {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -50,10 +50,45 @@ impl ComponentInputResult {
         }
     }
 }
+
+/// How far to move the selection in a tab's main panel.
+#[derive(Debug, Clone, Copy)]
+pub enum Scroll {
+    Down,
+    Up,
+    DownHalfPage,
+    UpHalfPage,
+}
+
 pub trait Component {
     /// Read whatever this component shows afresh from the repo.
     fn refresh(&mut self) -> Result<()> {
         Ok(())
+    }
+
+    /// Read afresh on the user's request, discarding anything cached.
+    fn force_refresh(&mut self) -> Result<()> {
+        self.refresh()
+    }
+
+    /// Move the selection in the main panel.
+    fn scroll_main_panel(&mut self, _scroll: Scroll) -> Result<()> {
+        Ok(())
+    }
+
+    /// Show the change the working copy is on.
+    fn focus_current(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    /// Keybindings of the main panel, for the help popup.
+    fn make_main_panel_help(&self) -> Vec<(String, String)> {
+        vec![]
+    }
+
+    /// Keybindings of the details panel, for the help popup.
+    fn make_details_panel_help(&self) -> Vec<(String, String)> {
+        vec![]
     }
 
     fn update(&mut self) -> Result<Option<AppAction>> {

--- a/src/ui/panel/log_panel.rs
+++ b/src/ui/panel/log_panel.rs
@@ -249,7 +249,7 @@ impl<'a> LogPanel<'a> {
     /// Number of log list items that fit on screen. Think of this as
     /// in unit head-index. Moving the head-index this much causes a
     /// full page scroll.
-    fn visible_heads(&self) -> u16 {
+    pub fn visible_heads(&self) -> u16 {
         // Every item in the log list is 2 lines high, so divide screen rows
         // by 2 to get the number of log items that fit in it.
         self.log_rect.height / 2
@@ -264,7 +264,7 @@ impl<'a> LogPanel<'a> {
     /// Move selection relative to the current position.
     /// The scroll is relative to head-index, not line-index.
     /// This will update self.head
-    fn scroll_relative(&mut self, scroll: isize) {
+    pub fn scroll_relative(&mut self, scroll: isize) {
         let log_output = match self.log_output.as_ref() {
             Ok(log_output) => log_output,
             Err(_) => return,
@@ -322,18 +322,6 @@ impl<'a> LogPanel<'a> {
 
     pub fn handle_event(&mut self, log_tab_event: LogTabEvent) -> Result<ComponentInputResult> {
         match log_tab_event {
-            LogTabEvent::ScrollDown => {
-                self.scroll_relative(1);
-            }
-            LogTabEvent::ScrollUp => {
-                self.scroll_relative(-1);
-            }
-            LogTabEvent::ScrollDownHalf => {
-                self.scroll_relative(self.visible_heads() as isize / 2);
-            }
-            LogTabEvent::ScrollUpHalf => {
-                self.scroll_relative((self.visible_heads() as isize / 2).saturating_neg());
-            }
             LogTabEvent::ScrollToBottom => {
                 self.scroll_relative(isize::MAX);
             }
@@ -406,11 +394,11 @@ impl Component for LogPanel<'_> {
             // Execute command dependent on panel and event kind
             match mouse_event.kind {
                 MouseEventKind::ScrollUp => {
-                    self.handle_event(LogTabEvent::ScrollUp)?;
+                    self.scroll_relative(-1);
                     return Ok(ComponentInputResult::Handled);
                 }
                 MouseEventKind::ScrollDown => {
-                    self.handle_event(LogTabEvent::ScrollDown)?;
+                    self.scroll_relative(1);
                     return Ok(ComponentInputResult::Handled);
                 }
                 MouseEventKind::Up(_) => {


### PR DESCRIPTION
Quitting, switching tabs and opening the command popup are matched on raw key codes in the app, while refreshing, scrolling the main panel, jumping to the current change and opening the help are repeated in every tab, each with its own hand-written help text and, for the log tab, its own config keys. Collecting them in a GlobalKeybinds layer that the app matches once the current tab has declined a key leaves a single definition, moves `focus-current`, `refresh` and `open-help` to the top-level keybinds config, and gives the help popup a section of its own to list them in. The tabs still do the work, but through Component hooks that the app calls. The log tab's refresh also drops the cached commit contents, which a refresh on tab switch has no reason to do, so that stays behind a separate force_refresh() hook.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
