### PR TITLE
panel: Keep the scroll position when a change is rewritten

### DIFF
--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -245,15 +245,14 @@ impl<'a> LogTab<'a> {
         let inner_width = self.head_panel.columns() as usize;
         let key = CommitShowKey::new(self.head.clone(), self.diff_format.clone(), inner_width);
 
-        let content_changed = self.head_key != key;
-
-        // Only update if content actually changed to prevent scroll jumping
-        // The next draw requests `jj show` for the new key if it is not
-        // already cached.
-        if content_changed {
-            self.head_key = key;
+        // Only selecting a different change starts over at the top
+        if self.head_key.id.change_id != key.id.change_id {
             self.head_panel.scroll_to(0);
         }
+
+        // The next draw requests `jj show` for the new key if it is not
+        // already cached.
+        self.head_key = key;
     }
 
     //


### PR DESCRIPTION
The details panel scrolls back to the top whenever the key of the shown document changes. That key covers the commit id, so refreshing a change that has been rewritten in the meantime, as happens for the working copy when the terminal regains focus, drops the position we had scrolled to, even though we keep showing the previous output until the new one arrives. So we only start over at the top when a different change gets selected. The key also covers the diff format and the render width, which now keep the position as well; clamping pulls it into the new content where that is shorter.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
