### PR TITLE
Drop the unit tuple on AppAction::RefreshTab

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -216,7 +216,7 @@ impl<'a> App<'a> {
             }
             AppAction::PopupDone => {
                 self.popup = None;
-                self.handle_action(AppAction::RefreshTab())?;
+                self.handle_action(AppAction::RefreshTab)?;
             }
             AppAction::PopupCanceled => {
                 self.popup = None;
@@ -226,7 +226,7 @@ impl<'a> App<'a> {
                     self.handle_action(app_action)?;
                 }
             }
-            AppAction::RefreshTab() => {
+            AppAction::RefreshTab => {
                 self.set_tab(self.current_tab)?;
             }
         }

--- a/src/ui/dialog/command.rs
+++ b/src/ui/dialog/command.rs
@@ -116,7 +116,7 @@ impl Component for CommandPopup<'_> {
                                 MessagePopup::new(format!("jj {command_input}"), output_str)
                                     .text_align(Alignment::Left),
                             )),
-                            AppAction::RefreshTab(),
+                            AppAction::RefreshTab,
                         ],
                     )));
                 }

--- a/src/ui/dialog/loader.rs
+++ b/src/ui/dialog/loader.rs
@@ -83,7 +83,7 @@ impl Component for LoaderPopup {
                     format!("{} message", self.operation_name),
                     output,
                 ))),
-                AppAction::RefreshTab(),
+                AppAction::RefreshTab,
             ]),
             Ok(_) => AppAction::PopupDone,
             Err(err) => AppAction::SetPopup(Box::new(MessagePopup::new(

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -1036,7 +1036,7 @@ impl Component for LogTab<'_> {
                 // when handle_input returns true,
                 // the popup should be closed
                 self.rebase_popup = None;
-                return Ok(ComponentInputResult::HandledAction(AppAction::RefreshTab()));
+                return Ok(ComponentInputResult::HandledAction(AppAction::RefreshTab));
             }
             return Ok(ComponentInputResult::Handled);
         }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -27,7 +27,7 @@ pub enum AppAction {
     /// Take the popup down, nothing having been done.
     PopupCanceled,
     Multiple(Vec<AppAction>),
-    RefreshTab(),
+    RefreshTab,
 }
 
 /// When a Component process an input event, it returns an ComponentInputResult


### PR DESCRIPTION
That's just noise. Be gone.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
