### PR TITLE
Fix the diff stat histogram not fitting the panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   again for a repo that has not changed
 - Resizing the details panel no longer empties it while an external diff tool
   renders the change again
+- With `diff-format = "stat"`, the histogram is now scaled to the panel rather
+  than to the whole terminal
 
 ## [0.8.0] - 2026-04-19
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -177,7 +177,7 @@ pub enum DiffFormat {
     ColorWords,
     Git,
     DiffTool(Option<String>),
-    // Unused
+    // Configuration only, [DiffFormat::get_next] does not cycle through these
     Summary,
     Stat,
 }
@@ -198,15 +198,18 @@ impl DiffFormat {
     }
 
     /// How wide output in this format is rendered, given the width of the
-    /// panel showing it. Only an external diff tool is told the width, via
-    /// the COLUMNS environment variable. jj's own formats produce the same
-    /// output whatever the width, and the panel wraps or scrolls it.
+    /// panel showing it. The width reaches an external diff tool through the
+    /// COLUMNS environment variable, and `--stat` scales its histogram to
+    /// it; the other formats produce the same output whatever the width,
+    /// and the panel wraps or scrolls it.
     ///
     /// A width too narrow to be passed on makes no difference either, so it
     /// comes out as no width at all rather than as a value of its own.
     pub fn render_width(&self, panel_width: usize) -> usize {
         match self {
-            DiffFormat::DiffTool(_) if panel_width >= MIN_SETTABLE_WIDTH => panel_width,
+            DiffFormat::DiffTool(_) | DiffFormat::Stat if panel_width >= MIN_SETTABLE_WIDTH => {
+                panel_width
+            }
             _ => 0,
         }
     }
@@ -237,22 +240,16 @@ mod tests {
     const PANEL_WIDTH: usize = 80;
 
     #[test]
-    fn only_a_diff_tool_is_told_the_panel_width() {
-        assert_eq!(
-            DiffFormat::DiffTool(Some("difft".to_owned())).render_width(PANEL_WIDTH),
-            PANEL_WIDTH
-        );
-        assert_eq!(
-            DiffFormat::DiffTool(None).render_width(PANEL_WIDTH),
-            PANEL_WIDTH
-        );
-
+    fn only_formats_that_scale_are_told_the_panel_width() {
         for format in [
-            DiffFormat::ColorWords,
-            DiffFormat::Git,
-            DiffFormat::Summary,
+            DiffFormat::DiffTool(Some("difft".to_owned())),
+            DiffFormat::DiffTool(None),
             DiffFormat::Stat,
         ] {
+            assert_eq!(format.render_width(PANEL_WIDTH), PANEL_WIDTH, "{format:?}");
+        }
+
+        for format in [DiffFormat::ColorWords, DiffFormat::Git, DiffFormat::Summary] {
             assert_eq!(format.render_width(PANEL_WIDTH), 0, "{format:?}");
         }
     }


### PR DESCRIPTION
`jj diff --stat` scales its histogram to `COLUMNS`, which is how a panel tells jj how much room it has. The width rule keeps that value only for an external diff tool, on the grounds that jj's own formats produce the same output whatever the width -- which does not hold for `--stat`. A details panel configured to `stat` therefore gets a histogram sized for the whole terminal and wraps into a mess.

The format is reachable through `blazingjj.diff-format` and `ui.diff.format` only, not the `w` key, which is why it went unnoticed.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
