### PR TITLE
Fix the details panel losing its content on a resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   change has conflicts in paths of differing lengths
 - Coming back to the terminal window no longer stalls the UI while `jj log` runs
   again for a repo that has not changed
+- Resizing the details panel no longer empties it while an external diff tool
+  renders the change again
 
 ## [0.8.0] - 2026-04-19
 

--- a/src/commander/mod.rs
+++ b/src/commander/mod.rs
@@ -62,6 +62,11 @@ use crate::env::get_env;
 const JJ_MIN_VERSION: &str = "0.37.0";
 const JJ_VERSION_IGNORE_HELP: &str = "If you want to continue anyway, use --ignore-jj-version";
 
+/// The narrowest width jj is told to limit secondary programs to. Anything
+/// below this is ignored, as those programs produce garbage output at that
+/// size, so it makes no difference to what they print.
+pub const MIN_SETTABLE_WIDTH: usize = 20;
+
 impl DiffFormat {
     pub fn get_args(&self) -> Vec<&str> {
         match self {
@@ -146,7 +151,6 @@ impl Commander {
     /// tools, by setting `COLUMNS` on every command this commander runs.
     /// Too narrow width requests are ignored, as they produce garbage output.
     pub fn limit_width(&mut self, columns: usize) {
-        const MIN_SETTABLE_WIDTH: usize = 20;
         if columns >= MIN_SETTABLE_WIDTH {
             self.columns = Some(columns);
         }

--- a/src/env.rs
+++ b/src/env.rs
@@ -15,6 +15,7 @@ use anyhow::bail;
 use ratatui::style::Color;
 use serde::Deserialize;
 
+use crate::commander::MIN_SETTABLE_WIDTH;
 use crate::commander::RemoveEndLine;
 use crate::commander::get_output_args;
 use crate::keybinds::KeybindsConfig;
@@ -195,6 +196,20 @@ impl DiffFormat {
             _ => DiffFormat::ColorWords,
         }
     }
+
+    /// How wide output in this format is rendered, given the width of the
+    /// panel showing it. Only an external diff tool is told the width, via
+    /// the COLUMNS environment variable. jj's own formats produce the same
+    /// output whatever the width, and the panel wraps or scrolls it.
+    ///
+    /// A width too narrow to be passed on makes no difference either, so it
+    /// comes out as no width at all rather than as a value of its own.
+    pub fn render_width(&self, panel_width: usize) -> usize {
+        match self {
+            DiffFormat::DiffTool(_) if panel_width >= MIN_SETTABLE_WIDTH => panel_width,
+            _ => 0,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Default, Copy, PartialEq)]
@@ -212,5 +227,45 @@ impl From<JJLayout> for ratatui::layout::Direction {
             JJLayout::Horizontal => ratatui::layout::Direction::Horizontal,
             JJLayout::Vertical => ratatui::layout::Direction::Vertical,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PANEL_WIDTH: usize = 80;
+
+    #[test]
+    fn only_a_diff_tool_is_told_the_panel_width() {
+        assert_eq!(
+            DiffFormat::DiffTool(Some("difft".to_owned())).render_width(PANEL_WIDTH),
+            PANEL_WIDTH
+        );
+        assert_eq!(
+            DiffFormat::DiffTool(None).render_width(PANEL_WIDTH),
+            PANEL_WIDTH
+        );
+
+        for format in [
+            DiffFormat::ColorWords,
+            DiffFormat::Git,
+            DiffFormat::Summary,
+            DiffFormat::Stat,
+        ] {
+            assert_eq!(format.render_width(PANEL_WIDTH), 0, "{format:?}");
+        }
+    }
+
+    #[test]
+    fn a_width_that_cannot_be_passed_on_is_no_width() {
+        let diff_tool = DiffFormat::DiffTool(None);
+
+        assert_eq!(
+            diff_tool.render_width(MIN_SETTABLE_WIDTH),
+            MIN_SETTABLE_WIDTH
+        );
+        assert_eq!(diff_tool.render_width(MIN_SETTABLE_WIDTH - 1), 0);
+        assert_eq!(diff_tool.render_width(0), 0);
     }
 }

--- a/src/ui/commit_show_cache.rs
+++ b/src/ui/commit_show_cache.rs
@@ -17,31 +17,18 @@ use crate::commander::log::Head;
 use crate::env::DiffFormat;
 use crate::ui::utils::LargeString;
 
-/// 'jj show' output depends on all these values
+/// The change and formatting a 'jj show' output belongs to
 #[derive(PartialEq, Eq, Hash, Clone)]
 pub struct CommitShowKey {
     /// Commit id of shown change
     pub id: Head,
     /// Formatting used to render change
     pub format: DiffFormat,
-    /// Render width.
-    /// Set to 0 for all except format=DiffTool.
-    /// For DiffTool it is set to the inner with of the details panel,
-    /// which is given to the tool via the COLUMNS environment variable.
-    pub width: usize,
 }
 
 impl CommitShowKey {
-    /// Create a new key. If DiffFormat is not DiffTool, then width
-    /// will be set to zero.
-    pub fn new(id: Head, format: DiffFormat, width: usize) -> Self {
-        // Keep with only for the DiffTool format
-        let width = if let DiffFormat::DiffTool(_) = format {
-            width
-        } else {
-            0
-        };
-        Self { id, format, width }
+    pub fn new(id: Head, format: DiffFormat) -> Self {
+        Self { id, format }
     }
 }
 
@@ -49,6 +36,10 @@ impl CommitShowKey {
 /// A structure that allows fast rendering of document with millions of lines
 pub struct CommitShowValue {
     key: CommitShowKey,
+    /// The render width this output was produced at
+    width: usize,
+    /// Whether the repo may have moved on since this output was produced
+    dirty: bool,
     /// Rank in the order the cache received its documents in.
     /// Assigned by [insert_document](CommitShowCache::insert_document)
     serial: u64,
@@ -57,15 +48,23 @@ pub struct CommitShowValue {
 
 impl CommitShowValue {
     /// Index value, and store both key and value
-    pub fn new(key: CommitShowKey, value: String) -> Self {
+    pub fn new(key: CommitShowKey, width: usize, value: String) -> Self {
         Self {
             key,
+            width,
+            dirty: false,
             serial: 0,
             jj_output: LargeString::new(value),
         }
     }
     pub fn value(&self) -> &LargeString {
         &self.jj_output
+    }
+
+    /// Whether this output is still what a panel of the given render
+    /// width is to show
+    fn is_fresh(&self, width: usize) -> bool {
+        !self.dirty && self.width == width
     }
 }
 
@@ -99,18 +98,15 @@ impl CommitShowCache {
             next_serial: 0,
         }
     }
-    /// Declare which commits should be kept. Any commit outside this set
-    /// that shares change id with this set will be kept until the correct
-    /// commit is available.
-    ///   The Head of the key is replaced with each head
-    /// from active_heads before inserting in active commits.
-    pub fn set_active(&mut self, active_heads: Vec<Head>, key: &CommitShowKey) {
+    /// Declare which commits should be kept, as rendered in the given
+    /// format. Any commit outside this set that shares change id with this
+    /// set will be kept until the correct commit is available.
+    pub fn set_active(&mut self, active_heads: Vec<Head>, format: &DiffFormat) {
         // Construct map of active_commits from ChangeId to HashSet<CommitShowKey>
         // containing all visible heads
         self.active_commits = HashMap::new();
         for head in active_heads {
-            let mut key = key.clone();
-            key.id = head;
+            let key = CommitShowKey::new(head, format.clone());
             let change_id = key.id.change_id.clone();
             self.active_commits
                 .entry(change_id)
@@ -148,33 +144,27 @@ impl CommitShowCache {
         }
     }
 
-    /// Mark all active heads as dirty by changing their width to 1.
-    /// This way they will all be seen as old next time [set_active](Self.set_active) is called.
+    /// Mark every cached output as dirty, so that it is rendered again
+    /// the next time it is asked for.
     pub fn mark_dirty(&mut self) {
-        // Collect all keys for active commits
-        // std::mem::take moves the map out of self and leaves an empty one in its place
-        let active_commits = std::mem::take(&mut self.active_commits);
-        let active_keys: Vec<CommitShowKey> = active_commits.values().flatten().cloned().collect();
-        // Mark document as dirty
-        for ac_key in active_keys {
-            let Some(mut value) = self.commit_document.remove(&ac_key) else {
-                continue;
-            };
-            value.key.width = 1;
-            self.insert_document(value);
+        for value in self.commit_document.values_mut() {
+            value.dirty = true;
         }
     }
 
-    /// Return true if the key is present as active
-    pub fn has_exact_match(&self, key: &CommitShowKey) -> bool {
-        self.commit_document.contains_key(key)
+    /// Return true if the cache holds the output for the key, rendered
+    /// at the given width and not outdated since.
+    pub fn is_fresh(&self, key: &CommitShowKey, width: usize) -> bool {
+        self.commit_document
+            .get(key)
+            .is_some_and(|value| value.is_fresh(width))
     }
 
     /// Search for best match of the provided key.
     pub fn get(&self, key: &CommitShowKey) -> Option<&CommitShowValue> {
         // Look for direct hit via CommitId
-        if self.has_exact_match(key) {
-            return self.commit_document.get(key);
+        if let Some(value) = self.commit_document.get(key) {
+            return Some(value);
         }
         // Look for indirect hit via ChangeId
         if let Some(old_key) = self.old_commits.get(&key.id.change_id) {
@@ -212,21 +202,20 @@ mod tests {
         }
     }
 
-    fn key(change_id: &str, commit_id: &str) -> CommitShowKey {
-        CommitShowKey::new(head(change_id, commit_id), DiffFormat::ColorWords, 0)
-    }
+    /// The width of a format that renders the same however wide the panel
+    /// showing it is
+    const NO_WIDTH: usize = 0;
 
-    /// A key of the only format that renders at a given width
-    fn tool_key(change_id: &str, commit_id: &str, width: usize) -> CommitShowKey {
-        CommitShowKey::new(
-            head(change_id, commit_id),
-            DiffFormat::DiffTool(None),
-            width,
-        )
+    fn key(change_id: &str, commit_id: &str) -> CommitShowKey {
+        CommitShowKey::new(head(change_id, commit_id), DiffFormat::ColorWords)
     }
 
     fn insert(cache: &mut CommitShowCache, key: &CommitShowKey, text: &str) {
-        cache.insert_document(CommitShowValue::new(key.clone(), text.to_owned()));
+        insert_at(cache, key, NO_WIDTH, text);
+    }
+
+    fn insert_at(cache: &mut CommitShowCache, key: &CommitShowKey, width: usize, text: &str) {
+        cache.insert_document(CommitShowValue::new(key.clone(), width, text.to_owned()));
     }
 
     fn text_of(value: Option<&CommitShowValue>) -> String {
@@ -237,13 +226,13 @@ mod tests {
     fn rewritten_commit_keeps_showing_its_previous_output() {
         let mut cache = CommitShowCache::new();
         let old = key("abc", "111");
-        cache.set_active(vec![old.id.clone()], &old);
+        cache.set_active(vec![old.id.clone()], &old.format);
         insert(&mut cache, &old, "old output");
 
         let new = key("abc", "222");
-        cache.set_active(vec![new.id.clone()], &new);
+        cache.set_active(vec![new.id.clone()], &new.format);
 
-        assert!(!cache.has_exact_match(&new));
+        assert!(!cache.is_fresh(&new, NO_WIDTH));
         assert_eq!(text_of(cache.get(&new)), "old output");
     }
 
@@ -254,7 +243,7 @@ mod tests {
         insert(&mut cache, &old, "old output");
 
         let new = key("abc", "222");
-        cache.set_active(vec![new.id.clone()], &new);
+        cache.set_active(vec![new.id.clone()], &new.format);
         insert(&mut cache, &new, "new output");
 
         assert_eq!(text_of(cache.get(&new)), "new output");
@@ -264,28 +253,24 @@ mod tests {
     #[test]
     fn output_rendered_for_another_width_is_kept() {
         let mut cache = CommitShowCache::new();
-        let narrow = tool_key("abc", "111", 80);
-        cache.set_active(vec![narrow.id.clone()], &narrow);
-        insert(&mut cache, &narrow, "narrow output");
+        let diff_tool = CommitShowKey::new(head("abc", "111"), DiffFormat::DiffTool(None));
+        cache.set_active(vec![diff_tool.id.clone()], &diff_tool.format);
+        insert_at(&mut cache, &diff_tool, 80, "narrow output");
 
-        let wide = tool_key("abc", "111", 100);
-        cache.set_active(vec![wide.id.clone()], &wide);
-
-        assert!(!cache.has_exact_match(&wide));
-        assert_eq!(text_of(cache.get(&wide)), "narrow output");
+        assert!(!cache.is_fresh(&diff_tool, 100));
+        assert_eq!(text_of(cache.get(&diff_tool)), "narrow output");
     }
 
     #[test]
     fn dirty_output_is_kept_until_it_is_rebuilt() {
         let mut cache = CommitShowCache::new();
         let active = key("abc", "111");
-        cache.set_active(vec![active.id.clone()], &active);
+        cache.set_active(vec![active.id.clone()], &active.format);
         insert(&mut cache, &active, "stale output");
 
         cache.mark_dirty();
-        cache.set_active(vec![active.id.clone()], &active);
 
-        assert!(!cache.has_exact_match(&active));
+        assert!(!cache.is_fresh(&active, NO_WIDTH));
         assert_eq!(text_of(cache.get(&active)), "stale output");
     }
 
@@ -296,7 +281,7 @@ mod tests {
         insert(&mut cache, &key("abc", "222"), "second output");
 
         let new = key("abc", "333");
-        cache.set_active(vec![new.id.clone()], &new);
+        cache.set_active(vec![new.id.clone()], &new.format);
 
         assert_eq!(text_of(cache.get(&new)), "second output");
         assert_eq!(cache.commit_document.len(), 1);
@@ -307,11 +292,11 @@ mod tests {
         let mut cache = CommitShowCache::new();
         let first = key("abc", "111");
         let second = key("abc", "222");
-        cache.set_active(vec![first.id.clone(), second.id.clone()], &first);
+        cache.set_active(vec![first.id.clone(), second.id.clone()], &first.format);
         insert(&mut cache, &first, "first output");
         insert(&mut cache, &second, "second output");
 
-        cache.set_active(vec![first.id.clone(), second.id.clone()], &first);
+        cache.set_active(vec![first.id.clone(), second.id.clone()], &first.format);
 
         assert_eq!(text_of(cache.get(&first)), "first output");
         assert_eq!(text_of(cache.get(&second)), "second output");

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -123,6 +123,8 @@ pub struct LogTab<'a> {
 struct PendingJjShow {
     /// The requested key
     key: CommitShowKey,
+    /// The render width the output is requested at
+    width: usize,
     /// The child process executing 'jj show'
     child: Child,
     /// The thread reading stdout from child process
@@ -169,8 +171,7 @@ impl<'a> LogTab<'a> {
     pub fn new(app_event_sender: Sender<AppEvent>, head: Head) -> Self {
         let diff_format = get_env().jj_config.diff_format();
 
-        const NO_WIDTH: usize = 0;
-        let head_key = CommitShowKey::new(head.clone(), diff_format.clone(), NO_WIDTH);
+        let head_key = CommitShowKey::new(head.clone(), diff_format.clone());
 
         let commit_show_cache = CommitShowCache::new();
 
@@ -252,12 +253,17 @@ impl<'a> LogTab<'a> {
         // generate different output for some keys. We probably need
         // a forced cache clear function.
 
-        // TODO use shared function to build key, so width can be cleared if not needed
-        let inner_width = self.head_panel.columns() as usize;
         // The next draw requests `jj show` for the new key if it is not
         // already cached, and moves the panel over once it has content.
-        self.head_key =
-            CommitShowKey::new(self.head.clone(), self.diff_format.clone(), inner_width);
+        self.head_key = CommitShowKey::new(self.head.clone(), self.diff_format.clone());
+    }
+
+    /// The width the details panel renders the selected change at. The
+    /// panel reports the width it got in the last frame, so this is only
+    /// meaningful once it has been drawn.
+    fn head_width(&self) -> usize {
+        self.diff_format
+            .render_width(self.head_panel.columns() as usize)
     }
 
     /// The content the details panel is to render. This is the selected
@@ -288,20 +294,17 @@ impl<'a> LogTab<'a> {
     /// the changes there as active. For non-active changes, keep at most
     /// one commit.
     fn update_cache_active_commits(&mut self) {
-        let key = CommitShowKey::new(
-            self.head.clone(),
-            self.diff_format.clone(),
-            self.head_panel.columns() as usize,
-        );
         let active_heads = self.log_panel.log_heads();
-        self.commit_show_cache.set_active(active_heads, &key);
+        self.commit_show_cache
+            .set_active(active_heads, &self.diff_format);
     }
 
     /// Launch of a child process for 'jj show'
-    fn request_jj_show(&mut self, launch_key: CommitShowKey) {
+    fn request_jj_show(&mut self, launch_key: CommitShowKey, launch_width: usize) {
         // Ignore request for already pending key
         if let Some(pjs) = self.pending_jj_show.as_ref()
             && pjs.key == launch_key
+            && pjs.width == launch_width
         {
             return;
         }
@@ -317,14 +320,14 @@ impl<'a> LogTab<'a> {
 
         // Lanuch new child process that runs 'jj show'
         let mut commander = new_commander();
-        commander.limit_width(launch_key.width);
+        commander.limit_width(launch_width);
         let launch_child =
             commander.spawn_commit_show(&launch_key.id.commit_id, &launch_key.format, true);
         let mut launch_child = match launch_child {
             Ok(child) => child,
             Err(err) => {
                 error!("Unable to spawn 'jj show': {err}");
-                self.show_error_in_details_panel(launch_key, err.to_string());
+                self.show_error_in_details_panel(launch_key, launch_width, err.to_string());
                 return;
             }
         };
@@ -338,6 +341,7 @@ impl<'a> LogTab<'a> {
 
         let pjs = PendingJjShow {
             key: launch_key,
+            width: launch_width,
             child: launch_child,
             stdout_reader,
             stderr_reader,
@@ -387,7 +391,11 @@ impl<'a> LogTab<'a> {
         // error instead of caching an empty document for the commit.
         if !status.success() {
             error!("'jj show' exited with status {status}:\n{stderr}");
-            self.show_error_in_details_panel(pjs.key, format!("jj show failed:\n\n{stderr}"));
+            self.show_error_in_details_panel(
+                pjs.key,
+                pjs.width,
+                format!("jj show failed:\n\n{stderr}"),
+            );
             return;
         }
         if !stderr.is_empty() {
@@ -395,7 +403,7 @@ impl<'a> LogTab<'a> {
         }
 
         let text = tabs_to_spaces(&String::from_utf8_lossy(&stdout));
-        let value = CommitShowValue::new(pjs.key, text);
+        let value = CommitShowValue::new(pjs.key, pjs.width, text);
         self.commit_show_cache.insert_document(value);
 
         // Note: self.pending_jj_show.take() has already cleared the
@@ -404,9 +412,9 @@ impl<'a> LogTab<'a> {
 
     /// Cache `message` as the content for `key`, so the details panel
     /// shows it instead of staying blank.
-    fn show_error_in_details_panel(&mut self, key: CommitShowKey, message: String) {
+    fn show_error_in_details_panel(&mut self, key: CommitShowKey, width: usize, message: String) {
         self.commit_show_cache
-            .insert_document(CommitShowValue::new(key, message));
+            .insert_document(CommitShowValue::new(key, width, message));
     }
 }
 
@@ -894,8 +902,9 @@ impl Component for LogTab<'_> {
 
         // Draw change details
         self.try_read_jj_show_output();
-        if !self.commit_show_cache.has_exact_match(&self.head_key) {
-            self.request_jj_show(self.head_key.clone());
+        let head_width = self.head_width();
+        if !self.commit_show_cache.is_fresh(&self.head_key, head_width) {
+            self.request_jj_show(self.head_key.clone(), head_width);
         }
         if let Some(key) = self.key_to_render()
             && let Some(content) = self.commit_show_cache.get(&key)


### PR DESCRIPTION
The output of `jj show` is cached under a key of commit, format and render width, so a details panel that has changed width misses its own cache entry and shows nothing while jj renders the diff again. What it rendered at the previous width is still in the cache, but reachable only through the fallback by change id that `set_active()` prepares on a log refresh, and a resize refreshes nothing. Only an external diff tool is affected, as it alone learns the width, through `COLUMNS`; jj's own formats produce the same output whatever the width, which is why the width is normalized away for them while a key is built -- a rule the files tab would have to repeat for its own key. Widths too narrow for `limit_width()` to pass on do not reach a diff tool either, and `mark_dirty()` says that an entry is out of date by rewriting the width in its key to 1.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
