### PR TITLE
ui: Have the main loop own every read from the repo

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -90,9 +90,9 @@ impl<'a> App<'a> {
 
         Ok(App {
             current_tab: TabId::Log,
-            log: LogTab::new(event_source.clone_event_sender())?,
-            files: FilesTab::new(&current_head)?,
-            bookmarks: BookmarksTab::new()?,
+            log: LogTab::new(event_source.clone_event_sender(), current_head.clone()),
+            files: FilesTab::new(&current_head),
+            bookmarks: BookmarksTab::new(),
             popup: None,
             stats: Stats {
                 start_time: Instant::now(),
@@ -108,7 +108,7 @@ impl<'a> App<'a> {
         self.get_tab(self.current_tab)
     }
 
-    pub fn set_next_tab_with_offset(&mut self, offset: i64) -> Result<()> {
+    pub fn set_next_tab_with_offset(&mut self, offset: i64) {
         let current_index = TabId::VALUES
             .iter()
             .position(|&t| t == self.current_tab)
@@ -116,7 +116,7 @@ impl<'a> App<'a> {
         let new_index = (current_index as i64 + TabId::VALUES.len() as i64 + offset) as usize
             % TabId::VALUES.len();
         let new_tab: TabId = TabId::VALUES[new_index];
-        self.set_tab(new_tab)
+        self.set_tab(new_tab);
     }
 
     fn open_help(&mut self) -> Result<()> {
@@ -131,11 +131,14 @@ impl<'a> App<'a> {
         Ok(())
     }
 
-    pub fn set_tab(&mut self, tab: TabId) -> Result<()> {
+    pub fn set_tab(&mut self, tab: TabId) {
         info!("Setting tab to {}", tab);
         self.current_tab = tab;
-        self.get_current_tab().refresh()?;
-        Ok(())
+    }
+
+    /// Read the current tab if it is stale.
+    pub fn refresh_current_tab(&mut self) -> Result<()> {
+        self.get_current_tab().refresh()
     }
 
     pub fn get_tab(&mut self, tab: TabId) -> &mut dyn Tab {
@@ -151,12 +154,12 @@ impl<'a> App<'a> {
     pub fn handle_action(&mut self, app_action: AppAction) -> Result<()> {
         match app_action {
             AppAction::ViewFiles(head) => {
-                self.set_tab(TabId::Files)?;
+                self.set_tab(TabId::Files);
                 self.files.set_head(&head)?;
             }
             AppAction::ViewLog(head) => {
                 self.log.set_head(head);
-                self.set_tab(TabId::Log)?;
+                self.set_tab(TabId::Log);
             }
             AppAction::ChangeHead(head) => {
                 self.files.set_head(&head)?;
@@ -177,7 +180,7 @@ impl<'a> App<'a> {
                 }
             }
             AppAction::RefreshTab => {
-                self.set_tab(self.current_tab)?;
+                self.get_current_tab().mark_stale();
             }
         }
 
@@ -318,7 +321,7 @@ impl<'a> App<'a> {
                 }
             };
         } else if event == event::Event::FocusGained {
-            self.get_current_tab().refresh()?;
+            self.get_current_tab().mark_stale();
         } else {
             match self.get_current_tab().input(event.clone())? {
                 ComponentInputResult::HandledAction(app_action) => {
@@ -351,11 +354,11 @@ impl<'a> App<'a> {
                                 self.get_current_tab().drop_caches();
                                 self.handle_action(AppAction::RefreshTab)?;
                             }
-                            GlobalEvent::NextTab => self.set_next_tab_with_offset(1)?,
-                            GlobalEvent::PrevTab => self.set_next_tab_with_offset(-1)?,
-                            GlobalEvent::LogTab => self.set_tab(TabId::Log)?,
-                            GlobalEvent::FilesTab => self.set_tab(TabId::Files)?,
-                            GlobalEvent::BookmarksTab => self.set_tab(TabId::Bookmarks)?,
+                            GlobalEvent::NextTab => self.set_next_tab_with_offset(1),
+                            GlobalEvent::PrevTab => self.set_next_tab_with_offset(-1),
+                            GlobalEvent::LogTab => self.set_tab(TabId::Log),
+                            GlobalEvent::FilesTab => self.set_tab(TabId::Files),
+                            GlobalEvent::BookmarksTab => self.set_tab(TabId::Bookmarks),
                             GlobalEvent::CommandPopup => {
                                 self.popup = Some(Box::new(CommandPopup::new()));
                             }

--- a/src/commander/log.rs
+++ b/src/commander/log.rs
@@ -35,7 +35,7 @@ pub struct Head {
     pub immutable: bool,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct LogOutput {
     pub graph: String,
     // Maps graph line -> heads

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,6 +164,9 @@ fn run_app(terminal: &mut DefaultTerminal, app: &mut App) -> Result<()> {
     app.launch_input_channel();
     loop {
         app.update()?;
+
+        app.refresh_current_tab()?;
+
         terminal.draw(|f| {
             let _ = app.draw(f, f.area());
         })?;

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -76,6 +76,8 @@ pub struct BookmarksTab {
 
     config: JjConfig,
     pane_divider: PaneDivider,
+
+    stale: bool,
 }
 
 fn get_current_bookmark_index(
@@ -109,49 +111,25 @@ fn get_current_bookmark_index(
 }
 
 impl BookmarksTab {
+    /// A stale tab holding no bookmarks yet.
     #[instrument(level = "info", name = "Initializing bookmarks tab", parent = None, skip())]
-    pub fn new() -> Result<Self> {
-        let diff_format = get_env().jj_config.diff_format();
-
-        let show_all = false;
-
-        let bookmarks_output = new_commander().get_bookmarks(show_all);
-        let bookmark = bookmarks_output
-            .as_ref()
-            .ok()
-            .and_then(|bookmarks_output| bookmarks_output.first())
-            .map(|bookmarks_output| bookmarks_output.to_owned());
-
-        let bookmarks_list_state = ListState::default().with_selected(get_current_bookmark_index(
-            bookmark.as_ref(),
-            &bookmarks_output,
-        ));
-
-        let bookmark_output = bookmark.as_ref().and_then(|bookmark| match bookmark {
-            BookmarkLine::Parsed { bookmark, .. } => Some(
-                new_commander()
-                    .get_bookmark_show(bookmark, &diff_format, true)
-                    .map(|diff| tabs_to_spaces(&diff)),
-            ),
-            _ => None,
-        });
-
+    pub fn new() -> Self {
         let (popup_tx, popup_rx) = std::sync::mpsc::channel();
         let (bookmark_name_popup_tx, bookmark_name_popup_rx) = std::sync::mpsc::channel();
 
         let config = get_env().jj_config.clone();
         let pane_divider = PaneDivider::new(config.layout_percent());
 
-        Ok(Self {
-            bookmarks_output,
-            bookmark,
-            bookmarks_list_state,
+        Self {
+            bookmarks_output: Ok(Vec::new()),
+            bookmark: None,
+            bookmarks_list_state: ListState::default(),
             bookmarks_height: 0,
 
-            show_all,
+            show_all: false,
 
             bookmark_panel: DetailsPanel::new(),
-            bookmark_output,
+            bookmark_output: None,
 
             delete: None,
             forget: None,
@@ -167,11 +145,13 @@ impl BookmarksTab {
             bookmark_name_popup_tx,
             bookmark_name_popup_rx,
 
-            diff_format,
+            diff_format: get_env().jj_config.diff_format(),
 
             config,
             pane_divider,
-        })
+
+            stale: true,
+        }
     }
 
     pub fn get_current_bookmark_index(&self) -> Option<usize> {
@@ -180,6 +160,17 @@ impl BookmarksTab {
 
     pub fn refresh_bookmarks(&mut self) {
         self.bookmarks_output = new_commander().get_bookmarks(self.show_all);
+
+        // The selected bookmark may be gone, deleted from here or from
+        // anywhere else, so fall back to the first one.
+        if self.get_current_bookmark_index().is_none() {
+            self.bookmark = self
+                .bookmarks_output
+                .as_ref()
+                .ok()
+                .and_then(|bookmarks| bookmarks.first())
+                .map(|bookmark| bookmark.to_owned());
+        }
     }
 
     pub fn refresh_bookmark(&mut self) {
@@ -221,9 +212,17 @@ impl BookmarksTab {
 
 impl Tab for BookmarksTab {
     fn refresh(&mut self) -> Result<()> {
-        self.refresh_bookmarks();
-        self.refresh_bookmark();
+        if self.stale {
+            self.refresh_bookmarks();
+            self.refresh_bookmark();
+            self.stale = false;
+        }
+
         Ok(())
+    }
+
+    fn mark_stale(&mut self) {
+        self.stale = true;
     }
 
     fn scroll_main_panel(&mut self, scroll: Scroll) -> Result<()> {
@@ -278,15 +277,7 @@ impl Component for BookmarksTab {
                 DELETE_BRANCH_POPUP_ID => {
                     if let Some(delete) = self.delete.as_ref() {
                         match new_commander().delete_bookmark(&delete.name) {
-                            Ok(_) => {
-                                self.refresh_bookmarks();
-                                let bookmarks = Vec::new();
-                                let bookmarks =
-                                    self.bookmarks_output.as_ref().unwrap_or(&bookmarks);
-                                self.bookmark =
-                                    bookmarks.first().map(|bookmark| bookmark.to_owned());
-                                self.refresh_bookmark();
-                            }
+                            Ok(_) => return Ok(Some(AppAction::RefreshTab)),
                             Err(err) => {
                                 return Ok(Some(AppAction::SetPopup(Box::new(MessagePopup::new(
                                     "Delete error",
@@ -299,15 +290,7 @@ impl Component for BookmarksTab {
                 FORGET_BRANCH_POPUP_ID => {
                     if let Some(forget) = self.forget.as_ref() {
                         match new_commander().forget_bookmark(&forget.name) {
-                            Ok(_) => {
-                                self.refresh_bookmarks();
-                                let bookmarks = Vec::new();
-                                let bookmarks =
-                                    self.bookmarks_output.as_ref().unwrap_or(&bookmarks);
-                                self.bookmark =
-                                    bookmarks.first().map(|bookmark| bookmark.to_owned());
-                                self.refresh_bookmark();
-                            }
+                            Ok(_) => return Ok(Some(AppAction::RefreshTab)),
                             Err(err) => {
                                 return Ok(Some(AppAction::SetPopup(Box::new(MessagePopup::new(
                                     "Forget error",
@@ -591,8 +574,7 @@ impl Component for BookmarksTab {
                         && bookmark.present
                     {
                         new_commander().track_bookmark(bookmark)?;
-                        self.refresh_bookmarks();
-                        self.refresh_bookmark();
+                        return Ok(ComponentInputResult::HandledAction(AppAction::RefreshTab));
                     }
                 }
                 KeyCode::Char('T') => {
@@ -601,8 +583,7 @@ impl Component for BookmarksTab {
                         && bookmark.present
                     {
                         new_commander().untrack_bookmark(bookmark)?;
-                        self.refresh_bookmarks();
-                        self.refresh_bookmark();
+                        return Ok(ComponentInputResult::HandledAction(AppAction::RefreshTab));
                     }
                 }
                 KeyCode::Char('n') | KeyCode::Char('N') => {

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -45,6 +45,8 @@ pub struct FilesTab {
 
     config: JjConfig,
     pane_divider: PaneDivider,
+
+    stale: bool,
 }
 
 fn get_current_file_index(
@@ -63,55 +65,32 @@ fn get_current_file_index(
 }
 
 impl FilesTab {
+    /// A stale tab at `current_head`, holding no files yet.
     #[instrument(level = "info", name = "Initializing files tab", parent = None, skip())]
-    pub fn new(head: &Head) -> Result<Self> {
-        let head = head.clone();
-        let is_current_head = head == new_commander().get_current_head()?;
-
-        let diff_format = get_env().jj_config.diff_format();
-
-        let files_output = new_commander().get_files(&head);
-        let conflicts_output = new_commander().get_conflicts(&head.commit_id)?;
-        let current_file = files_output
-            .as_ref()
-            .ok()
-            .and_then(|files_output| files_output.first())
-            .map(|file| file.to_owned());
-        let diff_output = current_file
-            .as_ref()
-            .map(|current_change| {
-                new_commander().get_file_diff(&head, current_change, &diff_format, true)
-            })
-            .map_or(Ok(None), |r| {
-                r.map(|diff| diff.map(|diff| tabs_to_spaces(&diff)))
-            });
-
-        let files_list_state = ListState::default().with_selected(get_current_file_index(
-            current_file.as_ref(),
-            files_output.as_ref(),
-        ));
-
+    pub fn new(current_head: &Head) -> Self {
         let config = get_env().jj_config.clone();
         let pane_divider = PaneDivider::new(config.layout_percent());
 
-        Ok(Self {
-            head,
-            is_current_head,
+        Self {
+            head: current_head.clone(),
+            is_current_head: true,
 
-            files_output,
-            file: current_file,
-            files_list_state,
+            files_output: Ok(Vec::new()),
+            file: None,
+            files_list_state: ListState::default(),
             files_height: 0,
 
-            conflicts_output,
+            conflicts_output: Vec::new(),
 
-            diff_output,
-            diff_format,
+            diff_output: Ok(None),
+            diff_format: get_env().jj_config.diff_format(),
             diff_panel: DetailsPanel::new(),
 
             config,
             pane_divider,
-        })
+
+            stale: true,
+        }
     }
 
     pub fn set_head(&mut self, head: &Head) -> Result<()> {
@@ -137,6 +116,16 @@ impl FilesTab {
     pub fn refresh_files(&mut self) -> Result<()> {
         self.files_output = new_commander().get_files(&self.head);
         self.conflicts_output = new_commander().get_conflicts(&self.head.commit_id)?;
+
+        if self.file.is_none() {
+            self.file = self
+                .files_output
+                .as_ref()
+                .ok()
+                .and_then(|files_output| files_output.first())
+                .map(|file| file.to_owned());
+        }
+
         Ok(())
     }
 
@@ -154,6 +143,14 @@ impl FilesTab {
                 r.map(|diff| diff.map(|diff| tabs_to_spaces(&diff)))
             });
         self.diff_panel.scroll_to(0);
+        Ok(())
+    }
+
+    /// Move to the working copy commit, dropping the selection, without
+    /// reading the files there.
+    fn follow_current_head(&mut self) -> Result<()> {
+        self.head = new_commander().get_current_head()?;
+        self.file = None;
         Ok(())
     }
 
@@ -196,11 +193,19 @@ impl FilesTab {
 
 impl Tab for FilesTab {
     fn refresh(&mut self) -> Result<()> {
-        self.is_current_head = self.head == new_commander().get_current_head()?;
-        self.head = new_commander().get_head_latest(&self.head)?;
-        self.refresh_files()?;
-        self.refresh_diff()?;
+        if self.stale {
+            self.is_current_head = self.head == new_commander().get_current_head()?;
+            self.head = new_commander().get_head_latest(&self.head)?;
+            self.refresh_files()?;
+            self.refresh_diff()?;
+            self.stale = false;
+        }
+
         Ok(())
+    }
+
+    fn mark_stale(&mut self) {
+        self.stale = true;
     }
 
     fn scroll_main_panel(&mut self, scroll: Scroll) -> Result<()> {
@@ -393,7 +398,8 @@ impl Component for FilesTab {
                             )),
                         )));
                     }
-                    self.set_head(&new_commander().get_current_head()?)?;
+                    self.follow_current_head()?;
+                    return Ok(ComponentInputResult::HandledAction(AppAction::RefreshTab));
                 }
                 KeyCode::Char('r') => {
                     if let Err(err) = self.restore_file() {
@@ -401,7 +407,8 @@ impl Component for FilesTab {
                             Box::new(MessagePopup::new("Can't restore file", err.to_string())),
                         )));
                     }
-                    self.set_head(&new_commander().get_current_head()?)?;
+                    self.follow_current_head()?;
+                    return Ok(ComponentInputResult::HandledAction(AppAction::RefreshTab));
                 }
                 _ => return Ok(ComponentInputResult::NotHandled),
             };

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -114,6 +114,8 @@ pub struct LogTab<'a> {
     config: JjConfig,
     pane_divider: PaneDivider,
     keybinds: LogTabKeybinds,
+
+    stale: bool,
 }
 
 /// A background process for fetching 'jj show' and a thread for signalling
@@ -144,7 +146,7 @@ The main functions are:
 
 * [refresh_log_output](LogTab::refresh_log_output) - Update the log panel
   by running `jj log`, and update the details panel.
-  (called by set_head)
+  (called by refresh)
 
 * [sync_head_output](LogTab::sync_head_output) - Make right panel show
   what left panel selected.
@@ -164,10 +166,8 @@ The main functions are:
 */
 impl<'a> LogTab<'a> {
     #[instrument(level = "info", name = "Initializing log tab", parent = None, skip())]
-    pub fn new(app_event_sender: Sender<AppEvent>) -> Result<Self> {
+    pub fn new(app_event_sender: Sender<AppEvent>, head: Head) -> Self {
         let diff_format = get_env().jj_config.diff_format();
-
-        let head = new_commander().get_current_head()?;
 
         const NO_WIDTH: usize = 0;
         let head_key = CommitShowKey::new(head.clone(), diff_format.clone(), NO_WIDTH);
@@ -184,12 +184,12 @@ impl<'a> LogTab<'a> {
         let config = get_env().jj_config.clone();
         let pane_divider = PaneDivider::new(config.layout_percent());
 
-        Ok(Self {
+        Self {
             app_event_sender,
 
             log_revset_textarea: None,
 
-            log_panel: LogPanel::new()?,
+            log_panel: LogPanel::new(head.clone()),
 
             head,
             head_panel: DetailsPanel::new(),
@@ -215,13 +215,16 @@ impl<'a> LogTab<'a> {
             config,
             pane_divider,
             keybinds,
-        })
+
+            stale: true,
+        }
     }
 
-    /// Set cursor and update log panel and diff panel
+    /// Move the cursor, updating the details panel. The log itself is
+    /// left as it was.
     pub fn set_head(&mut self, head: Head) {
         self.log_panel.set_head(head);
-        self.refresh_log_output();
+        self.sync_head_output();
     }
 
     /// Update the log panel and diff panel. This will also refresh
@@ -480,7 +483,10 @@ impl<'a> LogTab<'a> {
                 AppAction::SetPopup(Box::new(DescribePopup::new(self.head.clone(), vec![]))),
             ])));
         }
-        Ok(Some(AppAction::ChangeHead(self.head.clone())))
+        Ok(Some(AppAction::Multiple(vec![
+            AppAction::ChangeHead(self.head.clone()),
+            AppAction::RefreshTab,
+        ])))
     }
 
     fn handle_abandon(&mut self) -> Result<ComponentInputResult> {
@@ -543,9 +549,12 @@ impl<'a> LogTab<'a> {
         self.set_head(new_selection.clone());
         // If selection was moved, tell the application
         if new_selection != old_selection {
-            Ok(Some(AppAction::ChangeHead(self.head.clone())))
+            Ok(Some(AppAction::Multiple(vec![
+                AppAction::ChangeHead(self.head.clone()),
+                AppAction::RefreshTab,
+            ])))
         } else {
-            Ok(None)
+            Ok(Some(AppAction::RefreshTab))
         }
     }
 
@@ -563,7 +572,7 @@ impl<'a> LogTab<'a> {
             }
             LogTabEvent::Duplicate => {
                 let _ = new_commander().run_duplicate(&self.head.change_id.to_string());
-                self.refresh_log_output();
+                return Ok(ComponentInputResult::HandledAction(AppAction::RefreshTab));
             }
 
             LogTabEvent::CreateNew { describe } => {
@@ -665,8 +674,11 @@ impl<'a> LogTab<'a> {
             LogTabEvent::Absorb => {
                 new_commander().run_absorb(self.head.commit_id.as_str())?;
                 self.set_head(new_commander().get_head_latest(&self.head)?);
-                return Ok(ComponentInputResult::HandledAction(AppAction::ChangeHead(
-                    self.head.clone(),
+                return Ok(ComponentInputResult::HandledAction(AppAction::Multiple(
+                    vec![
+                        AppAction::ChangeHead(self.head.clone()),
+                        AppAction::RefreshTab,
+                    ],
                 )));
             }
             LogTabEvent::Describe => {
@@ -766,9 +778,18 @@ impl<'a> LogTab<'a> {
 
 impl Tab for LogTab<'_> {
     fn refresh(&mut self) -> Result<()> {
-        let latest_head = new_commander().get_head_latest(&self.head)?;
-        self.set_head(latest_head);
+        if self.stale {
+            let latest_head = new_commander().get_head_latest(&self.head)?;
+            self.log_panel.set_head(latest_head);
+            self.refresh_log_output();
+            self.stale = false;
+        }
+
         Ok(())
+    }
+
+    fn mark_stale(&mut self) {
+        self.stale = true;
     }
 
     fn drop_caches(&mut self) {
@@ -826,8 +847,10 @@ impl Component for LogTab<'_> {
                 EDIT_POPUP_ID => {
                     new_commander()
                         .run_edit(self.head.commit_id.as_str(), self.edit_ignore_immutable)?;
-                    self.refresh_log_output();
-                    return Ok(Some(AppAction::ChangeHead(self.head.clone())));
+                    return Ok(Some(AppAction::Multiple(vec![
+                        AppAction::ChangeHead(self.head.clone()),
+                        AppAction::RefreshTab,
+                    ])));
                 }
                 ABANDON_POPUP_ID => {
                     return self.execute_abandon();
@@ -840,7 +863,10 @@ impl Component for LogTab<'_> {
                         .commit_id;
                     new_commander().run_squash(target_id.as_str(), self.squash_ignore_immutable)?;
                     self.set_head(new_commander().get_current_head()?);
-                    return Ok(Some(AppAction::ChangeHead(self.head.clone())));
+                    return Ok(Some(AppAction::Multiple(vec![
+                        AppAction::ChangeHead(self.head.clone()),
+                        AppAction::RefreshTab,
+                    ])));
                 }
                 _ => {}
             }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -72,8 +72,12 @@ pub trait Component {
 
 /// A top-level tab, showing what it reads from the repo.
 pub trait Tab: Component {
-    /// Read whatever this tab shows afresh from the repo.
+    /// Read whatever this tab shows afresh from the repo if it is stale,
+    /// leaving it no longer stale. Does nothing otherwise.
     fn refresh(&mut self) -> Result<()>;
+
+    /// Have the next [refresh](Tab::refresh) read the repo.
+    fn mark_stale(&mut self);
 
     /// Discard whatever this tab has cached, so that the next read goes
     /// to the repo.

--- a/src/ui/panel/log_panel.rs
+++ b/src/ui/panel/log_panel.rs
@@ -106,33 +106,20 @@ fn get_head_index(head: &Head, log_output: &Result<LogOutput, CommandError>) -> 
 }
 
 impl<'a> LogPanel<'a> {
-    pub fn new() -> Result<Self> {
-        let log_revset = new_commander().env.default_revset.clone();
-        let log_output = new_commander().get_log(&log_revset);
-        let head = new_commander().get_current_head()?;
-
-        let log_list_state = ListState::default().with_selected(get_head_index(&head, &log_output));
-
+    /// A panel showing `head` selected in an empty log.
+    pub fn new(head: Head) -> Self {
         let mut keybinds = LogTabKeybinds::default();
         if let Some(keybinds_config) = new_commander().env.jj_config.keybinds() {
             keybinds.extend_from_config(keybinds_config);
         }
 
-        let log_output_text = match log_output.as_ref() {
-            Ok(log_output) => log_output
-                .graph
-                .into_text()
-                .unwrap_or(Text::from("Could not turn text into TUI text (coloring)")),
-            Err(_) => Text::default(),
-        };
-
-        Ok(Self {
-            log_output_text,
-            log_output,
-            log_list_state,
+        Self {
+            log_output_text: Text::default(),
+            log_output: Ok(LogOutput::default()),
+            log_list_state: ListState::default(),
             log_rect: Rect::ZERO,
 
-            log_revset,
+            log_revset: new_commander().env.default_revset.clone(),
 
             head,
             marked_heads: HashSet::new(),
@@ -140,7 +127,7 @@ impl<'a> LogPanel<'a> {
             panel_rect: Rect::ZERO,
 
             config: get_env().jj_config.clone(),
-        })
+        }
     }
 
     //


### PR DESCRIPTION
Each tab reads the repo in its constructor and then again whenever something decides it needs refreshing: on a tab switch, on regaining focus, and inline in the command handlers that change the repo. Reads are therefore spread over the whole app, and there is no single place that could decide whether one is needed at all. We give every tab a stale flag instead, so `refresh()` reads only when there is something to read, and let the loop call it before each frame. Tabs then start out stale rather than reading in their constructors, which lets those stop returning `Result`, and the command handlers ask for the tab to be re-read with `AppAction::RefreshTab` rather than re-reading it themselves. That costs the bookmarks tab its selection reset after a delete or forget, as it happened inline right after the command, so `refresh_bookmarks()` falls back to the first bookmark whenever the selected one is gone, which also covers it disappearing from elsewhere.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
