### PR TITLE
Extract BookmarksTab create/rename into BookmarkNamePopup

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -68,7 +68,7 @@ pub struct App<'a> {
     pub current_tab: TabId,
     pub log: LogTab<'a>,
     pub files: FilesTab,
-    pub bookmarks: BookmarksTab<'a>,
+    pub bookmarks: BookmarksTab,
     pub popup: Option<Box<dyn Component>>,
     pub stats: Stats,
     global_keybinds: GlobalKeybinds,

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -5,11 +5,8 @@ use anyhow::Result;
 use ratatui::crossterm::event::Event;
 use ratatui::crossterm::event::KeyCode;
 use ratatui::crossterm::event::KeyEventKind;
-use ratatui::crossterm::event::KeyModifiers;
 use ratatui::prelude::*;
 use ratatui::widgets::*;
-use ratatui_textarea::CursorMove;
-use ratatui_textarea::TextArea;
 use tracing::instrument;
 use tui_confirm_dialog::ButtonLabel;
 use tui_confirm_dialog::ConfirmDialog;
@@ -27,24 +24,13 @@ use crate::ui::Component;
 use crate::ui::ComponentInputResult;
 use crate::ui::Scroll;
 use crate::ui::Tab;
+use crate::ui::dialog::BookmarkNamePopup;
 use crate::ui::dialog::DescribePopup;
 use crate::ui::dialog::MessagePopup;
 use crate::ui::panel::DetailsPanel;
 use crate::ui::panel::TextContent;
 use crate::ui::utils::PaneDivider;
-use crate::ui::utils::centered_rect_line_height;
 use crate::ui::utils::tabs_to_spaces;
-
-struct CreateBookmark<'a> {
-    textarea: TextArea<'a>,
-    error: Option<anyhow::Error>,
-}
-
-struct RenameBookmark<'a> {
-    textarea: TextArea<'a>,
-    name: String,
-    error: Option<anyhow::Error>,
-}
 
 struct DeleteBookmark {
     name: String,
@@ -60,7 +46,7 @@ const NEW_POPUP_ID: u16 = 3;
 const EDIT_POPUP_ID: u16 = 4;
 
 /// Bookmarks tab. Shows bookmarks in main panel and selected bookmark current change in details panel.
-pub struct BookmarksTab<'a> {
+pub struct BookmarksTab {
     bookmarks_output: Result<Vec<BookmarkLine>, CommandError>,
     bookmarks_list_state: ListState,
     bookmarks_height: u16,
@@ -72,8 +58,6 @@ pub struct BookmarksTab<'a> {
     bookmark_panel: DetailsPanel,
     bookmark_output: Option<Result<String, CommandError>>,
 
-    create: Option<CreateBookmark<'a>>,
-    rename: Option<RenameBookmark<'a>>,
     delete: Option<DeleteBookmark>,
     forget: Option<ForgetBookmark>,
 
@@ -84,6 +68,9 @@ pub struct BookmarksTab<'a> {
     popup: ConfirmDialogState,
     popup_tx: std::sync::mpsc::Sender<Listener>,
     popup_rx: std::sync::mpsc::Receiver<Listener>,
+
+    bookmark_name_popup_tx: std::sync::mpsc::Sender<String>,
+    bookmark_name_popup_rx: std::sync::mpsc::Receiver<String>,
 
     diff_format: DiffFormat,
 
@@ -121,7 +108,7 @@ fn get_current_bookmark_index(
     }
 }
 
-impl BookmarksTab<'_> {
+impl BookmarksTab {
     #[instrument(level = "info", name = "Initializing bookmarks tab", parent = None, skip())]
     pub fn new() -> Result<Self> {
         let diff_format = get_env().jj_config.diff_format();
@@ -150,6 +137,7 @@ impl BookmarksTab<'_> {
         });
 
         let (popup_tx, popup_rx) = std::sync::mpsc::channel();
+        let (bookmark_name_popup_tx, bookmark_name_popup_rx) = std::sync::mpsc::channel();
 
         let config = get_env().jj_config.clone();
         let pane_divider = PaneDivider::new(config.layout_percent());
@@ -165,8 +153,6 @@ impl BookmarksTab<'_> {
             bookmark_panel: DetailsPanel::new(),
             bookmark_output,
 
-            create: None,
-            rename: None,
             delete: None,
             forget: None,
 
@@ -177,6 +163,9 @@ impl BookmarksTab<'_> {
             popup: ConfirmDialogState::default(),
             popup_tx,
             popup_rx,
+
+            bookmark_name_popup_tx,
+            bookmark_name_popup_rx,
 
             diff_format,
 
@@ -230,7 +219,7 @@ impl BookmarksTab<'_> {
     }
 }
 
