### PR TITLE
Unify RebasePopup with the SetPopup mechanism

### DIFF
--- a/src/ui/dialog/rebase.rs
+++ b/src/ui/dialog/rebase.rs
@@ -45,8 +45,10 @@ use crate::commander::new_commander;
 use crate::keybinds::rebase_popup::CutOption;
 use crate::keybinds::rebase_popup::PasteOption;
 use crate::keybinds::rebase_popup::PopupAction;
+use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
+use crate::ui::dialog::MessagePopup;
 use crate::ui::utils::centered_rect_fixed;
 
 type Keybinds = crate::keybinds::rebase_popup::Keybinds;
@@ -71,14 +73,6 @@ impl RebasePopup {
             source_mode: CutOption::SingleRevision,
             target_mode: PasteOption::NewBranch,
         }
-    }
-
-    /// Collect all the rendering code that would have been in
-    /// log_tab.rs/draw
-    pub fn render_widget(&mut self, frame: &mut Frame) {
-        let area = centered_rect_fixed(frame.area(), 32, 12);
-        self.draw(frame, area)
-            .expect("Expected drawing without failues");
     }
 
     /// Map an event to a popup action
@@ -107,31 +101,12 @@ impl RebasePopup {
         new_commander().run_rebase(src_mode, src_rev, tgt_mode, tgt_rev)?;
         Ok(())
     }
-
-    /// Process the input event. If this function returns Ok(true),
-    /// then the popup should be closed. Either a rebase was executed
-    /// or the operation was cancelled.
-    /// If the result is Ok(false) the function did handle
-    /// the input, but the popup should not be closed yet.
-    /// Err(_) will be returned if the jj command failed.
-    pub fn handle_input(&mut self, event: Event) -> Result<bool> {
-        match self.match_event(event) {
-            PopupAction::Ok => {
-                self.run_command()?;
-                return Ok(true);
-            }
-            PopupAction::Cancel => return Ok(true),
-            PopupAction::SetSourceMode(m) => self.source_mode = m,
-            PopupAction::SetTargetMode(m) => self.target_mode = m,
-            PopupAction::None => (),
-        }
-        Ok(false)
-    }
 }
 
 impl Component for RebasePopup {
     /// Render the dialog into the area.
     fn draw(&mut self, frame: &mut Frame<'_>, area: Rect) -> Result<()> {
+        let area = centered_rect_fixed(area, 32, 12);
         // The border of the dialog
         let block = Block::bordered()
             .title(Span::styled(" Rebase ", Style::new().bold().cyan()))
@@ -211,9 +186,27 @@ impl Component for RebasePopup {
         Ok(())
     }
 
-    fn input(&mut self, _event: Event) -> Result<ComponentInputResult> {
-        unreachable!();
-        //return Ok(ComponentInputResult::Handled);
+    fn input(&mut self, event: Event) -> Result<ComponentInputResult> {
+        match self.match_event(event) {
+            PopupAction::Ok => match self.run_command() {
+                Ok(()) => Ok(ComponentInputResult::HandledAction(AppAction::PopupDone)),
+                Err(e) => Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
+                    Box::new(MessagePopup::new("Error", e.to_string())),
+                ))),
+            },
+            PopupAction::Cancel => Ok(ComponentInputResult::HandledAction(
+                AppAction::PopupCanceled,
+            )),
+            PopupAction::SetSourceMode(m) => {
+                self.source_mode = m;
+                Ok(ComponentInputResult::Handled)
+            }
+            PopupAction::SetTargetMode(m) => {
+                self.target_mode = m;
+                Ok(ComponentInputResult::Handled)
+            }
+            PopupAction::None => Ok(ComponentInputResult::Handled),
+        }
     }
 }
 

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -98,8 +98,6 @@ pub struct LogTab<'a> {
     describe_textarea: Option<TextArea<'a>>,
     describe_after_new: bool,
 
-    rebase_popup: Option<RebasePopup>,
-
     squash_ignore_immutable: bool,
     squash_target: Option<Head>,
 
@@ -200,8 +198,6 @@ impl<'a> LogTab<'a> {
 
             describe_textarea: None,
             describe_after_new: false,
-
-            rebase_popup: None,
 
             squash_ignore_immutable: false,
             squash_target: None,
@@ -558,11 +554,9 @@ impl<'a> LogTab<'a> {
             }
             LogTabEvent::Rebase => {
                 let source_change = new_commander().get_current_head()?;
-                let target_change = &self.head;
-                self.rebase_popup = Some(RebasePopup::new(
-                    source_change.clone(),
-                    target_change.clone(),
-                ));
+                return Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
+                    Box::new(RebasePopup::new(source_change, self.head.clone())),
+                )));
             }
             LogTabEvent::Squash { ignore_immutable } => {
                 let current_head = new_commander().get_current_head()?;
@@ -964,13 +958,6 @@ impl Component for LogTab<'_> {
             }
         }
 
-        // Draw rebase popup
-        {
-            if let Some(log_rebase_popup) = &mut self.rebase_popup {
-                log_rebase_popup.render_widget(f)
-            }
-        }
-
         Ok(())
     }
 
@@ -1021,25 +1008,6 @@ impl Component for LogTab<'_> {
                 }
             }
             log_revset_textarea.input(event);
-            return Ok(ComponentInputResult::Handled);
-        }
-
-        if let Some(rebase_popup) = &mut self.rebase_popup {
-            let handled = rebase_popup.handle_input(event.clone());
-            if handled.is_err() {
-                // Close popup and show error message
-                self.rebase_popup = None;
-                let msg = handled.err().unwrap();
-                return Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
-                    Box::new(MessagePopup::new("Error", msg.to_string())),
-                )));
-            }
-            if handled.ok() == Some(true) {
-                // when handle_input returns true,
-                // the popup should be closed
-                self.rebase_popup = None;
-                return Ok(ComponentInputResult::HandledAction(AppAction::RefreshTab));
-            }
             return Ok(ComponentInputResult::Handled);
         }
 


### PR DESCRIPTION
RebasePopup already implements Component, but LogTab holds it in a typed field and drives it through bespoke render_widget() and handle_input() helpers, leaving the trait's input() as unreachable!(). Routing it through app.popup like every other dialog lets those trait methods carry the popup, including reporting a failed rebase, which LogTab previously had to translate into a MessagePopup itself.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
