### PR TITLE
Fix the UI stalling on every window focus change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no longer act on a path that does not exist
 - Conflicted paths in the files list no longer carry trailing spaces when a
   change has conflicts in paths of differing lengths
+- Coming back to the terminal window no longer stalls the UI while `jj log` runs
+  again for a repo that has not changed
 
 ## [0.8.0] - 2026-04-19
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -20,7 +20,9 @@ use ratatui::widgets::*;
 use tracing::info;
 use tracing::instrument;
 use tracing::trace;
+use tracing::warn;
 
+use crate::commander::ids::OperationId;
 use crate::commander::new_commander;
 use crate::env::get_env;
 use crate::event::AppEvent;
@@ -63,6 +65,9 @@ pub struct Stats {
     pub start_time: Instant,
 }
 
+/// How long after a check of what the repo is at the next one is due.
+const OP_ID_CHECK_INTERVAL: Duration = Duration::from_secs(1);
+
 pub struct App<'a> {
     // user interface
     pub current_tab: TabId,
@@ -72,6 +77,13 @@ pub struct App<'a> {
     pub popup: Option<Box<dyn Component>>,
     pub stats: Stats,
     global_keybinds: GlobalKeybinds,
+
+    repo_op_id: Option<OperationId>,
+    next_op_id_check: Instant,
+
+    /// Whether the next check may leave the working copy alone rather
+    /// than snapshotting it.
+    ignore_working_copy: bool,
 
     // event handling
     running: Arc<AtomicBool>,
@@ -98,6 +110,10 @@ impl<'a> App<'a> {
                 start_time: Instant::now(),
             },
             global_keybinds,
+
+            repo_op_id: None,
+            next_op_id_check: Instant::now(),
+            ignore_working_copy: false,
 
             running,
             event_source,
@@ -136,9 +152,51 @@ impl<'a> App<'a> {
         self.current_tab = tab;
     }
 
