### PR TITLE
Read bookmark information from a JSON template

### DIFF
--- a/src/commander/bookmarks.rs
+++ b/src/commander/bookmarks.rs
@@ -7,13 +7,12 @@ other jj bookmark commands are defined in module [jj][super::jj].
 It is mostly used in the [bookmarks_tab][crate::ui::bookmarks_tab] module.
 */
 use std::fmt::Display;
-use std::sync::LazyLock;
 
 use ansi_to_tui::IntoText;
 use anyhow::Result;
 use itertools::Itertools;
 use ratatui::text::Text;
-use regex::Regex;
+use serde::Deserialize;
 use tracing::instrument;
 
 use crate::commander::CommandError;
@@ -22,7 +21,12 @@ use crate::commander::RemoveEndLine;
 use crate::commander::ids::ChangeId;
 use crate::env::DiffFormat;
 
-#[derive(Clone, Debug, PartialEq)]
+/// A bookmark as [BRANCH_TEMPLATE] describes it. The field names are the
+/// ones the template writes.
+///
+/// `name` and `remote` are revset symbols, quoted where a plain name would
+/// not do, as every jj command taking one of them wants it.
+#[derive(Clone, Debug, PartialEq, Deserialize)]
 pub struct Bookmark {
     pub name: String,
     pub remote: Option<String>,
@@ -41,37 +45,26 @@ impl Display for Bookmark {
     }
 }
 
-// Template which outputs `[name@remote]`. Used to parse data from bookmark list
-const BRANCH_TEMPLATE: &str = r#""[" ++ name ++ "@" ++ remote ++ "|" ++ present ++ "|" ++ self.normal_target().committer().timestamp().format("%s") ++ "]""#;
-// Regex to parse bookmark
-static BRANCH_REGEX: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^\[(.*)@(.*)\|(true|false)\|(\d+)\]$").unwrap());
+/// Template writing a [Bookmark] as a JSON object, one per line.
+///
+/// `name` and `remote` are revset symbols, which jj only quotes when it
+/// renders them as a template -- `stringify()` alone would hand back the
+/// bare name. Concatenating is what puts them through that rendering.
+///
+/// A bookmark that has no single target has no timestamp either, and jj
+/// writes its error where the number belongs. That leaves the line
+/// unparsable, which is how such a bookmark is meant to come out.
+const BRANCH_TEMPLATE: &str = r#"
+    '{"name":' ++ stringify(concat(name)).escape_json()
+    ++ ',"remote":' ++ if(remote, stringify(concat(remote)).escape_json(), 'null')
+    ++ ',"present":' ++ present
+    ++ ',"timestamp":' ++ self.normal_target().committer().timestamp().format("%s")
+    ++ '}' ++ "\n"
+"#;
 
+/// Parse the [Bookmark] one line of [BRANCH_TEMPLATE] output describes.
 fn parse_bookmark(text: &str) -> Option<Bookmark> {
-    let captured = BRANCH_REGEX.captures(text);
-    captured.as_ref().and_then(|captured| {
-        let name = captured.get(1);
-        let remote = captured.get(2);
-        let present = captured.get(3);
-        let timestamp = captured.get(4);
-        if let (Some(name), Some(remote), Some(present), Some(timestamp)) =
-            (name, remote, present, timestamp)
-        {
-            let remote = remote.as_str().to_owned();
-            Some(Bookmark {
-                remote: if remote.is_empty() {
-                    None
-                } else {
-                    Some(remote)
-                },
-                name: name.as_str().to_owned(),
-                present: present.as_str() == "true",
-                timestamp: timestamp.as_str().parse::<i64>().unwrap_or(0),
-            })
-        } else {
-            None
-        }
-    })
+    serde_json::from_str(text).ok()
 }
 
 #[derive(Clone, Debug)]
@@ -121,16 +114,7 @@ impl Commander {
             .run()?;
 
         let bookmarks: Vec<BookmarkLine> = self
-            .jj([
-                vec![
-                    "bookmark",
-                    "list",
-                    "-T",
-                    &format!(r#"{BRANCH_TEMPLATE} ++ "\n""#),
-                ],
-                args,
-            ]
-            .concat())
+            .jj([vec!["bookmark", "list", "-T", BRANCH_TEMPLATE], args].concat())
             .run()?
             .lines()
             .zip(bookmarks_colored.lines())
@@ -152,7 +136,7 @@ impl Commander {
             "bookmark".to_owned(),
             "list".to_owned(),
             "-T".to_owned(),
-            format!(r#"if(present, {} ++ "\n", "")"#, BRANCH_TEMPLATE),
+            format!(r#"if(present, {BRANCH_TEMPLATE}, "")"#),
         ];
         if show_all {
             args.push("--all-remotes".to_owned());
@@ -212,6 +196,65 @@ mod tests {
 
     use super::*;
     use crate::commander::tests::TestRepo;
+
+    #[test]
+    fn parse_bookmark_reads_a_local_bookmark() {
+        assert_eq!(
+            parse_bookmark(
+                r#"{"name":"main","remote":null,"present":true,"timestamp":1786973730}"#
+            ),
+            Some(Bookmark {
+                name: "main".to_owned(),
+                remote: None,
+                present: true,
+                timestamp: 1786973730,
+            })
+        );
+    }
+
+    #[test]
+    fn parse_bookmark_reads_a_remote_bookmark() {
+        assert_eq!(
+            parse_bookmark(
+                r#"{"name":"main","remote":"origin","present":false,"timestamp":1786973730}"#
+            ),
+            Some(Bookmark {
+                name: "main".to_owned(),
+                remote: Some("origin".to_owned()),
+                present: false,
+                timestamp: 1786973730,
+            })
+        );
+    }
+
+    /// A name jj had to quote keeps its quotes, and an `@` in it stays on
+    /// the name side rather than being taken for the remote separator.
+    #[test]
+    fn parse_bookmark_reads_a_name_that_needed_quoting() {
+        assert_eq!(
+            parse_bookmark(
+                r#"{"name":"\"feature@v2\"","remote":"origin","present":true,"timestamp":1}"#
+            ),
+            Some(Bookmark {
+                name: "\"feature@v2\"".to_owned(),
+                remote: Some("origin".to_owned()),
+                present: true,
+                timestamp: 1,
+            })
+        );
+    }
+
+    /// Which is what jj leaves behind for a bookmark without a single
+    /// target, in place of the timestamp.
+    #[test]
+    fn parse_bookmark_rejects_a_record_holding_an_error() {
+        assert!(
+            parse_bookmark(
+                r#"{"name":"main","remote":null,"present":true,"timestamp":<Error: No commit available>}"#
+            )
+            .is_none()
+        );
+    }
 
     #[test]
     fn get_bookmarks() -> Result<()> {


### PR DESCRIPTION
The bookmark template packs name, remote, whether the bookmark is present and its target's commit timestamp between brackets, separated by `@` and `|`, and a regex takes them apart again. A bookmark name may hold any of those delimiters, so which value is which comes down to where they happen to fall -- an `@` in a name comes out right today only because the group before it is greedy and the anchored pattern has nowhere else to split.

The one thing the JSON template has to spell out is that `name` and `remote` are revset symbols: jj quotes those only while rendering them as a template, and `stringify()` on its own asks for the bare name instead. Every jj command these are handed to wants the symbol, so the template concatenates them to keep the quotes.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
