### PR TITLE
commander: Pass revision arguments as a Revset

### DIFF
--- a/src/commander/files.rs
+++ b/src/commander/files.rs
@@ -233,6 +233,7 @@ mod tests {
     use insta::assert_debug_snapshot;
 
     use super::*;
+    use crate::commander::revset::Revset;
     use crate::commander::tests::TestRepo;
 
     #[test]
@@ -545,11 +546,11 @@ mod tests {
     fn create_conflicting_changes(test_repo: &TestRepo) -> Result<(Head, Head)> {
         let root = test_repo.commander.get_current_head()?;
 
-        test_repo.commander.run_new([root.commit_id.as_str()])?;
+        test_repo.commander.run_new(&root.commit_id)?;
         let head1 = test_repo.commander.get_current_head()?;
         write_conflicting_files(test_repo, b"AAA")?;
 
-        test_repo.commander.run_new([root.commit_id.as_str()])?;
+        test_repo.commander.run_new(&root.commit_id)?;
         let head2 = test_repo.commander.get_current_head()?;
         write_conflicting_files(test_repo, b"BBB")?;
 
@@ -603,9 +604,9 @@ mod tests {
 
         // By change ID, as writing the files moved both changes on from the
         // commits they were looked up as.
-        test_repo
-            .commander
-            .run_new([head1.change_id.as_str(), head2.change_id.as_str()])?;
+        let parents = Revset::union([&head1.change_id, &head2.change_id])
+            .expect("two change IDs are not an empty union");
+        test_repo.commander.run_new(parents)?;
 
         let head = test_repo.commander.get_current_head()?;
 

--- a/src/commander/jj.rs
+++ b/src/commander/jj.rs
@@ -13,13 +13,19 @@ use crate::commander::CommandError;
 use crate::commander::Commander;
 use crate::commander::bookmarks::Bookmark;
 use crate::commander::ids::CommitId;
+use crate::commander::revset::Revset;
 
 impl Commander {
-    /// Create a new change after revisions. Maps to `jj new <revision>...`
-    #[instrument(level = "trace", skip(self, revisions))]
-    pub fn run_new<'a, T: IntoIterator<Item = &'a str>>(&self, revisions: T) -> Result<()> {
-        let args = ["new"].into_iter().chain::<T>(revisions);
-        self.jj(args).run_void().context("Failed executing jj new")
+    /// Create a new change. Maps to `jj new <revset>`.
+    pub fn run_new(&self, revset: impl Into<Revset>) -> Result<()> {
+        self.run_new_inner(revset.into().as_str())
+    }
+
+    #[instrument(level = "trace", name = "run_new", skip(self))]
+    fn run_new_inner(&self, revset: &str) -> Result<()> {
+        self.jj(["new", revset])
+            .run_void()
+            .context("Failed executing jj new")
     }
 
     /// Duplicate a change. Maps to `jj duplicate`
@@ -40,13 +46,14 @@ impl Commander {
         self.jj(args).run_void().context("Failed executing jj edit")
     }
 
-    /// Abandon change. Maps to `jj abandon <revision>`
-    #[instrument(level = "trace", skip(self))]
-    pub fn run_abandon(&self, commit_ids: &[CommitId]) -> Result<()> {
-        let args = ["abandon"]
-            .into_iter()
-            .chain(commit_ids.iter().map(CommitId::as_str));
-        self.jj(args)
+    /// Abandon change. Maps to `jj abandon <revset>`.
+    pub fn run_abandon(&self, revset: impl Into<Revset>) -> Result<()> {
+        self.run_abandon_inner(revset.into().as_str())
+    }
+
+    #[instrument(level = "trace", name = "run_abandon", skip(self))]
+    fn run_abandon_inner(&self, revset: &str) -> Result<()> {
+        self.jj(["abandon", revset])
             .run_void()
             .context("Failed executing jj abandon")
     }
@@ -64,8 +71,23 @@ impl Commander {
     }
 
     /// Rebase changes. Maps to `jj rebase -s <rev> -d <rev>` or similar
-    #[instrument(level = "trace", skip(self))]
     pub fn run_rebase(
+        &self,
+        src_mode: &str,
+        src_rev: impl Into<Revset>,
+        tgt_mode: &str,
+        tgt_rev: impl Into<Revset>,
+    ) -> Result<()> {
+        self.run_rebase_inner(
+            src_mode,
+            src_rev.into().as_str(),
+            tgt_mode,
+            tgt_rev.into().as_str(),
+        )
+    }
+
+    #[instrument(level = "trace", name = "run_rebase", skip(self))]
+    fn run_rebase_inner(
         &self,
         src_mode: &str,
         src_rev: &str,
@@ -216,8 +238,6 @@ impl Commander {
 
 #[cfg(test)]
 mod tests {
-    use core::slice;
-
     use super::*;
     use crate::commander::tests::TestRepo;
 
@@ -226,7 +246,7 @@ mod tests {
         let test_repo = TestRepo::new()?;
 
         let head = test_repo.commander.get_current_head()?;
-        test_repo.commander.run_new([head.commit_id.as_str()])?;
+        test_repo.commander.run_new(&head.commit_id)?;
         assert_ne!(head, test_repo.commander.get_current_head()?);
 
         Ok(())
@@ -237,7 +257,7 @@ mod tests {
         let test_repo = TestRepo::new()?;
 
         let head = test_repo.commander.get_current_head()?;
-        test_repo.commander.run_new([head.commit_id.as_str()])?;
+        test_repo.commander.run_new(&head.commit_id)?;
         assert_ne!(head, test_repo.commander.get_current_head()?);
         test_repo
             .commander
@@ -252,9 +272,7 @@ mod tests {
         let test_repo = TestRepo::new()?;
 
         let head = test_repo.commander.get_current_head()?;
-        test_repo
-            .commander
-            .run_abandon(slice::from_ref(&head.commit_id))?;
+        test_repo.commander.run_abandon(&head.commit_id)?;
         assert_ne!(head, test_repo.commander.get_current_head()?);
 
         Ok(())
@@ -317,7 +335,7 @@ mod tests {
 
         // Create new change, since by default `jj bookmark create` uses current change
         let head = test_repo.commander.get_current_head()?;
-        test_repo.commander.run_new([head.commit_id.as_str()])?;
+        test_repo.commander.run_new(&head.commit_id)?;
         assert_ne!(head, test_repo.commander.get_current_head()?);
 
         let bookmark = test_repo
@@ -349,7 +367,7 @@ mod tests {
 
         // Create new change, since by default `jj bookmark create` uses current change
         let old_head = test_repo.commander.get_current_head()?;
-        test_repo.commander.run_new([old_head.commit_id.as_str()])?;
+        test_repo.commander.run_new(&old_head.commit_id)?;
         let new_head = test_repo.commander.get_current_head()?;
         assert_ne!(old_head, new_head);
 

--- a/src/commander/mod.rs
+++ b/src/commander/mod.rs
@@ -28,6 +28,7 @@ pub mod ids;
 pub mod jj;
 pub mod log;
 pub mod operation;
+pub mod revset;
 
 use std::ffi::OsStr;
 use std::ffi::OsString;

--- a/src/commander/revset.rs
+++ b/src/commander/revset.rs
@@ -1,0 +1,89 @@
+/*!
+Revset expressions for jj revision arguments
+*/
+use std::fmt::Display;
+
+use crate::commander::ids::ChangeId;
+use crate::commander::ids::CommitId;
+
+/// A jj revset expression.
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub struct Revset(String);
+
+impl Revset {
+    /// An arbitrary revset expression, such as one entered by the user.
+    pub fn expression(expression: impl Into<String>) -> Self {
+        Self(expression.into())
+    }
+
+    /// The union of the given revsets, or [None] if there are none.
+    pub fn union(revsets: impl IntoIterator<Item = impl Into<Revset>>) -> Option<Self> {
+        let expressions: Vec<_> = revsets.into_iter().map(|revset| revset.into().0).collect();
+        if expressions.is_empty() {
+            return None;
+        }
+
+        Some(Self(expressions.join(" | ")))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<&ChangeId> for Revset {
+    fn from(id: &ChangeId) -> Self {
+        Self(id.as_string())
+    }
+}
+
+impl From<&CommitId> for Revset {
+    fn from(id: &CommitId) -> Self {
+        Self(id.as_str().to_owned())
+    }
+}
+
+impl Display for Revset {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn union_of_nothing() {
+        assert_eq!(Revset::union(Vec::<Revset>::new()), None);
+    }
+
+    #[test]
+    fn union_of_one_is_bare() {
+        let ids = [CommitId("abc".to_owned())];
+        assert_eq!(Revset::union(&ids), Some(Revset::expression("abc")));
+    }
+
+    #[test]
+    fn union_of_several() {
+        let ids = [
+            CommitId("abc".to_owned()),
+            CommitId("def".to_owned()),
+            CommitId("ghi".to_owned()),
+        ];
+        assert_eq!(
+            Revset::union(&ids),
+            Some(Revset::expression("abc | def | ghi"))
+        );
+    }
+
+    #[test]
+    fn union_of_mixed_ids() {
+        let commit = CommitId("abc".to_owned());
+        let change = ChangeId("xyz".to_owned());
+        assert_eq!(
+            Revset::union([Revset::from(&commit), Revset::from(&change)]),
+            Some(Revset::expression("abc | xyz"))
+        );
+    }
+}

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -16,6 +16,7 @@ use tui_confirm_dialog::Listener;
 use crate::commander::CommandError;
 use crate::commander::bookmarks::BookmarkLine;
 use crate::commander::new_commander;
+use crate::commander::revset::Revset;
 use crate::env::DiffFormat;
 use crate::env::JjConfig;
 use crate::env::get_env;
@@ -299,7 +300,7 @@ impl Component for BookmarksTab {
                 }
                 NEW_POPUP_ID => {
                     if let Some(BookmarkLine::Parsed { bookmark, .. }) = self.bookmark.as_ref() {
-                        new_commander().run_new([bookmark.to_string().as_str()])?;
+                        new_commander().run_new(Revset::expression(bookmark.to_string()))?;
                         let head = new_commander().get_current_head()?;
                         if self.describe_after_new {
                             self.describe_after_new = false;

--- a/src/ui/dialog/rebase.rs
+++ b/src/ui/dialog/rebase.rs
@@ -86,8 +86,6 @@ impl RebasePopup {
 
     /// Run the command that the popup is currently configured to do
     fn run_command(&self) -> Result<()> {
-        let src_rev = self.source_rev.commit_id.as_str();
-        let tgt_rev = self.target_rev.commit_id.as_str();
         let src_mode = match self.source_mode {
             CutOption::IncludeDescendants => "-s",
             CutOption::IncludeBranch => "-b",
@@ -98,7 +96,12 @@ impl RebasePopup {
             PasteOption::InsertAfter => "-A",
             PasteOption::InsertBefore => "-B",
         };
-        new_commander().run_rebase(src_mode, src_rev, tgt_mode, tgt_rev)?;
+        new_commander().run_rebase(
+            src_mode,
+            &self.source_rev.commit_id,
+            tgt_mode,
+            &self.target_rev.commit_id,
+        )?;
         Ok(())
     }
 }

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -25,9 +25,9 @@ use tui_confirm_dialog::ConfirmDialog;
 use tui_confirm_dialog::ConfirmDialogState;
 use tui_confirm_dialog::Listener;
 
-use crate::commander::ids::CommitId;
 use crate::commander::log::Head;
 use crate::commander::new_commander;
+use crate::commander::revset::Revset;
 use crate::env::DiffFormat;
 use crate::env::JjConfig;
 use crate::env::get_env;
@@ -470,11 +470,9 @@ impl<'a> LogTab<'a> {
     // Execute new command, after self.popup returned
     fn execute_new(&mut self) -> Result<Option<AppAction>> {
         let commit_ids = self.log_panel.extract_and_clear_head_marks();
-        if commit_ids.is_empty() {
-            new_commander().run_new([self.head.commit_id.as_str()])?;
-        } else {
-            new_commander().run_new(commit_ids.iter().map(CommitId::as_str))?;
-        }
+        let revset =
+            Revset::union(&commit_ids).unwrap_or_else(|| Revset::from(&self.head.commit_id));
+        new_commander().run_new(revset)?;
         self.set_head(new_commander().get_current_head()?);
         if self.describe_after_new {
             self.describe_after_new = false;
@@ -542,7 +540,9 @@ impl<'a> LogTab<'a> {
         }
         // Abandon marked commmits
         let commit_id_list = self.log_panel.extract_and_clear_head_marks();
-        new_commander().run_abandon(&commit_id_list)?;
+        let revset =
+            Revset::union(&commit_id_list).unwrap_or_else(|| Revset::from(&self.head.commit_id));
+        new_commander().run_abandon(revset)?;
         // Update selection to latest version, in case abandon triggered a rebase.
         let new_selection = new_commander().get_head_latest(&selection)?;
         // Update log panel and diff panel


### PR DESCRIPTION
The commander functions take their revision arguments as bare strings, so any string passes for a revset, and run_new() and run_abandon() take several of them to pass to jj as separate arguments. Upcoming work routes the log tab's marked commits through a single union expression instead, so we introduce a type for these arguments and hand the operations one revset each. Change and commit IDs convert implicitly, being valid revsets on their own, while an arbitrary expression has to go through expression() so that a stray string cannot pass for one. union() returns None for an empty input rather than none(): the callers all have a meaningful fallback, usually the current head, and an operation on none() would either fail in jj or silently do nothing.

The operations take anything convertible so that a caller can hand over an ID without naming the type. As instrumenting a generic function would have to skip the argument it is called with, the tracing moves to an inner function taking the expression itself.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
