### PR TITLE
Stop the tab reads from snapshotting the working copy

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -182,7 +182,12 @@ impl<'a> App<'a> {
             return false;
         }
 
-        let result = new_commander().get_operation_id(self.ignore_working_copy);
+        let mut commander = new_commander();
+        if self.ignore_working_copy {
+            commander.ignore_working_copy();
+        }
+
+        let result = commander.get_operation_id();
         self.next_op_id_check = Instant::now() + OP_ID_CHECK_INTERVAL;
 
         let operation_id = match result {

--- a/src/commander/bookmarks.rs
+++ b/src/commander/bookmarks.rs
@@ -84,7 +84,8 @@ impl BookmarkLine {
 
 impl Commander {
     /// Get bookmarks.
-    /// Maps to `jj bookmark list`
+    /// Leaves the working copy alone.
+    /// Maps to `jj bookmark list --ignore-working-copy`
     #[instrument(level = "trace", skip(self))]
     pub fn get_bookmarks(&self, show_all: bool) -> Result<Vec<BookmarkLine>, CommandError> {
         let mut args = vec![];
@@ -111,10 +112,12 @@ impl Commander {
             ]
             .concat())
             .color()
+            .ignore_working_copy()
             .run()?;
 
         let bookmarks: Vec<BookmarkLine> = self
             .jj([vec!["bookmark", "list", "-T", BRANCH_TEMPLATE], args].concat())
+            .ignore_working_copy()
             .run()?
             .lines()
             .zip(bookmarks_colored.lines())
@@ -130,6 +133,8 @@ impl Commander {
         Ok(bookmarks)
     }
 
+    /// Get the bookmarks that exist, newest first, leaving the working
+    /// copy alone.
     #[instrument(level = "trace", skip(self))]
     pub fn get_bookmarks_list(&self, show_all: bool) -> Result<Vec<Bookmark>, CommandError> {
         let mut args = vec![
@@ -144,6 +149,7 @@ impl Commander {
 
         let bookmarks: Vec<Bookmark> = self
             .jj(args)
+            .ignore_working_copy()
             .run()?
             .lines()
             .filter_map(parse_bookmark)

--- a/src/commander/files.rs
+++ b/src/commander/files.rs
@@ -128,7 +128,8 @@ fn parse_file(line: &str) -> File {
 
 impl Commander {
     /// Get list of changes files in a change. Parses the output.
-    /// Maps to `jj log -r <revision>` with [FILES_TEMPLATE]
+    /// Leaves the working copy alone.
+    /// Maps to `jj log -r <revision> --ignore-working-copy` with [FILES_TEMPLATE]
     #[instrument(level = "trace", skip(self))]
     pub fn get_files(&self, head: &Head) -> Result<Vec<File>, CommandError> {
         Ok(self
@@ -140,6 +141,7 @@ impl Commander {
                 "-r",
                 head.commit_id.as_str(),
             ])
+            .ignore_working_copy()
             .run()?
             .lines()
             .map(parse_file)
@@ -147,7 +149,9 @@ impl Commander {
     }
 
     /// Get list of conflicted files in a change. Parses the output.
-    /// Maps to `jj log -r <revision>` with [CONFLICTS_TEMPLATE]
+    /// Leaves the working copy alone.
+    /// Maps to `jj log -r <revision> --ignore-working-copy` with
+    /// [CONFLICTS_TEMPLATE]
     #[instrument(level = "trace", skip(self))]
     pub fn get_conflicts(&self, commit_id: &CommitId) -> Result<Vec<Conflict>> {
         Ok(self
@@ -159,6 +163,7 @@ impl Commander {
                 "-r",
                 commit_id.as_str(),
             ])
+            .ignore_working_copy()
             .run()
             .context("Failed getting conflicts")?
             .lines()

--- a/src/commander/log.rs
+++ b/src/commander/log.rs
@@ -112,7 +112,8 @@ impl Commander {
     }
 
     /// Get log. Returns human readable log and mapping to log line to head.
-    /// Maps to `jj log`
+    /// Leaves the working copy alone.
+    /// Maps to `jj log --ignore-working-copy`
     #[instrument(level = "trace", skip(self))]
     pub fn get_log(&self, revset: &Option<String>) -> Result<LogOutput, CommandError> {
         let mut args = vec![];
@@ -130,6 +131,7 @@ impl Commander {
             ]
             .concat())
             .color()
+            .ignore_working_copy()
             .run()?;
 
         // Extract the log one more time, but this time use a template
@@ -148,6 +150,7 @@ impl Commander {
                 args,
             ]
             .concat())
+            .ignore_working_copy()
             .run()?
             .lines()
             .map(|line| parse_head(line).ok())

--- a/src/commander/mod.rs
+++ b/src/commander/mod.rs
@@ -115,6 +115,10 @@ pub struct Commander {
     /// command this commander runs, since it describes the output device
     /// rather than any single command.
     columns: Option<usize>,
+    /// Whether every command this commander runs leaves the working copy
+    /// alone, for a caller that must not record an operation whatever it
+    /// ends up asking.
+    ignore_working_copy: bool,
 
     // Used for testing
     pub jj_config_toml: Option<Vec<String>>,
@@ -132,6 +136,7 @@ impl Commander {
         Self {
             env: env.clone(),
             columns: None,
+            ignore_working_copy: false,
             jj_config_toml: None,
             force_no_color: false,
         }
@@ -145,6 +150,14 @@ impl Commander {
         if columns >= MIN_SETTABLE_WIDTH {
             self.columns = Some(columns);
         }
+    }
+
+    /// Leave the working copy alone in every command this commander runs,
+    /// so nothing it asks can record an operation. For a caller whose
+    /// whole read has to leave the repo where it found it, rather than
+    /// one command that happens not to need a snapshot.
+    pub fn ignore_working_copy(&mut self) {
+        self.ignore_working_copy = true;
     }
 
     /// Start building a single jj invocation with the given arguments.
@@ -167,7 +180,7 @@ impl Commander {
             args: args.into_iter().map(|s| s.as_ref().to_owned()).collect(),
             color: false,
             quiet: true,
-            ignore_working_copy: false,
+            ignore_working_copy: self.ignore_working_copy,
             stdin: None,
             env_var,
         }
@@ -225,8 +238,8 @@ pub struct JjCommand<'a> {
     color: bool,
     /// Whether to pass `--quiet`. On by default.
     quiet: bool,
-    /// Whether to pass `--ignore-working-copy`. Off by default, so a
-    /// command sees the files as they are now.
+    /// Whether to pass `--ignore-working-copy`. Off unless the commander
+    /// already asks for it, so a command sees the files as they are now.
     ignore_working_copy: bool,
     /// Data to feed the command on standard input, if any.
     stdin: Option<String>,
@@ -254,9 +267,9 @@ impl JjCommand<'_> {
     /// Pass `--ignore-working-copy`, so the command reads the repo as it
     /// stands without snapshotting the files first.
     ///
-    /// Off by default. Use it where a stale answer beats an operation of
-    /// our own: reads that are meant to leave the repo where the caller
-    /// found it.
+    /// Off unless the commander already asks for it. Use it where a stale
+    /// answer beats an operation of our own: reads that are meant to
+    /// leave the repo where the caller found it.
     pub fn ignore_working_copy(mut self) -> Self {
         self.ignore_working_copy = true;
         self

--- a/src/commander/operation.rs
+++ b/src/commander/operation.rs
@@ -9,16 +9,17 @@ use crate::commander::RemoveEndLine;
 use crate::commander::ids::OperationId;
 
 impl Commander {
-    /// Get the operation the repo is at.
+    /// Get the operation the repo is at, snapshotting the working copy
+    /// first unless the commander leaves it alone. Snapshotting makes the
+    /// two a single step, so no snapshot of ours lands after the answer.
     /// Maps to `jj op log --limit 1 --no-graph -T id`
     #[instrument(level = "trace", skip(self))]
-    pub fn get_operation_id(&self, ignore_working_copy: bool) -> Result<OperationId, CommandError> {
-        let mut command = self.jj(["op", "log", "--limit", "1", "--no-graph", "-T", "id"]);
-        if ignore_working_copy {
-            command = command.ignore_working_copy();
-        }
-
-        Ok(OperationId(command.run()?.remove_end_line()))
+    pub fn get_operation_id(&self) -> Result<OperationId, CommandError> {
+        Ok(OperationId(
+            self.jj(["op", "log", "--limit", "1", "--no-graph", "-T", "id"])
+                .run()?
+                .remove_end_line(),
+        ))
     }
 }
 
@@ -34,18 +35,21 @@ mod tests {
     fn get_operation_id_ignoring_working_copy() -> Result<()> {
         let test_repo = TestRepo::new()?;
 
-        let operation_id = test_repo.commander.get_operation_id(true)?;
+        let mut checking = test_repo.commander.clone();
+        checking.ignore_working_copy();
+
+        let operation_id = checking.get_operation_id()?;
         assert!(!operation_id.0.is_empty());
 
         // Asking twice gives the same answer, so a caller can compare
         // against what it saw last without its own check moving the
         // operation on.
-        assert_eq!(operation_id, test_repo.commander.get_operation_id(true)?);
+        assert_eq!(operation_id, checking.get_operation_id()?);
 
         // A change to the working copy is only an operation once some
         // other command has snapshotted it, so it goes unnoticed here.
         fs::write(test_repo.directory.path().join("README"), b"AAA")?;
-        assert_eq!(operation_id, test_repo.commander.get_operation_id(true)?);
+        assert_eq!(operation_id, checking.get_operation_id()?);
 
         Ok(())
     }
@@ -54,16 +58,16 @@ mod tests {
     fn get_operation_id_snapshotting_working_copy() -> Result<()> {
         let test_repo = TestRepo::new()?;
 
-        let operation_id = test_repo.commander.get_operation_id(true)?;
+        let operation_id = test_repo.commander.get_operation_id()?;
 
         // Snapshotting a changed working copy is an operation of its
         // own, so the answer moves on.
         fs::write(test_repo.directory.path().join("README"), b"AAA")?;
-        let snapshot_id = test_repo.commander.get_operation_id(false)?;
+        let snapshot_id = test_repo.commander.get_operation_id()?;
         assert_ne!(operation_id, snapshot_id);
 
         // With nothing left to snapshot, it stays where it is.
-        assert_eq!(snapshot_id, test_repo.commander.get_operation_id(false)?);
+        assert_eq!(snapshot_id, test_repo.commander.get_operation_id()?);
 
         Ok(())
     }

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -779,7 +779,13 @@ impl<'a> LogTab<'a> {
 impl Tab for LogTab<'_> {
     fn refresh(&mut self) -> Result<()> {
         if self.stale {
-            let latest_head = new_commander().get_head_latest(&self.head)?;
+            // The log we are about to read leaves the working copy alone,
+            // so following the selection has to as well, or the two
+            // disagree.
+            let mut commander = new_commander();
+            commander.ignore_working_copy();
+
+            let latest_head = commander.get_head_latest(&self.head)?;
             self.log_panel.set_head(latest_head);
             self.refresh_log_output();
             self.stale = false;


### PR DESCRIPTION
The reads a tab makes go through `jj log` and `jj bookmark list`, which snapshot the working copy before they answer, so a read of ours can record an operation, and the next check of what the repo is at then finds it moved and has the tab read again what it has only just read. Passing --ignore-working-copy on those reads leaves the snapshot to that check, the one place that decides whether to take one. Where the choice belongs to the caller rather than to a single command it sits on the commander, as the log tab has to follow its selection through a read that will not snapshot for the head it keeps to agree with the log it reads right after; get_operation_id() then has no need of an argument of its own. The files tab is the exception: get_current_head() is how the rebase and squash popups get the commit id of `@` they build a revset from, so the head that tab compares and follows has to keep being the snapshotted one.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
