### PR TITLE
Keep the details panel filled while 'jj show' runs

### DIFF
--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -62,6 +62,12 @@ const EDIT_POPUP_ID: u16 = 2;
 const ABANDON_POPUP_ID: u16 = 3;
 const SQUASH_POPUP_ID: u16 = 4;
 
+/// How long the details panel hides that 'jj show' is running: it keeps
+/// showing the change it already has and, if it has none, stays empty
+/// until the request it waits for has taken this long. Each request
+/// gets its own grace, so moving on keeps the panel quiet.
+const LOADING_GRACE: Duration = Duration::from_secs(1);
+
 /// Log tab. Shows `jj log` in main panel and shows selected change details of in details panel.
 pub struct LogTab<'a> {
     /// Channel for app events
@@ -78,6 +84,10 @@ pub struct LogTab<'a> {
 
     /// The selected change content key in the cache
     head_key: CommitShowKey,
+
+    /// The content key the details panel currently renders. This lags
+    /// behind `head_key` while we wait for 'jj show'
+    shown_key: Option<CommitShowKey>,
 
     /// Cached change content
     commit_show_cache: CommitShowCache,
@@ -186,6 +196,7 @@ impl<'a> LogTab<'a> {
             head,
             head_panel: DetailsPanel::new(),
             head_key,
+            shown_key: None,
 
             commit_show_cache,
             pending_jj_show: None,
@@ -243,17 +254,24 @@ impl<'a> LogTab<'a> {
 
         // TODO use shared function to build key, so width can be cleared if not needed
         let inner_width = self.head_panel.columns() as usize;
-        let key = CommitShowKey::new(self.head.clone(), self.diff_format.clone(), inner_width);
-
-        let content_changed = self.head_key != key;
-
-        // Only update if content actually changed to prevent scroll jumping
         // The next draw requests `jj show` for the new key if it is not
-        // already cached.
-        if content_changed {
-            self.head_key = key;
-            self.head_panel.scroll_to(0);
+        // already cached, and moves the panel over once it has content.
+        self.head_key =
+            CommitShowKey::new(self.head.clone(), self.diff_format.clone(), inner_width);
+    }
+
+    /// The content the details panel is to render. This is the selected
+    /// change as soon as the cache can serve it, and the change the panel
+    /// already shows while we briefly wait for 'jj show'.
+    fn key_to_render(&self) -> Option<CommitShowKey> {
+        if self.commit_show_cache.get(&self.head_key).is_some() {
+            return Some(self.head_key.clone());
         }
+        let pending = self.pending_jj_show.as_ref()?;
+        if pending.timer.elapsed() < LOADING_GRACE {
+            return self.shown_key.clone();
+        }
+        None
     }
 
     //
@@ -849,14 +867,22 @@ impl Component for LogTab<'_> {
         if !self.commit_show_cache.has_exact_match(&self.head_key) {
             self.request_jj_show(self.head_key.clone());
         }
-        if let Some(content) = self.commit_show_cache.get(&self.head_key) {
+        if let Some(key) = self.key_to_render()
+            && let Some(content) = self.commit_show_cache.get(&key)
+        {
+            // Read a change from its top, but stay put while it is only
+            // being rewritten under us
+            if self.shown_key.as_ref().map(|shown| &shown.id.change_id) != Some(&key.id.change_id) {
+                self.head_panel.scroll_to(0);
+            }
             self.head_panel
                 .render_context::<LargeStringContent>(content.value())
-                .title(format!(" Details for {} ", self.head.change_id))
-                .draw(f, chunks[1])
+                .title(format!(" Details for {} ", key.id.change_id))
+                .draw(f, chunks[1]);
+            self.shown_key = Some(key);
         } else if let Some(pjj) = &self.pending_jj_show {
             let duration = pjj.timer.elapsed();
-            let message = if duration < Duration::from_secs(1) {
+            let message = if duration < LOADING_GRACE {
                 "".to_string()
             } else {
                 let mut sec = duration.as_secs();


### PR DESCRIPTION
Now that the details panel gets its content from a 'jj show' running in the background, it goes empty the moment another change is selected and stays that way until the output arrives, which reads as a flicker even when the wait is only a few frames. We therefore leave the change that is already on screen there until the request for the new one has run for a second, and only reset the scroll position once the panel actually moves on to another change. That also keeps the position when a change is merely rewritten under us, as happens on every refresh of the working copy.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
