### PR TITLE
ui: Split the tab-only half out of Component

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -31,6 +31,7 @@ use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
 use crate::ui::Scroll;
+use crate::ui::Tab;
 use crate::ui::bookmarks_tab::BookmarksTab;
 use crate::ui::dialog::CommandPopup;
 use crate::ui::dialog::HelpPopup;
@@ -38,24 +39,24 @@ use crate::ui::files_tab::FilesTab;
 use crate::ui::log_tab::LogTab;
 
 #[derive(PartialEq, Copy, Clone)]
-pub enum Tab {
+pub enum TabId {
     Log,
     Files,
     Bookmarks,
 }
 
-impl fmt::Display for Tab {
+impl fmt::Display for TabId {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Tab::Log => write!(f, "Log"),
-            Tab::Files => write!(f, "Files"),
-            Tab::Bookmarks => write!(f, "Bookmarks"),
+            TabId::Log => write!(f, "Log"),
+            TabId::Files => write!(f, "Files"),
+            TabId::Bookmarks => write!(f, "Bookmarks"),
         }
     }
 }
 
-impl Tab {
-    pub const VALUES: [Self; 3] = [Tab::Log, Tab::Files, Tab::Bookmarks];
+impl TabId {
+    pub const VALUES: [Self; 3] = [TabId::Log, TabId::Files, TabId::Bookmarks];
 }
 
 pub struct Stats {
@@ -64,7 +65,7 @@ pub struct Stats {
 
 pub struct App<'a> {
     // user interface
-    pub current_tab: Tab,
+    pub current_tab: TabId,
     pub log: LogTab<'a>,
     pub files: FilesTab,
     pub bookmarks: BookmarksTab<'a>,
@@ -88,7 +89,7 @@ impl<'a> App<'a> {
         let current_head = new_commander().get_current_head()?;
 
         Ok(App {
-            current_tab: Tab::Log,
+            current_tab: TabId::Log,
             log: LogTab::new(event_source.clone_event_sender())?,
             files: FilesTab::new(&current_head)?,
             bookmarks: BookmarksTab::new()?,
@@ -103,18 +104,18 @@ impl<'a> App<'a> {
         })
     }
 
-    pub fn get_current_tab(&mut self) -> &mut dyn Component {
+    pub fn get_current_tab(&mut self) -> &mut dyn Tab {
         self.get_tab(self.current_tab)
     }
 
     pub fn set_next_tab_with_offset(&mut self, offset: i64) -> Result<()> {
-        let current_index = Tab::VALUES
+        let current_index = TabId::VALUES
             .iter()
             .position(|&t| t == self.current_tab)
             .unwrap();
-        let new_index =
-            (current_index as i64 + Tab::VALUES.len() as i64 + offset) as usize % Tab::VALUES.len();
-        let new_tab: Tab = Tab::VALUES[new_index];
+        let new_index = (current_index as i64 + TabId::VALUES.len() as i64 + offset) as usize
+            % TabId::VALUES.len();
+        let new_tab: TabId = TabId::VALUES[new_index];
         self.set_tab(new_tab)
     }
 
@@ -130,18 +131,18 @@ impl<'a> App<'a> {
         Ok(())
     }
 
-    pub fn set_tab(&mut self, tab: Tab) -> Result<()> {
+    pub fn set_tab(&mut self, tab: TabId) -> Result<()> {
         info!("Setting tab to {}", tab);
         self.current_tab = tab;
         self.get_current_tab().refresh()?;
         Ok(())
     }
 
-    pub fn get_tab(&mut self, tab: Tab) -> &mut dyn Component {
+    pub fn get_tab(&mut self, tab: TabId) -> &mut dyn Tab {
         match tab {
-            Tab::Log => &mut self.log,
-            Tab::Files => &mut self.files,
-            Tab::Bookmarks => &mut self.bookmarks,
+            TabId::Log => &mut self.log,
+            TabId::Files => &mut self.files,
+            TabId::Bookmarks => &mut self.bookmarks,
         }
     }
 
@@ -150,12 +151,12 @@ impl<'a> App<'a> {
     pub fn handle_action(&mut self, app_action: AppAction) -> Result<()> {
         match app_action {
             AppAction::ViewFiles(head) => {
-                self.set_tab(Tab::Files)?;
+                self.set_tab(TabId::Files)?;
                 self.files.set_head(&head)?;
             }
             AppAction::ViewLog(head) => {
                 self.log.set_head(head);
-                self.set_tab(Tab::Log)?;
+                self.set_tab(TabId::Log)?;
             }
             AppAction::ChangeHead(head) => {
                 self.files.set_head(&head)?;
@@ -212,7 +213,7 @@ impl<'a> App<'a> {
 
         {
             let tabs = Tabs::new(
-                Tab::VALUES
+                TabId::VALUES
                     .iter()
                     .enumerate()
                     .map(|(i, tab)| format!("[{}] {}", i + 1, tab)),
@@ -224,7 +225,7 @@ impl<'a> App<'a> {
             )
             .highlight_style(Style::default().bg(get_env().jj_config.highlight_color()))
             .select(
-                Tab::VALUES
+                TabId::VALUES
                     .iter()
                     .position(|tab| tab == &self.current_tab)
                     .unwrap_or(0),
@@ -352,9 +353,9 @@ impl<'a> App<'a> {
                             }
                             GlobalEvent::NextTab => self.set_next_tab_with_offset(1)?,
                             GlobalEvent::PrevTab => self.set_next_tab_with_offset(-1)?,
-                            GlobalEvent::LogTab => self.set_tab(Tab::Log)?,
-                            GlobalEvent::FilesTab => self.set_tab(Tab::Files)?,
-                            GlobalEvent::BookmarksTab => self.set_tab(Tab::Bookmarks)?,
+                            GlobalEvent::LogTab => self.set_tab(TabId::Log)?,
+                            GlobalEvent::FilesTab => self.set_tab(TabId::Files)?,
+                            GlobalEvent::BookmarksTab => self.set_tab(TabId::Bookmarks)?,
                             GlobalEvent::CommandPopup => {
                                 self.popup = Some(Box::new(CommandPopup::new()));
                             }

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -27,6 +27,7 @@ use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
 use crate::ui::Scroll;
+use crate::ui::Tab;
 use crate::ui::dialog::MessagePopup;
 use crate::ui::panel::DetailsPanel;
 use crate::ui::panel::TextContent;
@@ -234,7 +235,7 @@ impl BookmarksTab<'_> {
     }
 }
 
-impl Component for BookmarksTab<'_> {
+impl Tab for BookmarksTab<'_> {
     fn refresh(&mut self) -> Result<()> {
         self.refresh_bookmarks();
         self.refresh_bookmark();
@@ -281,7 +282,9 @@ impl Component for BookmarksTab<'_> {
             ("W".to_owned(), "toggle wrapping".to_owned()),
         ]
     }
+}
 
+impl Component for BookmarksTab<'_> {
     fn update(&mut self) -> Result<Option<AppAction>> {
         // Check for popup action
         if let Ok(res) = self.popup_rx.try_recv()

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -21,6 +21,7 @@ use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
 use crate::ui::Scroll;
+use crate::ui::Tab;
 use crate::ui::dialog::MessagePopup;
 use crate::ui::panel::DetailsPanel;
 use crate::ui::panel::TextContent;
@@ -193,7 +194,7 @@ impl FilesTab {
     }
 }
 
-impl Component for FilesTab {
+impl Tab for FilesTab {
     fn refresh(&mut self) -> Result<()> {
         self.is_current_head = self.head == new_commander().get_current_head()?;
         self.head = new_commander().get_head_latest(&self.head)?;
@@ -238,7 +239,9 @@ impl Component for FilesTab {
             ("W".to_owned(), "toggle wrapping".to_owned()),
         ]
     }
+}
 
+impl Component for FilesTab {
     fn draw(
         &mut self,
         f: &mut ratatui::prelude::Frame<'_>,

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -39,6 +39,7 @@ use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
 use crate::ui::Scroll;
+use crate::ui::Tab;
 use crate::ui::commit_show_cache::CommitShowCache;
 use crate::ui::commit_show_cache::CommitShowKey;
 use crate::ui::commit_show_cache::CommitShowValue;
@@ -754,7 +755,7 @@ impl<'a> LogTab<'a> {
     }
 }
 
-impl Component for LogTab<'_> {
+impl Tab for LogTab<'_> {
     fn refresh(&mut self) -> Result<()> {
         let latest_head = new_commander().get_head_latest(&self.head)?;
         self.set_head(latest_head);
@@ -801,7 +802,9 @@ impl Component for LogTab<'_> {
             ("W".to_owned(), "toggle wrapping".to_owned()),
         ]
     }
+}
 
+impl Component for LogTab<'_> {
     fn update(&mut self) -> Result<Option<AppAction>> {
         // Check for popup action
         if let Ok(res) = self.popup_rx.try_recv()

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -61,35 +61,6 @@ pub enum Scroll {
 }
 
 pub trait Component {
-    /// Read whatever this component shows afresh from the repo.
-    fn refresh(&mut self) -> Result<()> {
-        Ok(())
-    }
-
-    /// Discard whatever this component has cached, so that the next read
-    /// goes to the repo.
-    fn drop_caches(&mut self) {}
-
-    /// Move the selection in the main panel.
-    fn scroll_main_panel(&mut self, _scroll: Scroll) -> Result<()> {
-        Ok(())
-    }
-
-    /// Show the change the working copy is on.
-    fn focus_current(&mut self) -> Result<()> {
-        Ok(())
-    }
-
-    /// Keybindings of the main panel, for the help popup.
-    fn make_main_panel_help(&self) -> Vec<(String, String)> {
-        vec![]
-    }
-
-    /// Keybindings of the details panel, for the help popup.
-    fn make_details_panel_help(&self) -> Vec<(String, String)> {
-        vec![]
-    }
-
     fn update(&mut self) -> Result<Option<AppAction>> {
         Ok(None)
     }
@@ -97,4 +68,28 @@ pub trait Component {
     fn draw(&mut self, f: &mut Frame<'_>, area: Rect) -> Result<()>;
 
     fn input(&mut self, event: Event) -> Result<ComponentInputResult>;
+}
+
+/// A top-level tab, showing what it reads from the repo.
+pub trait Tab: Component {
+    /// Read whatever this tab shows afresh from the repo.
+    fn refresh(&mut self) -> Result<()>;
+
+    /// Discard whatever this tab has cached, so that the next read goes
+    /// to the repo.
+    fn drop_caches(&mut self) {}
+
+    /// Move the selection in the main panel.
+    fn scroll_main_panel(&mut self, scroll: Scroll) -> Result<()>;
+
+    /// Show the change the working copy is on, if the tab has one.
+    fn focus_current(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    /// Keybindings of the main panel, for the help popup.
+    fn make_main_panel_help(&self) -> Vec<(String, String)>;
+
+    /// Keybindings of the details panel, for the help popup.
+    fn make_details_panel_help(&self) -> Vec<(String, String)>;
 }


### PR DESCRIPTION
Component covers both the three tabs and the popups, but six of its nine methods are only ever called through App::get_tab(): refresh(), drop_caches(), scroll_main_panel(), focus_current() and the two make_*_help(). Every popup and LogPanel implements draw(), input() and sometimes update(), and takes the default body for the rest, so the trait offers each of them six things they are never asked for. Splitting the six off into a Tab supertrait leaves Component as what the popups are, lets refresh(), scroll_main_panel() and the help methods lose their defaults, and gives App::get_tab() a return type that says the caller is holding a tab. That takes the Tab name, so the enum that picks one becomes TabId; it is only used within app.rs.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
