### PR TITLE
Read the log head information from a JSON template

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,7 @@ dependencies = [
  "ratatui-textarea",
  "regex",
  "serde",
+ "serde_json",
  "serde_with",
  "shell-words",
  "tempfile",
@@ -1037,9 +1038,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmem"
@@ -1376,18 +1377,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -1748,9 +1749,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -2854,6 +2855,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ ratatui = { version = "0.30.2", features = [
 regex = "1.13.1"
 serde = { version = "1.0.229", features = ["derive"] }
 serde_with = "3.22.0"
+serde_json = "1.0.151"
 shell-words = "1.1.1"
 tempfile = "3.27.0"
 thiserror = "2.0.20"

--- a/src/commander/ids.rs
+++ b/src/commander/ids.rs
@@ -4,8 +4,10 @@ Helper structs [ChangeId] and [CommitId]
 use std::ffi::OsStr;
 use std::fmt::Display;
 
+use serde::Deserialize;
+
 /// Wrapper around change ID.
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Deserialize)]
 pub struct ChangeId(pub String);
 
 impl ChangeId {
@@ -35,7 +37,7 @@ impl Display for ChangeId {
 }
 
 /// Wrapper around commit ID.
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Deserialize)]
 pub struct CommitId(pub String);
 
 impl CommitId {

--- a/src/commander/log.rs
+++ b/src/commander/log.rs
@@ -7,14 +7,12 @@ It is mostly used in the [log_tab][crate::ui::log_tab] module.
 
 use std::fmt::Display;
 use std::process::Child;
-use std::sync::LazyLock;
 
 use anyhow::Context;
 use anyhow::Result;
-use anyhow::anyhow;
 use anyhow::bail;
 use itertools::Itertools;
-use regex::Regex;
+use serde::Deserialize;
 use thiserror::Error;
 use tracing::instrument;
 
@@ -27,7 +25,9 @@ use crate::commander::ids::ChangeId;
 use crate::commander::ids::CommitId;
 use crate::env::DiffFormat;
 
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+/// A change as [HEAD_TEMPLATE] describes it. The field names are the ones
+/// the template writes.
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Deserialize)]
 pub struct Head {
     pub change_id: ChangeId,
     pub commit_id: CommitId,
@@ -58,37 +58,37 @@ impl Display for HeadParseError {
     }
 }
 
-// Template which outputs `[change_id|commit_id|divergent]`. Used to parse data from log and other
-// commands which supports templating.
-const HEAD_TEMPLATE: &str =
-    r#""[" ++ change_id ++ "|" ++ commit_id ++ "|" ++ divergent ++ "|" ++ immutable ++ "]""#;
-const HEAD_TEMPLATE_NL: &str = r#""[" ++ change_id ++ "|" ++ commit_id ++ "|" ++ divergent ++ "|" ++ immutable ++ "]" ++ "\n""#;
-// Regex to parse HEAD_TEMPLATE
-static HEAD_TEMPLATE_REGEX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"\[(.*)\|(.*)\|(.*)\|(.*)\]").unwrap());
+/// Template writing a [Head] as a JSON object, for `jj log` and the other
+/// commands that take a template. `escape_json()` keeps a value that needs
+/// quoting from ending the object early, or the line.
+const HEAD_TEMPLATE: &str = r#"
+    '{"change_id":' ++ stringify(change_id).escape_json()
+    ++ ',"commit_id":' ++ stringify(commit_id).escape_json()
+    ++ ',"divergent":' ++ divergent
+    ++ ',"immutable":' ++ immutable
+    ++ '}'
+"#;
+/// [HEAD_TEMPLATE] with a newline behind it, so that output holding more
+/// than one head has one object per line.
+const HEAD_TEMPLATE_NL: &str = r#"
+    '{"change_id":' ++ stringify(change_id).escape_json()
+    ++ ',"commit_id":' ++ stringify(commit_id).escape_json()
+    ++ ',"divergent":' ++ divergent
+    ++ ',"immutable":' ++ immutable
+    ++ '}'
+    ++ "\n"
+"#;
 
