### PR TITLE
Extract LogTab describe_textarea into DescribePopup

### DIFF
--- a/src/ui/dialog/describe.rs
+++ b/src/ui/dialog/describe.rs
@@ -1,0 +1,111 @@
+use std::cmp::max;
+
+use anyhow::Result;
+use ratatui::Frame;
+use ratatui::crossterm::event::Event;
+use ratatui::crossterm::event::KeyCode;
+use ratatui::crossterm::event::KeyEventKind;
+use ratatui::crossterm::event::KeyModifiers;
+use ratatui::layout::Alignment;
+use ratatui::layout::Constraint;
+use ratatui::layout::Direction;
+use ratatui::layout::Layout;
+use ratatui::layout::Rect;
+use ratatui::prelude::Stylize;
+use ratatui::style::Color;
+use ratatui::style::Style;
+use ratatui::text::Span;
+use ratatui::widgets::Block;
+use ratatui::widgets::BorderType;
+use ratatui::widgets::Borders;
+use ratatui::widgets::Clear;
+use ratatui::widgets::Paragraph;
+use ratatui_textarea::CursorMove;
+use ratatui_textarea::TextArea;
+
+use crate::commander::log::Head;
+use crate::commander::new_commander;
+use crate::ui::AppAction;
+use crate::ui::Component;
+use crate::ui::ComponentInputResult;
+use crate::ui::utils::centered_rect_fixed;
+
+pub struct DescribePopup<'a> {
+    head: Head,
+    textarea: TextArea<'a>,
+}
+
+impl DescribePopup<'_> {
+    pub fn new(head: Head, lines: Vec<String>) -> DescribePopup<'static> {
+        let mut textarea = TextArea::new(lines);
+        textarea.move_cursor(CursorMove::End);
+        DescribePopup { head, textarea }
+    }
+}
+
+impl Component for DescribePopup<'_> {
+    fn draw(&mut self, f: &mut Frame<'_>, area: Rect) -> Result<()> {
+        let block = Block::bordered()
+            .title(Span::styled(" Describe ", Style::new().bold().cyan()))
+            .title_alignment(Alignment::Center)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(Color::Green));
+
+        const MAX_COMMIT_WIDTH: u16 = 72;
+        const MIN_COMMIT_HEIGHT: u16 = 5;
+        let area = centered_rect_fixed(
+            area,
+            MAX_COMMIT_WIDTH + 2,
+            max(MIN_COMMIT_HEIGHT + 4, area.height / 2),
+        );
+        f.render_widget(Clear, area);
+        f.render_widget(&block, area);
+
+        let popup_chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Fill(1), Constraint::Length(2)])
+            .split(block.inner(area));
+
+        f.render_widget(&self.textarea, popup_chunks[0]);
+
+        let help = Paragraph::new(vec!["Ctrl+s: save | Escape: cancel".into()])
+            .fg(Color::DarkGray)
+            .alignment(Alignment::Center)
+            .block(
+                Block::default()
+                    .borders(Borders::TOP)
+                    .border_type(BorderType::Rounded)
+                    .border_style(Style::default().fg(Color::DarkGray)),
+            );
+        f.render_widget(help, popup_chunks[1]);
+
+        Ok(())
+    }
+
+    fn input(&mut self, event: Event) -> Result<ComponentInputResult> {
+        if let Event::Key(key) = event
+            && key.kind == KeyEventKind::Press
+        {
+            match (key.code, key.modifiers) {
+                (KeyCode::Char('s'), m) if m.contains(KeyModifiers::CONTROL) => {
+                    new_commander().run_describe(
+                        self.head.commit_id.as_str(),
+                        &self.textarea.lines().join("\n"),
+                    )?;
+                    let latest = new_commander().get_head_latest(&self.head)?;
+                    return Ok(ComponentInputResult::HandledAction(AppAction::Multiple(
+                        vec![AppAction::PopupDone, AppAction::ViewLog(latest)],
+                    )));
+                }
+                (KeyCode::Esc, _) => {
+                    return Ok(ComponentInputResult::HandledAction(
+                        AppAction::PopupCanceled,
+                    ));
+                }
+                _ => {}
+            }
+        }
+        self.textarea.input(event);
+        Ok(ComponentInputResult::Handled)
+    }
+}

--- a/src/ui/dialog/mod.rs
+++ b/src/ui/dialog/mod.rs
@@ -10,6 +10,7 @@ until it sends [`AppAction::PopupDone`](crate::ui::AppAction) or
 
 mod bookmark_set;
 mod command;
+mod describe;
 mod help;
 mod loader;
 mod message;
@@ -17,6 +18,7 @@ mod rebase;
 
 pub use bookmark_set::BookmarkSetPopup;
 pub use command::CommandPopup;
+pub use describe::DescribePopup;
 pub use help::HelpPopup;
 pub use loader::LoaderPopup;
 pub use message::MessagePopup;

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -1,6 +1,5 @@
 #![expect(clippy::borrow_interior_mutable_const)]
 
-use std::cmp::max;
 use std::io::Read;
 use std::process::Child;
 use std::sync::mpsc::Sender;
@@ -44,6 +43,7 @@ use crate::ui::commit_show_cache::CommitShowCache;
 use crate::ui::commit_show_cache::CommitShowKey;
 use crate::ui::commit_show_cache::CommitShowValue;
 use crate::ui::dialog::BookmarkSetPopup;
+use crate::ui::dialog::DescribePopup;
 use crate::ui::dialog::LoaderPopup;
 use crate::ui::dialog::MessagePopup;
 use crate::ui::dialog::RebasePopup;
@@ -53,7 +53,6 @@ use crate::ui::panel::LogPanel;
 use crate::ui::panel::TextContent;
 use crate::ui::utils::PaneDivider;
 use crate::ui::utils::Timer;
