### PR TITLE
Upgrade dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ dependencies = [
  "ratatui-core",
  "simdutf8",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -91,9 +91,18 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "atomic"
@@ -139,9 +148,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 dependencies = [
  "serde_core",
 ]
@@ -156,7 +165,7 @@ dependencies = [
  "clap",
  "crossterm 0.29.0",
  "insta",
- "itertools",
+ "itertools 0.15.0",
  "ratatui",
  "ratatui-textarea",
  "regex",
@@ -164,7 +173,7 @@ dependencies = [
  "serde_with",
  "shell-words",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "throbber-widgets-tui",
  "toml",
  "tracing",
@@ -185,10 +194,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytemuck"
@@ -229,9 +253,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -243,9 +267,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -253,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -265,14 +289,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -338,12 +362,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -361,7 +391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
  "base64",
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "crossterm_winapi",
  "derive_more",
  "document-features",
@@ -435,6 +465,37 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -666,6 +727,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -749,14 +815,15 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.47.2"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
 dependencies = [
  "console",
  "once_cell",
  "regex",
  "similar",
+ "strip-ansi-escapes",
  "tempfile",
 ]
 
@@ -789,10 +856,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "js-sys"
@@ -812,7 +941,7 @@ checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -840,12 +969,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "line-clipping"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -883,11 +1018,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -945,7 +1080,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1040,6 +1175,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddeed8580d347d2abf3dcf06a5f0b3dc020258338526b277847cd4248a70fc64"
+dependencies = [
+ "approx",
+ "libm",
+ "palette_derive",
+ "palette_math",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88537020289b719d81be994ccf1bbf4990f477e2f69ee52fe3e45f43a02e56be"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "palette_math"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e6eb142958d64335fb0e345c5b9ead2ecd6fc438c307e9d7d3c4fd428dbaf12"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -1173,6 +1341,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1273,14 +1450,15 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.30.0"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
 dependencies = [
  "instability",
  "ratatui-core",
  "ratatui-crossterm",
  "ratatui-macros",
+ "ratatui-termina",
  "ratatui-termion",
  "ratatui-termwiz",
  "ratatui-widgets",
@@ -1289,20 +1467,21 @@ dependencies = [
 
 [[package]]
 name = "ratatui-core"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "compact_str",
- "hashbrown 0.16.1",
- "indoc",
- "itertools",
+ "critical-section",
+ "hashbrown 0.17.0",
+ "itertools 0.14.0",
  "kasuari",
  "lru",
+ "palette",
  "serde",
  "strum",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width",
@@ -1310,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-crossterm"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
 dependencies = [
  "cfg-if",
  "crossterm 0.28.1",
@@ -1323,19 +1502,30 @@ dependencies = [
 
 [[package]]
 name = "ratatui-macros"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+checksum = "ed7dc68daa7498a43e4d68e0eb078427e10c38fbcfbb1e42d955f1fa2140d814"
 dependencies = [
  "ratatui-core",
  "ratatui-widgets",
 ]
 
 [[package]]
-name = "ratatui-termion"
+name = "ratatui-termina"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cade85a8591fbc911e147951422f0d6fd40f4948b271b6216c7dc01838996f8"
+checksum = "c0bf912d9e66f057a759d92e386a280ea886b352ab757d6ac4d653c7ed2c43c2"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "termina",
+]
+
+[[package]]
+name = "ratatui-termion"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87c732202fa5a71a9da0991013f0853e53f87048f45198e3a1ca3ee722accc2f"
 dependencies = [
  "instability",
  "ratatui-core",
@@ -1344,9 +1534,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-termwiz"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+checksum = "faf03e0380b7744054d6cb74224fe3adf062a029754933f575ca1e3b4c2ce977"
 dependencies = [
  "ratatui-core",
  "termwiz",
@@ -1354,9 +1544,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-textarea"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2950274c0e155944158cf766848dd87bd6db6dad27da1c23ee4a7c8de71dbf1f"
+checksum = "3c78d5ba0f26f97baed69a4c479f268a31c7b5b89d68ab939842152e383d6e73"
 dependencies = [
  "ratatui-core",
  "ratatui-crossterm",
@@ -1367,15 +1557,15 @@ dependencies = [
 
 [[package]]
 name = "ratatui-widgets"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
 dependencies = [
- "bitflags 2.11.1",
- "hashbrown 0.16.1",
+ "bitflags 2.13.1",
+ "hashbrown 0.17.0",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
  "serde",
@@ -1391,7 +1581,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -1416,9 +1606,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1428,9 +1618,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1439,9 +1629,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustc_version"
@@ -1458,7 +1648,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -1471,7 +1661,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -1528,9 +1718,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1538,22 +1728,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1580,15 +1770,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.14.0",
+ "jiff",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -1599,9 +1791,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1703,6 +1895,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1710,18 +1911,18 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1752,6 +1953,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1761,6 +1973,19 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termina"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
+dependencies = [
+ "bitflags 2.13.1",
+ "parking_lot",
+ "rustix 1.1.4",
+ "signal-hook",
  "windows-sys 0.61.2",
 ]
 
@@ -1804,7 +2029,7 @@ checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
  "base64",
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
@@ -1850,11 +2075,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -1870,13 +2095,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1890,9 +2115,9 @@ dependencies = [
 
 [[package]]
 name = "throbber-widgets-tui"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e6941f74491a80911cb8821cb1f55f7e13bca867b28a2b14e5a1daaf691eb3"
+checksum = "0b0452e418faaa263a742d94e5c2f9f50c777a0ae5b3ec53ce754d917d568e36"
 dependencies = [
  "ratatui",
 ]
@@ -1931,10 +2156,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml"
-version = "1.1.2+spec-1.1.0"
+name = "tinyvec"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "toml"
+version = "1.1.4+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap 2.14.0",
  "serde_core",
@@ -1956,18 +2196,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tracing"
@@ -2080,7 +2320,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -2133,6 +2373,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vte"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "vtparse"
@@ -2240,7 +2489,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
@@ -2553,7 +2802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "indexmap 2.14.0",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,30 +16,30 @@ pkg-url = "{ repo }/releases/download/v{ version }/blazingjj-v{ version }-{ targ
 
 [dependencies]
 ansi-to-tui = "8.0.1"
-anyhow = "1.0.100"
-chrono = "0.4.42"
-clap = { version = "4.5.53", features = ["derive", "env"] }
+anyhow = "1.0.104"
+chrono = "0.4.45"
+clap = { version = "4.6.6", features = ["derive", "env"] }
 crossterm = { version = "0.29.0", features = ["osc52"] }
-insta = { version = "1.45.0", features = ["filters"] }
-itertools = "0.14.0"
-ratatui = { version = "0.30.0", features = [
+insta = { version = "1.48.0", features = ["filters"] }
+itertools = "0.15.0"
+ratatui = { version = "0.30.2", features = [
   "serde",
   "unstable-rendered-line-info",
 ] }
-regex = "1.12.2"
-serde = { version = "1.0.228", features = ["derive"] }
-serde_with = "3.16.1"
+regex = "1.13.1"
+serde = { version = "1.0.229", features = ["derive"] }
+serde_with = "3.22.0"
 shell-words = "1.1.1"
-tempfile = "3.24.0"
-thiserror = "2.0.17"
-throbber-widgets-tui = "0.11.0"
-toml = "1.1.0"
+tempfile = "3.27.0"
+thiserror = "2.0.20"
+throbber-widgets-tui = "0.11.1"
+toml = "1.1.4"
 tracing = { version = "0.1.44", features = ["attributes"] }
 tracing-chrome = "0.7.2"
 tracing-log = "0.2.0"
-tracing-subscriber = "0.3.22"
-ratatui-textarea = "0.9.1"
-tui_confirm_dialog = "0.4.0"
+tracing-subscriber = "0.3.23"
+ratatui-textarea = "0.9.2"
+tui_confirm_dialog = "0.4.1"
 version-compare = "0.2.1"
 
 # Release build optimize size.


### PR DESCRIPTION
| Package                    | From             | To               | Compare   |
|----------------------------|------------------|------------------|-----------|
| [anyhow][01]               | 1.0.102          | 1.0.104          | [...][02] |
| [approx][03]               | NEW              | 0.5.1            |           |
| [bitflags][04]             | 2.11.1           | 2.13.1           | [...][05] |
| [bs58][06]                 | NEW              | 0.5.1            |           |
| [by_address][07]           | NEW              | 1.2.1            |           |
| [chrono][08]               | 0.4.44           | 0.4.45           | [...][09] |
| [clap][0A]                 | 4.6.1            | 4.6.6            | [...][0B] |
| [clap_builder][0C]         | 4.6.0            | 4.6.6            | [...][0D] |
| [clap_derive][0E]          | 4.6.1            | 4.6.4            | [...][0F] |
| [critical-section][10]     | NEW              | 1.2.0            |           |
| [defmt][11]                | NEW              | 1.1.1            |           |
| [defmt-macros][12]         | NEW              | 1.1.1            |           |
| [defmt-parser][13]         | NEW              | 1.0.0            |           |
| [insta][14]                | 1.47.2           | 1.48.0           | [...][15] |
| [itertools][16]            | NEW              | 0.15.0           |           |
| [jiff][17]                 | NEW              | 0.2.35           |           |
| [jiff-core][18]            | NEW              | 0.1.0            |           |
| [jiff-static][19]          | NEW              | 0.2.35           |           |
| [jiff-tzdb][1A]            | NEW              | 0.1.8            |           |
| [jiff-tzdb-platform][1B]   | NEW              | 0.1.3            |           |
| [libm][1C]                 | NEW              | 0.2.16           |           |
| [lru][1D]                  | 0.16.4           | 0.18.2           | [...][1E] |
| [palette][1F]              | NEW              | 0.7.7            |           |
| [palette_derive][20]       | NEW              | 0.7.7            |           |
| [palette_math][21]         | NEW              | 0.7.7            |           |
| [portable-atomic-util][22] | NEW              | 0.2.7            |           |
| [ratatui][23]              | 0.30.0           | 0.30.2           | [...][24] |
| [ratatui-core][25]         | 0.1.0            | 0.1.2            | [...][26] |
| [ratatui-crossterm][27]    | 0.1.0            | 0.1.2            | [...][28] |
| [ratatui-macros][29]       | 0.7.0            | 0.7.2            | [...][2A] |
| [ratatui-termina][2B]      | NEW              | 0.1.0            |           |
| [ratatui-termion][2C]      | 0.1.0            | 0.1.2            | [...][2D] |
| [ratatui-termwiz][2E]      | 0.1.0            | 0.1.2            | [...][2F] |
| [ratatui-textarea][30]     | 0.9.1            | 0.9.2            | [...][31] |
| [ratatui-widgets][32]      | 0.3.0            | 0.3.2            | [...][33] |
| [regex][34]                | 1.12.3           | 1.13.1           | [...][35] |
| [regex-automata][36]       | 0.4.14           | 0.4.18           | [...][37] |
| [regex-syntax][38]         | 0.8.10           | 0.8.11           | [...][39] |
| [serde][3A]                | 1.0.228          | 1.0.229          | [...][3B] |
| [serde_core][3C]           | 1.0.228          | 1.0.229          | [...][3D] |
| [serde_derive][3E]         | 1.0.228          | 1.0.229          | [...][3F] |
| [serde_with][40]           | 3.18.0           | 3.22.0           | [...][41] |
| [serde_with_macros][42]    | 3.18.0           | 3.22.0           | [...][43] |
| [strip-ansi-escapes][44]   | NEW              | 0.2.1            |           |
| [strum][45]                | 0.27.2           | 0.28.0           | [...][46] |
| [strum_macros][47]         | 0.27.2           | 0.28.0           | [...][48] |
| [syn][49]                  | NEW              | 3.0.3            |           |
| [termina][4A]              | NEW              | 0.3.3            |           |
| [thiserror][4B]            | 2.0.18           | 2.0.20           | [...][4C] |
| [thiserror-impl][4D]       | 2.0.18           | 2.0.20           | [...][4E] |
| [throbber-widgets-tui][4F] | 0.11.0           | 0.11.1           | [...][50] |
| [tinyvec][51]              | NEW              | 1.12.0           |           |
| [tinyvec_macros][52]       | NEW              | 0.1.1            |           |
| [toml][53]                 | 1.1.2+spec-1.1.0 | 1.1.4+spec-1.1.0 | [...][54] |
| [toml_parser][55]          | 1.1.2+spec-1.1.0 | 1.1.3+spec-1.1.0 | [...][56] |
| [toml_writer][57]          | 1.1.1+spec-1.1.0 | 1.1.2+spec-1.1.0 | [...][58] |
| [vte][59]                  | NEW              | 0.14.1           |           |

[01]: https://crates.io/crates/anyhow
[02]: https://diff.rs/anyhow/1%2E0%2E102/anyhow/1%2E0%2E104/Cargo.toml
[03]: https://crates.io/crates/approx
[04]: https://crates.io/crates/bitflags
[05]: https://diff.rs/bitflags/2%2E11%2E1/bitflags/2%2E13%2E1/Cargo.toml
[06]: https://crates.io/crates/bs58
[07]: https://crates.io/crates/by_address
[08]: https://crates.io/crates/chrono
[09]: https://diff.rs/chrono/0%2E4%2E44/chrono/0%2E4%2E45/Cargo.toml
[0A]: https://crates.io/crates/clap
[0B]: https://diff.rs/clap/4%2E6%2E1/clap/4%2E6%2E6/Cargo.toml
[0C]: https://crates.io/crates/clap_builder
[0D]: https://diff.rs/clap%5Fbuilder/4%2E6%2E0/clap%5Fbuilder/4%2E6%2E6/Cargo.toml
[0E]: https://crates.io/crates/clap_derive
[0F]: https://diff.rs/clap%5Fderive/4%2E6%2E1/clap%5Fderive/4%2E6%2E4/Cargo.toml
[10]: https://crates.io/crates/critical-section
[11]: https://crates.io/crates/defmt
[12]: https://crates.io/crates/defmt-macros
[13]: https://crates.io/crates/defmt-parser
[14]: https://crates.io/crates/insta
[15]: https://diff.rs/insta/1%2E47%2E2/insta/1%2E48%2E0/Cargo.toml
[16]: https://crates.io/crates/itertools
[17]: https://crates.io/crates/jiff
[18]: https://crates.io/crates/jiff-core
[19]: https://crates.io/crates/jiff-static
[1A]: https://crates.io/crates/jiff-tzdb
[1B]: https://crates.io/crates/jiff-tzdb-platform
[1C]: https://crates.io/crates/libm
[1D]: https://crates.io/crates/lru
[1E]: https://diff.rs/lru/0%2E16%2E4/lru/0%2E18%2E2/Cargo.toml
[1F]: https://crates.io/crates/palette
[20]: https://crates.io/crates/palette_derive
[21]: https://crates.io/crates/palette_math
[22]: https://crates.io/crates/portable-atomic-util
[23]: https://crates.io/crates/ratatui
[24]: https://diff.rs/ratatui/0%2E30%2E0/ratatui/0%2E30%2E2/Cargo.toml
[25]: https://crates.io/crates/ratatui-core
[26]: https://diff.rs/ratatui%2Dcore/0%2E1%2E0/ratatui%2Dcore/0%2E1%2E2/Cargo.toml
[27]: https://crates.io/crates/ratatui-crossterm
[28]: https://diff.rs/ratatui%2Dcrossterm/0%2E1%2E0/ratatui%2Dcrossterm/0%2E1%2E2/Cargo.toml
[29]: https://crates.io/crates/ratatui-macros
[2A]: https://diff.rs/ratatui%2Dmacros/0%2E7%2E0/ratatui%2Dmacros/0%2E7%2E2/Cargo.toml
[2B]: https://crates.io/crates/ratatui-termina
[2C]: https://crates.io/crates/ratatui-termion
[2D]: https://diff.rs/ratatui%2Dtermion/0%2E1%2E0/ratatui%2Dtermion/0%2E1%2E2/Cargo.toml
[2E]: https://crates.io/crates/ratatui-termwiz
[2F]: https://diff.rs/ratatui%2Dtermwiz/0%2E1%2E0/ratatui%2Dtermwiz/0%2E1%2E2/Cargo.toml
[30]: https://crates.io/crates/ratatui-textarea
[31]: https://diff.rs/ratatui%2Dtextarea/0%2E9%2E1/ratatui%2Dtextarea/0%2E9%2E2/Cargo.toml
[32]: https://crates.io/crates/ratatui-widgets
[33]: https://diff.rs/ratatui%2Dwidgets/0%2E3%2E0/ratatui%2Dwidgets/0%2E3%2E2/Cargo.toml
[34]: https://crates.io/crates/regex
[35]: https://diff.rs/regex/1%2E12%2E3/regex/1%2E13%2E1/Cargo.toml
[36]: https://crates.io/crates/regex-automata
[37]: https://diff.rs/regex%2Dautomata/0%2E4%2E14/regex%2Dautomata/0%2E4%2E18/Cargo.toml
[38]: https://crates.io/crates/regex-syntax
[39]: https://diff.rs/regex%2Dsyntax/0%2E8%2E10/regex%2Dsyntax/0%2E8%2E11/Cargo.toml
[3A]: https://crates.io/crates/serde
[3B]: https://diff.rs/serde/1%2E0%2E228/serde/1%2E0%2E229/Cargo.toml
[3C]: https://crates.io/crates/serde_core
[3D]: https://diff.rs/serde%5Fcore/1%2E0%2E228/serde%5Fcore/1%2E0%2E229/Cargo.toml
[3E]: https://crates.io/crates/serde_derive
[3F]: https://diff.rs/serde%5Fderive/1%2E0%2E228/serde%5Fderive/1%2E0%2E229/Cargo.toml
[40]: https://crates.io/crates/serde_with
[41]: https://diff.rs/serde%5Fwith/3%2E18%2E0/serde%5Fwith/3%2E22%2E0/Cargo.toml
[42]: https://crates.io/crates/serde_with_macros
[43]: https://diff.rs/serde%5Fwith%5Fmacros/3%2E18%2E0/serde%5Fwith%5Fmacros/3%2E22%2E0/Cargo.toml
[44]: https://crates.io/crates/strip-ansi-escapes
[45]: https://crates.io/crates/strum
[46]: https://diff.rs/strum/0%2E27%2E2/strum/0%2E28%2E0/Cargo.toml
[47]: https://crates.io/crates/strum_macros
[48]: https://diff.rs/strum%5Fmacros/0%2E27%2E2/strum%5Fmacros/0%2E28%2E0/Cargo.toml
[49]: https://crates.io/crates/syn
[4A]: https://crates.io/crates/termina
[4B]: https://crates.io/crates/thiserror
[4C]: https://diff.rs/thiserror/2%2E0%2E18/thiserror/2%2E0%2E20/Cargo.toml
[4D]: https://crates.io/crates/thiserror-impl
[4E]: https://diff.rs/thiserror%2Dimpl/2%2E0%2E18/thiserror%2Dimpl/2%2E0%2E20/Cargo.toml
[4F]: https://crates.io/crates/throbber-widgets-tui
[50]: https://diff.rs/throbber%2Dwidgets%2Dtui/0%2E11%2E0/throbber%2Dwidgets%2Dtui/0%2E11%2E1/Cargo.toml
[51]: https://crates.io/crates/tinyvec
[52]: https://crates.io/crates/tinyvec_macros
[53]: https://crates.io/crates/toml
[54]: https://diff.rs/toml/1%2E1%2E2%2Bspec%2D1%2E1%2E0/toml/1%2E1%2E4%2Bspec%2D1%2E1%2E0/Cargo.toml
[55]: https://crates.io/crates/toml_parser
[56]: https://diff.rs/toml%5Fparser/1%2E1%2E2%2Bspec%2D1%2E1%2E0/toml%5Fparser/1%2E1%2E3%2Bspec%2D1%2E1%2E0/Cargo.toml
[57]: https://crates.io/crates/toml_writer
[58]: https://diff.rs/toml%5Fwriter/1%2E1%2E1%2Bspec%2D1%2E1%2E0/toml%5Fwriter/1%2E1%2E2%2Bspec%2D1%2E1%2E0/Cargo.toml
[59]: https://crates.io/crates/vte