-// Parse a head with HEAD_TEMPLATE.
+/// Parse the [Head] one line of [HEAD_TEMPLATE] output describes.
+///
+/// jj draws the graph in front of what the template writes, so the object
+/// starts at the first brace of the line. A line the graph draws for edges
+/// alone carries no template output, and neither does one for an elided
+/// revision, so those have no brace and no head.
 fn parse_head(text: &str) -> Result<Head> {
-    let captured = HEAD_TEMPLATE_REGEX.captures(text);
-    captured
-        .as_ref()
-        .map_or(Err(anyhow!(HeadParseError(text.to_owned()))), |captured| {
-            if let (Some(change_id), Some(commit_id), Some(divergent), Some(immutable)) = (
-                captured.get(1),
-                captured.get(2),
-                captured.get(3),
-                captured.get(4),
-            ) {
-                Ok(Head {
-                    change_id: ChangeId(change_id.as_str().to_string()),
-                    commit_id: CommitId(commit_id.as_str().to_string()),
-                    divergent: divergent.as_str() == "true",
-                    immutable: immutable.as_str() == "true",
-                })
-            } else {
-                bail!(HeadParseError(text.to_owned()))
-            }
-        })
+    text.find('{')
+        .and_then(|start| serde_json::from_str(&text[start..]).ok())
+        .ok_or_else(|| HeadParseError(text.to_owned()).into())
 }
 
 impl Commander {
@@ -133,7 +133,7 @@ impl Commander {
             .run()?;
 
         // Extract the log one more time, but this time use a template
-        // where each line begins with Head information. Since jj has
+        // which describes the head behind each line. Since jj has
         // 2 lines per change, there will also be two lines with head info.
         // The number of lines in graph and the number of items in graph_heads
         // should be identical.
@@ -143,7 +143,7 @@ impl Commander {
                     "log",
                     "--template",
                     // Match builtin_log_compact with 2 lines per change
-                    &format!(r#"{HEAD_TEMPLATE} ++ " " ++ bookmarks ++"\n" ++ {HEAD_TEMPLATE}"#),
+                    &format!(r#"{HEAD_TEMPLATE} ++ "\n" ++ {HEAD_TEMPLATE}"#),
                 ],
                 args,
             ]
@@ -319,6 +319,51 @@ mod tests {
 
     use super::*;
     use crate::commander::tests::TestRepo;
+
+    fn head(change_id: &str, commit_id: &str, divergent: bool, immutable: bool) -> Head {
+        Head {
+            change_id: ChangeId(change_id.to_owned()),
+            commit_id: CommitId(commit_id.to_owned()),
+            divergent,
+            immutable,
+        }
+    }
+
+    #[test]
+    fn parse_head_reads_a_record_of_its_own() -> Result<()> {
+        assert_eq!(
+            parse_head(
+                r#"{"change_id":"kxq","commit_id":"1f2e","divergent":false,"immutable":true}"#
+            )?,
+            head("kxq", "1f2e", false, true)
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn parse_head_reads_a_record_behind_the_graph() -> Result<()> {
+        assert_eq!(
+            parse_head(
+                r#"│ ├─╮  {"change_id":"kxq","commit_id":"1f2e","divergent":true,"immutable":false}"#
+            )?,
+            head("kxq", "1f2e", true, false)
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn a_graph_line_without_a_record_has_no_head() {
+        assert!(parse_head("│ ├─╯").is_err());
+        assert!(parse_head("~  (elided revisions)").is_err());
+        assert!(parse_head("").is_err());
+    }
+
+    #[test]
+    fn a_record_missing_a_field_is_no_head() {
+        assert!(parse_head(r#"{"change_id":"kxq","commit_id":"1f2e"}"#).is_err());
+    }
 
     #[test]
     fn get_log() -> Result<()> {


### PR DESCRIPTION
The head template packs change ID, commit ID and the divergent and immutable flags between brackets separated by `|`, which a regex of four greedy `(.*)` groups takes apart again. Position is all that ties a group to a field, and nothing keeps a value out of the delimiters -- what carries the parse today is only that IDs are hex and that flags render as `true` or `false`.

The log tab also asks for `bookmarks` behind the head, which nothing reads. Where the regex ignores trailing text, serde rejects it, so dropping that is part of the parse rather than cleanup alongside it.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