-use crate::ui::utils::centered_rect_fixed;
 use crate::ui::utils::centered_rect_line_height;
 use crate::ui::utils::tabs_to_spaces;
 
@@ -95,7 +94,6 @@ pub struct LogTab<'a> {
     popup_tx: std::sync::mpsc::Sender<Listener>,
     popup_rx: std::sync::mpsc::Receiver<Listener>,
 
-    describe_textarea: Option<TextArea<'a>>,
     describe_after_new: bool,
 
     squash_ignore_immutable: bool,
@@ -196,7 +194,6 @@ impl<'a> LogTab<'a> {
             popup_tx,
             popup_rx,
 
-            describe_textarea: None,
             describe_after_new: false,
 
             squash_ignore_immutable: false,
@@ -460,8 +457,10 @@ impl<'a> LogTab<'a> {
         self.set_head(new_commander().get_current_head()?);
         if self.describe_after_new {
             self.describe_after_new = false;
-            let textarea = TextArea::default();
-            self.describe_textarea = Some(textarea);
+            return Ok(Some(AppAction::Multiple(vec![
+                AppAction::ChangeHead(self.head.clone()),
+                AppAction::SetPopup(Box::new(DescribePopup::new(self.head.clone(), vec![]))),
+            ])));
         }
         Ok(Some(AppAction::ChangeHead(self.head.clone())))
     }
@@ -661,16 +660,14 @@ impl<'a> LogTab<'a> {
                         )),
                     )));
                 } else {
-                    let mut textarea = TextArea::new(
-                        new_commander()
-                            .get_commit_description(&self.head.commit_id)?
-                            .split("\n")
-                            .map(|line| line.to_string())
-                            .collect(),
-                    );
-                    textarea.move_cursor(CursorMove::End);
-                    self.describe_textarea = Some(textarea);
-                    return Ok(ComponentInputResult::Handled);
+                    let lines = new_commander()
+                        .get_commit_description(&self.head.commit_id)?
+                        .split("\n")
+                        .map(|line| line.to_string())
+                        .collect();
+                    return Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
+                        Box::new(DescribePopup::new(self.head.clone(), lines)),
+                    )));
                 }
             }
             LogTabEvent::EditRevset => {
@@ -884,47 +881,6 @@ impl Component for LogTab<'_> {
             f.render_stateful_widget(popup, area, &mut self.popup);
         }
 
-        // Draw describe textarea
-        {
-            if let Some(describe_textarea) = self.describe_textarea.as_mut() {
-                let block = Block::bordered()
-                    .title(Span::styled(" Describe ", Style::new().bold().cyan()))
-                    .title_alignment(Alignment::Center)
-                    .border_type(BorderType::Rounded)
-                    .border_style(Style::default().fg(Color::Green));
-                // Text target size
-                const MAX_COMMIT_WIDTH: u16 = 72; // git recommended max width
-                const MIN_COMMIT_HEIGHT: u16 = 5; // heading + blank + 3 lines
-                // Include margin and help text to get size
-                let area = centered_rect_fixed(
-                    area,
-                    /* width */ MAX_COMMIT_WIDTH + 2,
-                    /* height */ max(MIN_COMMIT_HEIGHT + 4, area.height / 2),
-                );
-                f.render_widget(Clear, area);
-                f.render_widget(&block, area);
-
-                let popup_chunks = Layout::default()
-                    .direction(Direction::Vertical)
-                    .constraints([Constraint::Fill(1), Constraint::Length(2)])
-                    .split(block.inner(area));
-
-                f.render_widget(&*describe_textarea, popup_chunks[0]);
-
-                let help = Paragraph::new(vec!["Ctrl+s: save | Escape: cancel".into()])
-                    .fg(Color::DarkGray)
-                    .alignment(Alignment::Center)
-                    .block(
-                        Block::default()
-                            .borders(Borders::TOP)
-                            .border_type(BorderType::Rounded)
-                            .border_style(Style::default().fg(Color::DarkGray)),
-                    );
-
-                f.render_widget(help, popup_chunks[1]);
-            }
-        }
-
         // Draw revset textarea
         {
             if let Some(log_revset_textarea) = self.log_revset_textarea.as_mut() {
@@ -962,30 +918,6 @@ impl Component for LogTab<'_> {
     }
 
     fn input(&mut self, event: Event) -> Result<ComponentInputResult> {
-        if let Some(describe_textarea) = self.describe_textarea.as_mut() {
-            if let Event::Key(key) = event {
-                match self.keybinds.match_event(key) {
-                    LogTabEvent::Save => {
-                        // TODO: Handle error
-                        new_commander().run_describe(
-                            self.head.commit_id.as_str(),
-                            &describe_textarea.lines().join("\n"),
-                        )?;
-                        self.set_head(new_commander().get_head_latest(&self.head)?);
-                        self.describe_textarea = None;
-                        return Ok(ComponentInputResult::Handled);
-                    }
-                    LogTabEvent::Cancel => {
-                        self.describe_textarea = None;
-                        return Ok(ComponentInputResult::Handled);
-                    }
-                    _ => (),
-                }
-            }
-            describe_textarea.input(event);
-            return Ok(ComponentInputResult::Handled);
-        }
-
         if let Some(log_revset_textarea) = self.log_revset_textarea.as_mut() {
             if let Event::Key(key) = event {
                 match self.keybinds.match_event(key) {


### PR DESCRIPTION
LogTab holds describe_textarea as a typed field and draws and handles it inline, bypassing the SetPopup mechanism the other dialogs use. Moving it into a DescribePopup component that owns the head it describes both removes that bespoke path and makes the popup reusable.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
