### PR TITLE
Draw a frame only when something has changed

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -153,8 +153,9 @@ impl<'a> App<'a> {
     }
 
     /// Mark every tab stale if the repo has moved since the last check,
-    /// then read the current tab if it is stale.
-    pub fn refresh_view(&mut self) -> Result<()> {
+    /// then read the current tab if it is stale. Returns whether
+    /// anything on screen changed.
+    pub fn refresh_view(&mut self) -> Result<bool> {
         if self.check_repo_moved() {
             trace!("The repo has moved, so every tab is stale");
             for tab in TabId::VALUES {
@@ -162,7 +163,13 @@ impl<'a> App<'a> {
             }
         }
 
-        self.get_current_tab().refresh()
+        if !self.get_current_tab().is_stale() {
+            return Ok(false);
+        }
+
+        self.get_current_tab().refresh()?;
+
+        Ok(true)
     }
 
     /// Ask for the next check to read the repo without waiting out
@@ -253,8 +260,12 @@ impl<'a> App<'a> {
         Ok(())
     }
 
+    /// Returns whether anything that shows may have changed.
     #[instrument(level = "trace", skip(self))]
-    pub fn update(&mut self) -> Result<()> {
+    pub fn update(&mut self) -> Result<bool> {
+        // A popup animates, so it wants a frame whatever it says.
+        let mut changed = self.popup.is_some();
+
         if let Some(popup) = self.popup.as_mut()
             && let Some(component_action) = popup.update()?
         {
@@ -263,9 +274,10 @@ impl<'a> App<'a> {
 
         if let Some(component_action) = self.get_current_tab().update()? {
             self.handle_action(component_action)?;
+            changed = true;
         }
 
-        Ok(())
+        Ok(changed)
     }
 
     #[instrument(level = "trace", skip(self, f))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -162,27 +162,40 @@ fn init_env() -> Result<Env> {
 
 fn run_app(terminal: &mut DefaultTerminal, app: &mut App) -> Result<()> {
     app.launch_input_channel();
+    let mut idle = false;
     loop {
-        app.update()?;
+        let mut changed = app.update()?;
 
-        app.refresh_view()?;
+        changed |= app.refresh_view()?;
 
-        terminal.draw(|f| {
-            let _ = app.draw(f, f.area());
-        })?;
+        // Waking up to find that nothing has happened must not cost a
+        // frame, or the app would rebuild the whole display for it.
+        if changed || !idle {
+            terminal.draw(|f| {
+                let _ = app.draw(f, f.area());
+            })?;
+        }
 
-        let should_stop = input_to_app(app)?;
-
-        if should_stop {
-            return Ok(());
+        match input_to_app(app)? {
+            Input::Stop => return Ok(()),
+            Input::Handled => idle = false,
+            Input::Idle => idle = true,
         }
     }
 }
 
-/// Let app process all input events in queue before returning
-/// to draw the next frame.
-/// Return true if application should stop
-fn input_to_app(app: &mut App) -> Result<bool> {
+/// What waiting for input produced.
+enum Input {
+    /// The app was asked to stop.
+    Stop,
+    /// Events were handled, so what the app shows may have changed.
+    Handled,
+    /// Nothing arrived before the wait ran out.
+    Idle,
+}
+
+/// Let app process all input events in queue before returning.
+fn input_to_app(app: &mut App) -> Result<Input> {
     // Duration::MAX overflows the timespec struct used by kevent/kqueue on macOS,
     // causing EINVAL (os error 22). Use a safe large value instead.
     const FOREVER: Duration = Duration::from_secs(24 * 3600);
@@ -196,15 +209,20 @@ fn input_to_app(app: &mut App) -> Result<bool> {
 
     // Handle all pending events in the queue.
     // Stop if an event requested the app to stop.
-    // If no event arrives, return and draw next frame.
     let mut event = app.try_recv_app_event(wait_duration);
     app.stats.start_time = Instant::now();
+    let handled = event.is_some();
     let mut should_stop: bool = false;
     while event.is_some() && !should_stop {
         should_stop = app.input(event.unwrap())?;
         event = app.try_recv_app_event(Duration::ZERO);
     }
-    Ok(should_stop)
+
+    Ok(match (should_stop, handled) {
+        (true, _) => Input::Stop,
+        (false, true) => Input::Handled,
+        (false, false) => Input::Idle,
+    })
 }
 
 fn create_terminal() -> Result<DefaultTerminal> {

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -217,17 +217,19 @@ impl BookmarksTab {
 
 impl Tab for BookmarksTab {
     fn refresh(&mut self) -> Result<()> {
-        if self.stale {
-            self.refresh_bookmarks();
-            self.refresh_bookmark();
-            self.stale = false;
-        }
+        self.refresh_bookmarks();
+        self.refresh_bookmark();
+        self.stale = false;
 
         Ok(())
     }
 
     fn mark_stale(&mut self) {
         self.stale = true;
+    }
+
+    fn is_stale(&self) -> bool {
+        self.stale
     }
 
     fn scroll_main_panel(&mut self, scroll: Scroll) -> Result<()> {

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -197,19 +197,21 @@ impl FilesTab {
 
 impl Tab for FilesTab {
     fn refresh(&mut self) -> Result<()> {
-        if self.stale {
-            self.is_current_head = self.head == new_commander().get_current_head()?;
-            self.head = new_commander().get_head_latest(&self.head)?;
-            self.refresh_files()?;
-            self.refresh_diff()?;
-            self.stale = false;
-        }
+        self.is_current_head = self.head == new_commander().get_current_head()?;
+        self.head = new_commander().get_head_latest(&self.head)?;
+        self.refresh_files()?;
+        self.refresh_diff()?;
+        self.stale = false;
 
         Ok(())
     }
 
     fn mark_stale(&mut self) {
         self.stale = true;
+    }
+
+    fn is_stale(&self) -> bool {
+        self.stale
     }
 
     fn scroll_main_panel(&mut self, scroll: Scroll) -> Result<()> {

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -778,24 +778,25 @@ impl<'a> LogTab<'a> {
 
 impl Tab for LogTab<'_> {
     fn refresh(&mut self) -> Result<()> {
-        if self.stale {
-            // The log we are about to read leaves the working copy alone,
-            // so following the selection has to as well, or the two
-            // disagree.
-            let mut commander = new_commander();
-            commander.ignore_working_copy();
+        // The log we are about to read leaves the working copy alone, so
+        // following the selection has to as well, or the two disagree.
+        let mut commander = new_commander();
+        commander.ignore_working_copy();
 
-            let latest_head = commander.get_head_latest(&self.head)?;
-            self.log_panel.set_head(latest_head);
-            self.refresh_log_output();
-            self.stale = false;
-        }
+        let latest_head = commander.get_head_latest(&self.head)?;
+        self.log_panel.set_head(latest_head);
+        self.refresh_log_output();
+        self.stale = false;
 
         Ok(())
     }
 
     fn mark_stale(&mut self) {
         self.stale = true;
+    }
+
+    fn is_stale(&self) -> bool {
+        self.stale
     }
 
     fn drop_caches(&mut self) {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -72,12 +72,15 @@ pub trait Component {
 
 /// A top-level tab, showing what it reads from the repo.
 pub trait Tab: Component {
-    /// Read whatever this tab shows afresh from the repo if it is stale,
-    /// leaving it no longer stale. Does nothing otherwise.
+    /// Read whatever this tab shows afresh from the repo, leaving it no
+    /// longer stale.
     fn refresh(&mut self) -> Result<()>;
 
     /// Have the next [refresh](Tab::refresh) read the repo.
     fn mark_stale(&mut self);
+
+    /// Whether the next [refresh](Tab::refresh) will read the repo.
+    fn is_stale(&self) -> bool;
 
     /// Discard whatever this tab has cached, so that the next read goes
     /// to the repo.


### PR DESCRIPTION
Every pass of the loop follows an event, so drawing on each one costs nothing that the event did not already ask for. Waking up on a timer to check the repo, which is what we are after next, breaks that: a wake-up that finds nothing to report would rebuild the whole display anyway. So we have update() and refresh_view() report whether they did anything, keep track of whether the last wait ran out without an event, and leave the display alone when neither has anything new. A popup counts as a change whatever it says, as it animates while it is up.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