-impl Tab for BookmarksTab<'_> {
+impl Tab for BookmarksTab {
     fn refresh(&mut self) -> Result<()> {
         self.refresh_bookmarks();
         self.refresh_bookmark();
@@ -279,7 +268,7 @@ impl Tab for BookmarksTab<'_> {
     }
 }
 
-impl Component for BookmarksTab<'_> {
+impl Component for BookmarksTab {
     fn update(&mut self) -> Result<Option<AppAction>> {
         // Check for popup action
         if let Ok(res) = self.popup_rx.try_recv()
@@ -353,6 +342,19 @@ impl Component for BookmarksTab<'_> {
                 }
                 _ => {}
             }
+        }
+
+        if let Ok(name) = self.bookmark_name_popup_rx.try_recv() {
+            self.refresh_bookmarks();
+            if let Some(bookmark) = self.bookmarks_output.as_ref().ok().and_then(|list| {
+                list.iter().find(|b| match b {
+                    BookmarkLine::Unparsable(_) => false,
+                    BookmarkLine::Parsed { bookmark, .. } => bookmark.name == name,
+                })
+            }) {
+                self.bookmark = Some(bookmark.clone());
+            }
+            self.refresh_bookmark();
         }
 
         Ok(None)
@@ -493,241 +495,10 @@ impl Component for BookmarksTab<'_> {
             f.render_stateful_widget(popup, area, &mut self.popup);
         }
 
