### PR TITLE
GHA: Update actions still running on Node.js 20

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -8,4 +8,4 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
-    - uses: dangoslen/changelog-enforcer@v3
+    - uses: dangoslen/changelog-enforcer@v3.7.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,7 +143,7 @@ jobs:
             echo "ASSET=$name.tar.gz" >> $GITHUB_ENV
           fi
       - name: Upload archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.ASSET }}
           path: ${{ env.ASSET }}


### PR DESCRIPTION
The runners force actions targeting Node.js 20 onto Node.js 24 already and warn about the deprecation, so we bump to versions that ask for Node.js 24 themselves. The changelog enforcer needs a full version, as upstream stopped moving the `v3` tag along with its releases.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