-    /// Read the current tab if it is stale.
-    pub fn refresh_current_tab(&mut self) -> Result<()> {
+    /// Mark every tab stale if the repo has moved since the last check,
+    /// then read the current tab if it is stale.
+    pub fn refresh_view(&mut self) -> Result<()> {
+        if self.check_repo_moved() {
+            trace!("The repo has moved, so every tab is stale");
+            for tab in TabId::VALUES {
+                self.get_tab(tab).mark_stale();
+            }
+        }
+
         self.get_current_tab().refresh()
+    }
+
+    /// Ask for the next check to read the repo without waiting out
+    /// [OP_ID_CHECK_INTERVAL], and snapshot the working copy while at it.
+    fn request_check_with_snapshot(&mut self) {
+        self.next_op_id_check = Instant::now();
+        self.ignore_working_copy = false;
+    }
+
+    /// Read what operation the repo is at once the last check is an
+    /// [OP_ID_CHECK_INTERVAL] old, or as soon as one was asked for, and
+    /// remember it. Reports whether it differs from what was remembered
+    /// before; a check that is not due yet or that fails reports no
+    /// movement.
+    fn check_repo_moved(&mut self) -> bool {
+        if Instant::now() < self.next_op_id_check {
+            return false;
+        }
+
+        let result = new_commander().get_operation_id(self.ignore_working_copy);
+        self.next_op_id_check = Instant::now() + OP_ID_CHECK_INTERVAL;
+
+        let operation_id = match result {
+            Ok(operation_id) => operation_id,
+            Err(err) => {
+                warn!("Could not read what the repo is at: {err}");
+                return false;
+            }
+        };
+        self.ignore_working_copy = true;
+
+        let moved = self.repo_op_id.as_ref() != Some(&operation_id);
+        self.repo_op_id = Some(operation_id);
+        moved
     }
 
     pub fn get_tab(&mut self, tab: TabId) -> &mut dyn Tab {
@@ -181,6 +239,9 @@ impl<'a> App<'a> {
             }
             AppAction::RefreshTab => {
                 self.get_current_tab().mark_stale();
+                // Whatever asks for this has likely moved the repo, so
+                // the other tabs want checking without delay.
+                self.next_op_id_check = Instant::now();
             }
         }
 
@@ -295,6 +356,13 @@ impl<'a> App<'a> {
             trace!("an event that was not a UserInput was ignored");
             return Ok(false); // do not terminate the app
         };
+        // Coming back to the window is worth a check, as the repo may
+        // well have moved while we were not being watched.
+        if event == event::Event::FocusGained {
+            self.request_check_with_snapshot();
+            return Ok(false);
+        }
+
         if let Some(popup) = self.popup.as_mut() {
             match popup.input(event.clone())? {
                 ComponentInputResult::HandledAction(app_action) => {
@@ -320,8 +388,6 @@ impl<'a> App<'a> {
                     }
                 }
             };
-        } else if event == event::Event::FocusGained {
-            self.get_current_tab().mark_stale();
         } else {
             match self.get_current_tab().input(event.clone())? {
                 ComponentInputResult::HandledAction(app_action) => {
@@ -351,6 +417,7 @@ impl<'a> App<'a> {
                                 self.get_current_tab().focus_current()?;
                             }
                             GlobalEvent::Refresh => {
+                                self.request_check_with_snapshot();
                                 self.get_current_tab().drop_caches();
                                 self.handle_action(AppAction::RefreshTab)?;
                             }

--- a/src/commander/ids.rs
+++ b/src/commander/ids.rs
@@ -1,5 +1,5 @@
 /*!
-Helper structs [ChangeId] and [CommitId]
+Helper structs [ChangeId], [CommitId] and [OperationId]
 */
 use std::ffi::OsStr;
 use std::fmt::Display;
@@ -65,3 +65,7 @@ impl Display for CommitId {
         write!(f, "{}", self.as_str())
     }
 }
+
+/// Wrapper around operation ID.
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub struct OperationId(pub String);

--- a/src/commander/mod.rs
+++ b/src/commander/mod.rs
@@ -27,6 +27,7 @@ pub mod files;
 pub mod ids;
 pub mod jj;
 pub mod log;
+pub mod operation;
 
 use std::ffi::OsStr;
 use std::ffi::OsString;

--- a/src/commander/operation.rs
+++ b/src/commander/operation.rs
@@ -1,0 +1,70 @@
+/*!
+[Commander] member functions related to jj operations.
+*/
+use tracing::instrument;
+
+use crate::commander::CommandError;
+use crate::commander::Commander;
+use crate::commander::RemoveEndLine;
+use crate::commander::ids::OperationId;
+
+impl Commander {
+    /// Get the operation the repo is at.
+    /// Maps to `jj op log --limit 1 --no-graph -T id`
+    #[instrument(level = "trace", skip(self))]
+    pub fn get_operation_id(&self, ignore_working_copy: bool) -> Result<OperationId, CommandError> {
+        let mut command = self.jj(["op", "log", "--limit", "1", "--no-graph", "-T", "id"]);
+        if ignore_working_copy {
+            command = command.ignore_working_copy();
+        }
+
+        Ok(OperationId(command.run()?.remove_end_line()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use anyhow::Result;
+
+    use crate::commander::tests::TestRepo;
+
+    #[test]
+    fn get_operation_id_ignoring_working_copy() -> Result<()> {
+        let test_repo = TestRepo::new()?;
+
+        let operation_id = test_repo.commander.get_operation_id(true)?;
+        assert!(!operation_id.0.is_empty());
+
+        // Asking twice gives the same answer, so a caller can compare
+        // against what it saw last without its own check moving the
+        // operation on.
+        assert_eq!(operation_id, test_repo.commander.get_operation_id(true)?);
+
+        // A change to the working copy is only an operation once some
+        // other command has snapshotted it, so it goes unnoticed here.
+        fs::write(test_repo.directory.path().join("README"), b"AAA")?;
+        assert_eq!(operation_id, test_repo.commander.get_operation_id(true)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn get_operation_id_snapshotting_working_copy() -> Result<()> {
+        let test_repo = TestRepo::new()?;
+
+        let operation_id = test_repo.commander.get_operation_id(true)?;
+
+        // Snapshotting a changed working copy is an operation of its
+        // own, so the answer moves on.
+        fs::write(test_repo.directory.path().join("README"), b"AAA")?;
+        let snapshot_id = test_repo.commander.get_operation_id(false)?;
+        assert_ne!(operation_id, snapshot_id);
+
+        // With nothing left to snapshot, it stays where it is.
+        assert_eq!(snapshot_id, test_repo.commander.get_operation_id(false)?);
+
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,7 +165,7 @@ fn run_app(terminal: &mut DefaultTerminal, app: &mut App) -> Result<()> {
     loop {
         app.update()?;
 
-        app.refresh_current_tab()?;
+        app.refresh_view()?;
 
         terminal.draw(|f| {
             let _ = app.draw(f, f.area());


### PR DESCRIPTION
Regaining focus refreshes the current tab unconditionally, so on the log tab we block the whole app while `jj log` runs over the whole revset, usually only to redraw what was already there. The operation id tells us whether the repo moved at all, at a fixed cost, so we can read it before each frame and only mark the tabs stale when it changed. As reading it is itself a jj invocation and input arrives in bursts, we do so at most once a second, and regaining focus asks for it right away, as the repo may well have moved while we were not being watched. A check normally leaves the working copy alone, as snapshotting to find out whether anything happened would record an operation for a file the user may still be editing. Startup, a regained focus and an explicit refresh do ask for a snapshot, so that edits made outside the app are picked up at the points where the user expects to see them.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
