### PR TITLE
Leave the read a refresh asks for to the app

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -402,7 +402,8 @@ impl<'a> App<'a> {
                                 self.get_or_init_current_tab()?.focus_current()?;
                             }
                             GlobalEvent::Refresh => {
-                                self.get_or_init_current_tab()?.force_refresh()?;
+                                self.get_or_init_current_tab()?.drop_caches();
+                                self.handle_action(AppAction::RefreshTab)?;
                             }
                             GlobalEvent::NextTab => self.set_next_tab_with_offset(1)?,
                             GlobalEvent::PrevTab => self.set_next_tab_with_offset(-1)?,

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -761,9 +761,8 @@ impl Component for LogTab<'_> {
         Ok(())
     }
 
-    fn force_refresh(&mut self) -> Result<()> {
+    fn drop_caches(&mut self) {
         self.mark_cache_as_dirty();
-        self.refresh()
     }
 
     fn scroll_main_panel(&mut self, scroll: Scroll) -> Result<()> {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -66,10 +66,9 @@ pub trait Component {
         Ok(())
     }
 
-    /// Read afresh on the user's request, discarding anything cached.
-    fn force_refresh(&mut self) -> Result<()> {
-        self.refresh()
-    }
+    /// Discard whatever this component has cached, so that the next read
+    /// goes to the repo.
+    fn drop_caches(&mut self) {}
 
     /// Move the selection in the main panel.
     fn scroll_main_panel(&mut self, _scroll: Scroll) -> Result<()> {


### PR DESCRIPTION
The refresh key goes straight to the tab through force_refresh(), which drops what the tab has cached and reads it afresh, while every other re-read goes through AppAction::RefreshTab. That leaves the app with no way to tell that a refresh was asked for, which is what picking up work done outside the app will want to know. Route the key through the action too, leaving the tab only the cache drop, as the app knows nothing about that. What the action does is unchanged, so the tab is still read right away.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