-        // Draw create textarea
-        {
-            if let Some(create) = self.create.as_mut() {
-                let block = Block::bordered()
-                    .title(Span::styled(
-                        " Create bookmark ",
-                        Style::new().bold().cyan(),
-                    ))
-                    .title_alignment(Alignment::Center)
-                    .border_type(BorderType::Rounded)
-                    .border_style(Style::default().fg(Color::Green));
-                let error_lines = create
-                    .error
-                    .as_ref()
-                    .map(|error| error.to_string().into_text().unwrap().lines);
-                let error_height = if let Some(error_lines) = error_lines.as_ref() {
-                    error_lines.len() + 1
-                } else {
-                    0
-                };
-                let area = centered_rect_line_height(area, 30, 5 + error_height as u16);
-                f.render_widget(Clear, area);
-                f.render_widget(&block, area);
-
-                let popup_chunks = Layout::default()
-                    .direction(Direction::Vertical)
-                    .constraints([
-                        Constraint::Fill(1),
-                        Constraint::Length(error_height as u16),
-                        Constraint::Length(2),
-                    ])
-                    .split(block.inner(area));
-
-                f.render_widget(&create.textarea, popup_chunks[0]);
-
-                if let Some(error_lines) = error_lines {
-                    let help = Paragraph::new(error_lines).block(
-                        Block::default()
-                            .borders(Borders::TOP)
-                            .border_type(BorderType::Rounded)
-                            .border_style(Style::default().fg(Color::DarkGray)),
-                    );
-
-                    f.render_widget(help, popup_chunks[1]);
-                }
-
-                let help = Paragraph::new(vec!["Ctrl+s: save | Escape: cancel".into()])
-                    .fg(Color::DarkGray)
-                    .alignment(Alignment::Center)
-                    .block(
-                        Block::default()
-                            .borders(Borders::TOP)
-                            .border_type(BorderType::Rounded)
-                            .border_style(Style::default().fg(Color::DarkGray)),
-                    );
-
-                f.render_widget(help, popup_chunks[2]);
-            }
-        }
-
-        // Draw rename textarea
-        {
-            if let Some(rename) = self.rename.as_mut() {
-                let block = Block::bordered()
-                    .title(Span::styled(
-                        " Rename bookmark ",
-                        Style::new().bold().cyan(),
-                    ))
-                    .title_alignment(Alignment::Center)
-                    .border_type(BorderType::Rounded)
-                    .border_style(Style::default().fg(Color::Green));
-                let error_lines = rename
-                    .error
-                    .as_ref()
-                    .map(|error| error.to_string().into_text().unwrap().lines);
-                let error_height = if let Some(error_lines) = error_lines.as_ref() {
-                    error_lines.len() + 1
-                } else {
-                    0
-                };
-                let area = centered_rect_line_height(area, 30, 5 + error_height as u16);
-                f.render_widget(Clear, area);
-                f.render_widget(&block, area);
-
-                let popup_chunks = Layout::default()
-                    .direction(Direction::Vertical)
-                    .constraints([
-                        Constraint::Fill(1),
-                        Constraint::Length(error_height as u16),
-                        Constraint::Length(2),
-                    ])
-                    .split(block.inner(area));
-
-                f.render_widget(&rename.textarea, popup_chunks[0]);
-
-                if let Some(error_lines) = error_lines {
-                    let help = Paragraph::new(error_lines).block(
-                        Block::default()
-                            .borders(Borders::TOP)
-                            .border_type(BorderType::Rounded)
-                            .border_style(Style::default().fg(Color::DarkGray)),
-                    );
-
-                    f.render_widget(help, popup_chunks[1]);
-                }
-
-                let help = Paragraph::new(vec!["Ctrl+s: save | Escape: cancel".into()])
-                    .fg(Color::DarkGray)
-                    .alignment(Alignment::Center)
-                    .block(
-                        Block::default()
-                            .borders(Borders::TOP)
-                            .border_type(BorderType::Rounded)
-                            .border_style(Style::default().fg(Color::DarkGray)),
-                    );
-
-                f.render_widget(help, popup_chunks[2]);
-            }
-        }
-
         Ok(())
     }
 
     fn input(&mut self, event: Event) -> Result<ComponentInputResult> {
-        if let Some(create) = self.create.as_mut() {
-            if let Event::Key(key) = event {
-                match key.code {
-                    _ if (key.code == KeyCode::Char('s')
-                        && key.modifiers.contains(KeyModifiers::CONTROL))
-                        || (key.code == KeyCode::Enter) =>
-                    {
-                        let name = create.textarea.lines().join("\n");
-
-                        if name.trim().is_empty() {
-                            create.error =
-                                Some(anyhow::Error::msg("Bookmark name cannot be empty"));
-                            return Ok(ComponentInputResult::Handled);
-                        }
-
-                        if let Err(err) = new_commander().create_bookmark(&name) {
-                            create.error = Some(anyhow::Error::new(err));
-                            return Ok(ComponentInputResult::Handled);
-                        }
-
-                        self.create = None;
-                        self.refresh_bookmarks();
-
-                        // Select new bookmark
-                        if let Some(bookmark) =
-                            self.bookmarks_output
-                                .as_ref()
-                                .ok()
-                                .and_then(|bookmarks_output| {
-                                    bookmarks_output.iter().find(|bookmark| match bookmark {
-                                        BookmarkLine::Unparsable(_) => false,
-                                        BookmarkLine::Parsed { bookmark, .. } => {
-                                            bookmark.name == name
-                                        }
-                                    })
-                                })
-                        {
-                            self.bookmark = Some(bookmark.clone());
-                        }
-
-                        self.refresh_bookmark();
-
-                        return Ok(ComponentInputResult::Handled);
-                    }
-                    KeyCode::Esc => {
-                        self.create = None;
-                        return Ok(ComponentInputResult::Handled);
-                    }
-                    _ => {}
-                }
-            }
-            create.textarea.input(event);
-            return Ok(ComponentInputResult::Handled);
-        }
-
-        if let Some(rename) = self.rename.as_mut() {
-            if let Event::Key(key) = event {
-                match key.code {
-                    _ if (key.code == KeyCode::Char('s')
-                        && key.modifiers.contains(KeyModifiers::CONTROL))
-                        || (key.code == KeyCode::Enter) =>
-                    {
-                        let new = rename.textarea.lines().join("\n");
-
-                        if new.trim().is_empty() {
-                            rename.error =
-                                Some(anyhow::Error::msg("Bookmark name cannot be empty"));
-                            return Ok(ComponentInputResult::Handled);
-                        }
-
-                        let old = rename.name.clone();
-
-                        if let Err(err) = new_commander().rename_bookmark(&old, &new) {
-                            rename.error = Some(anyhow::Error::new(err));
-                            return Ok(ComponentInputResult::Handled);
-                        }
-                        self.rename = None;
-                        self.refresh_bookmarks();
-
-                        // Select new bookmark
-                        if let Some(bookmark) =
-                            self.bookmarks_output
-                                .as_ref()
-                                .ok()
-                                .and_then(|bookmarks_output| {
-                                    bookmarks_output.iter().find(|bookmark| match bookmark {
-                                        BookmarkLine::Unparsable(_) => false,
-                                        BookmarkLine::Parsed { bookmark, .. } => {
-                                            bookmark.name == new
-                                        }
-                                    })
-                                })
-                        {
-                            self.bookmark = Some(bookmark.clone());
-                        }
-
-                        self.refresh_bookmark();
-
-                        return Ok(ComponentInputResult::Handled);
-                    }
-                    KeyCode::Esc => {
-                        self.rename = None;
-                        return Ok(ComponentInputResult::Handled);
-                    }
-                    _ => {}
-                }
-            }
-            rename.textarea.input(event);
-            return Ok(ComponentInputResult::Handled);
-        }
-
         if let Event::Key(key) = event {
             if key.kind != KeyEventKind::Press {
                 return Ok(ComponentInputResult::Handled);
@@ -756,23 +527,21 @@ impl Component for BookmarksTab<'_> {
                     self.refresh_bookmarks();
                 }
                 KeyCode::Char('c') => {
-                    let textarea = TextArea::default();
-                    self.create = Some(CreateBookmark {
-                        textarea,
-                        error: None,
-                    });
-                    return Ok(ComponentInputResult::Handled);
+                    return Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
+                        Box::new(BookmarkNamePopup::new_create(
+                            self.bookmark_name_popup_tx.clone(),
+                        )),
+                    )));
                 }
                 KeyCode::Char('r') => {
                     if let Some(BookmarkLine::Parsed { bookmark, .. }) = self.bookmark.as_ref() {
-                        let mut textarea = TextArea::new(vec![bookmark.name.clone()]);
-                        textarea.move_cursor(CursorMove::End);
-                        self.rename = Some(RenameBookmark {
-                            textarea,
-                            name: bookmark.name.clone(),
-                            error: None,
-                        });
-                        return Ok(ComponentInputResult::Handled);
+                        let old_name = bookmark.name.clone();
+                        return Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
+                            Box::new(BookmarkNamePopup::new_rename(
+                                old_name,
+                                self.bookmark_name_popup_tx.clone(),
+                            )),
+                        )));
                     }
                 }
                 KeyCode::Char('d') => {

--- a/src/ui/dialog/bookmark_name.rs
+++ b/src/ui/dialog/bookmark_name.rs
@@ -1,0 +1,179 @@
+use std::sync::mpsc::Sender;
+
+use ansi_to_tui::IntoText;
+use anyhow::Result;
+use ratatui::Frame;
+use ratatui::crossterm::event::Event;
+use ratatui::crossterm::event::KeyCode;
+use ratatui::crossterm::event::KeyEventKind;
+use ratatui::crossterm::event::KeyModifiers;
+use ratatui::layout::Alignment;
+use ratatui::layout::Constraint;
+use ratatui::layout::Direction;
+use ratatui::layout::Layout;
+use ratatui::layout::Rect;
+use ratatui::prelude::Stylize;
+use ratatui::style::Color;
+use ratatui::style::Style;
+use ratatui::text::Span;
+use ratatui::widgets::Block;
+use ratatui::widgets::BorderType;
+use ratatui::widgets::Borders;
+use ratatui::widgets::Clear;
+use ratatui::widgets::Paragraph;
+use ratatui_textarea::CursorMove;
+use ratatui_textarea::TextArea;
+
+use crate::commander::new_commander;
+use crate::ui::AppAction;
+use crate::ui::Component;
+use crate::ui::ComponentInputResult;
+use crate::ui::utils::centered_rect_line_height;
+
+pub enum BookmarkNameMode {
+    Create,
+    Rename { old_name: String },
+}
+
+pub struct BookmarkNamePopup<'a> {
+    mode: BookmarkNameMode,
+    textarea: TextArea<'a>,
+    error: Option<anyhow::Error>,
+    /// Receives the saved bookmark name on success; nothing is sent on cancel.
+    tx: Sender<String>,
+}
+
+impl BookmarkNamePopup<'_> {
+    pub fn new_create(tx: Sender<String>) -> BookmarkNamePopup<'static> {
+        BookmarkNamePopup {
+            mode: BookmarkNameMode::Create,
+            textarea: TextArea::default(),
+            error: None,
+            tx,
+        }
+    }
+
+    pub fn new_rename(old_name: String, tx: Sender<String>) -> BookmarkNamePopup<'static> {
+        let mut textarea = TextArea::new(vec![old_name.clone()]);
+        textarea.move_cursor(CursorMove::End);
+        BookmarkNamePopup {
+            mode: BookmarkNameMode::Rename { old_name },
+            textarea,
+            error: None,
+            tx,
+        }
+    }
+
+    fn title(&self) -> &str {
+        match &self.mode {
+            BookmarkNameMode::Create => " Create bookmark ",
+            BookmarkNameMode::Rename { .. } => " Rename bookmark ",
+        }
+    }
+
+    fn run_command(&self, name: &str) -> Result<(), anyhow::Error> {
+        match &self.mode {
+            BookmarkNameMode::Create => new_commander()
+                .create_bookmark(name)
+                .map(|_| ())
+                .map_err(anyhow::Error::new),
+            BookmarkNameMode::Rename { old_name } => new_commander()
+                .rename_bookmark(old_name, name)
+                .map_err(anyhow::Error::new),
+        }
+    }
+}
+
+impl Component for BookmarkNamePopup<'_> {
+    fn draw(&mut self, f: &mut Frame<'_>, area: Rect) -> Result<()> {
+        let block = Block::bordered()
+            .title(Span::styled(self.title(), Style::new().bold().cyan()))
+            .title_alignment(Alignment::Center)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(Color::Green));
+
+        let error_lines = self
+            .error
+            .as_ref()
+            .map(|e| e.to_string().into_text().unwrap().lines);
+        let error_height = error_lines.as_ref().map_or(0, |l| l.len() + 1);
+
+        let area = centered_rect_line_height(area, 30, 5 + error_height as u16);
+        f.render_widget(Clear, area);
+        f.render_widget(&block, area);
+
+        let popup_chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Fill(1),
+                Constraint::Length(error_height as u16),
+                Constraint::Length(2),
+            ])
+            .split(block.inner(area));
+
+        f.render_widget(&self.textarea, popup_chunks[0]);
+
+        if let Some(error_lines) = error_lines {
+            f.render_widget(
+                Paragraph::new(error_lines).block(
+                    Block::default()
+                        .borders(Borders::TOP)
+                        .border_type(BorderType::Rounded)
+                        .border_style(Style::default().fg(Color::DarkGray)),
+                ),
+                popup_chunks[1],
+            );
+        }
+
+        f.render_widget(
+            Paragraph::new(vec!["Ctrl+s: save | Escape: cancel".into()])
+                .fg(Color::DarkGray)
+                .alignment(Alignment::Center)
+                .block(
+                    Block::default()
+                        .borders(Borders::TOP)
+                        .border_type(BorderType::Rounded)
+                        .border_style(Style::default().fg(Color::DarkGray)),
+                ),
+            popup_chunks[2],
+        );
+
+        Ok(())
+    }
+
+    fn input(&mut self, event: Event) -> Result<ComponentInputResult> {
+        if let Event::Key(key) = event
+            && key.kind == KeyEventKind::Press
+        {
+            let is_save = (key.code == KeyCode::Char('s')
+                && key.modifiers.contains(KeyModifiers::CONTROL))
+                || key.code == KeyCode::Enter;
+
+            if is_save {
+                let name = self.textarea.lines().join("\n");
+                if name.trim().is_empty() {
+                    self.error = Some(anyhow::anyhow!("Bookmark name cannot be empty"));
+                    return Ok(ComponentInputResult::Handled);
+                }
+                match self.run_command(&name) {
+                    Ok(()) => {
+                        let _ = self.tx.send(name);
+                        return Ok(ComponentInputResult::HandledAction(AppAction::PopupDone));
+                    }
+                    Err(err) => {
+                        self.error = Some(err);
+                        return Ok(ComponentInputResult::Handled);
+                    }
+                }
+            }
+
+            if key.code == KeyCode::Esc {
+                return Ok(ComponentInputResult::HandledAction(
+                    AppAction::PopupCanceled,
+                ));
+            }
+        }
+        self.textarea.input(event);
+        Ok(ComponentInputResult::Handled)
+    }
+}

--- a/src/ui/dialog/mod.rs
+++ b/src/ui/dialog/mod.rs
@@ -8,6 +8,7 @@ until it sends [`AppAction::PopupDone`](crate::ui::AppAction) or
 [`AppAction::PopupCanceled`](crate::ui::AppAction).
 */
 
+mod bookmark_name;
 mod bookmark_set;
 mod command;
 mod describe;
@@ -16,6 +17,7 @@ mod loader;
 mod message;
 mod rebase;
 
+pub use bookmark_name::BookmarkNamePopup;
 pub use bookmark_set::BookmarkSetPopup;
 pub use command::CommandPopup;
 pub use describe::DescribePopup;


### PR DESCRIPTION
BookmarksTab keeps CreateBookmark and RenameBookmark as typed fields and draws and handles both inline, in two near-identical copies of the same code; a single BookmarkNamePopup with a mode enum covers both. Since a popup closed through SetPopup cannot return a value, it sends the saved name to the tab over a channel, which the tab needs in order to select the created or renamed bookmark afterwards. With no TextArea left in it, BookmarksTab loses its lifetime parameter.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
