### PR TITLE
keybinds: Give the details panel its own keybind layer

### DIFF
--- a/src/keybinds/bookmarks_tab.rs
+++ b/src/keybinds/bookmarks_tab.rs
@@ -14,7 +14,6 @@ pub struct BookmarksTabKeybinds {
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum BookmarksTabEvent {
-    ToggleDiffFormat,
     ToggleShowAll,
     CreateBookmark,
     RenameBookmark,
@@ -34,7 +33,6 @@ impl Default for BookmarksTabKeybinds {
         let mut keys = KeybindsStore::<BookmarksTabEvent>::default();
         set_keybinds!(
             keys,
-            BookmarksTabEvent::ToggleDiffFormat => "w",
             BookmarksTabEvent::ToggleShowAll => "a",
             BookmarksTabEvent::CreateBookmark => "c",
             BookmarksTabEvent::RenameBookmark => "r",

--- a/src/keybinds/details_panel.rs
+++ b/src/keybinds/details_panel.rs
@@ -1,0 +1,79 @@
+use std::str::FromStr;
+
+use ratatui::crossterm::event::KeyEvent;
+
+use super::Keybind;
+use super::Shortcut;
+use super::keybinds_store::KeybindsStore;
+use crate::make_keybinds_help;
+use crate::set_keybinds;
+
+#[derive(Debug)]
+pub struct DetailsPanelKeybinds {
+    keys: KeybindsStore<DetailsPanelEvent>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum DetailsPanelEvent {
+    ScrollDown,
+    ScrollUp,
+    ScrollDownHalfPage,
+    ScrollUpHalfPage,
+    ScrollDownPage,
+    ScrollUpPage,
+    ToggleWrap,
+    ToggleDiffFormat,
+    Unbound,
+}
+
+impl Default for DetailsPanelKeybinds {
+    fn default() -> Self {
+        let mut keys = KeybindsStore::<DetailsPanelEvent>::default();
+        set_keybinds!(
+            keys,
+            DetailsPanelEvent::ScrollDown => "ctrl+e",
+            DetailsPanelEvent::ScrollUp => "ctrl+y",
+            DetailsPanelEvent::ScrollDownHalfPage => "ctrl+d",
+            DetailsPanelEvent::ScrollUpHalfPage => "ctrl+u",
+            DetailsPanelEvent::ScrollDownPage => "ctrl+f",
+            DetailsPanelEvent::ScrollUpPage => "ctrl+b",
+            DetailsPanelEvent::ToggleWrap => "shift+w",
+            DetailsPanelEvent::ToggleDiffFormat => "w",
+        );
+        Self { keys }
+    }
+}
+
+impl DetailsPanelKeybinds {
+    pub fn match_event(&self, event: KeyEvent) -> DetailsPanelEvent {
+        self.keys
+            .match_event(event)
+            .unwrap_or(DetailsPanelEvent::Unbound)
+    }
+
+    pub fn extend_from_config(&mut self, toggle_diff_format: Option<&Keybind>) {
+        if let Some(k) = toggle_diff_format {
+            self.keys
+                .replace_action_from_config(DetailsPanelEvent::ToggleDiffFormat, k);
+        }
+    }
+
+    pub fn make_help(&self) -> Vec<(String, String)> {
+        make_keybinds_help!(
+            self.keys,
+            DetailsPanelEvent::ScrollDown => "scroll down",
+            DetailsPanelEvent::ScrollUp => "scroll up",
+            DetailsPanelEvent::ScrollDownHalfPage => "scroll down by ½ page",
+            DetailsPanelEvent::ScrollUpHalfPage => "scroll up by ½ page",
+            DetailsPanelEvent::ScrollDownPage => "scroll down by page",
+            DetailsPanelEvent::ScrollUpPage => "scroll up by page",
+            DetailsPanelEvent::ToggleDiffFormat => "toggle diff format",
+            DetailsPanelEvent::ToggleWrap => "toggle wrapping",
+        )
+    }
+}
+
+#[test]
+fn test_details_panel_keybinds_default() {
+    let _ = DetailsPanelKeybinds::default();
+}

--- a/src/keybinds/files_tab.rs
+++ b/src/keybinds/files_tab.rs
@@ -14,7 +14,6 @@ pub struct FilesTabKeybinds {
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum FilesTabEvent {
-    ToggleDiffFormat,
     Untrack,
     Restore,
 
@@ -26,7 +25,6 @@ impl Default for FilesTabKeybinds {
         let mut keys = KeybindsStore::<FilesTabEvent>::default();
         set_keybinds!(
             keys,
-            FilesTabEvent::ToggleDiffFormat => "w",
             FilesTabEvent::Untrack => "x",
             FilesTabEvent::Restore => "r",
         );

--- a/src/keybinds/log_tab.rs
+++ b/src/keybinds/log_tab.rs
@@ -27,7 +27,6 @@ pub enum LogTabEvent {
     ScrollToTop,
 
     ToggleHeadMark,
-    ToggleDiffFormat,
 
     CreateNew {
         describe: bool,
@@ -71,8 +70,6 @@ impl Default for LogTabKeybinds {
             LogTabEvent::ScrollToBottom => "ctrl+end",
             LogTabEvent::ScrollToTop => "ctrl+home",
             LogTabEvent::ToggleHeadMark => "space",
-            // todo: move to DetailsKeybindings
-            LogTabEvent::ToggleDiffFormat => "w",
             LogTabEvent::Duplicate => "shift+d",
             LogTabEvent::CreateNew { describe: false } => "n",
             LogTabEvent::CreateNew { describe: true } => "shift+n",
@@ -121,7 +118,6 @@ impl LogTabKeybinds {
             LogTabEvent::Save => config.save,
             LogTabEvent::Cancel => config.cancel,
             LogTabEvent::ClosePopup => config.close_popup,
-            LogTabEvent::ToggleDiffFormat => config.toggle_diff_format,
             LogTabEvent::Duplicate => config.duplicate,
             LogTabEvent::CreateNew { describe: false } => config.create_new,
             LogTabEvent::CreateNew { describe: true } => config.create_new_describe,

--- a/src/keybinds/mod.rs
+++ b/src/keybinds/mod.rs
@@ -5,6 +5,8 @@ pub use bookmarks_tab::BookmarksTabEvent;
 pub use bookmarks_tab::BookmarksTabKeybinds;
 pub use config::Keybind;
 pub use config::KeybindsConfig;
+pub use details_panel::DetailsPanelEvent;
+pub use details_panel::DetailsPanelKeybinds;
 pub use files_tab::FilesTabEvent;
 pub use files_tab::FilesTabKeybinds;
 pub use global::GlobalEvent;
@@ -19,6 +21,7 @@ use ratatui::crossterm::event::KeyModifiers;
 
 mod bookmarks_tab;
 mod config;
+mod details_panel;
 mod files_tab;
 mod global;
 mod keybinds_store;

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -22,6 +22,8 @@ use crate::env::JjConfig;
 use crate::env::get_env;
 use crate::keybinds::BookmarksTabEvent;
 use crate::keybinds::BookmarksTabKeybinds;
+use crate::keybinds::DetailsPanelEvent;
+use crate::keybinds::DetailsPanelKeybinds;
 use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
@@ -79,6 +81,7 @@ pub struct BookmarksTab {
 
     config: JjConfig,
     keybinds: BookmarksTabKeybinds,
+    details_keybinds: DetailsPanelKeybinds,
     pane_divider: PaneDivider,
 
     stale: bool,
@@ -124,6 +127,7 @@ impl BookmarksTab {
         let config = get_env().jj_config.clone();
         let pane_divider = PaneDivider::new(config.layout_percent());
         let keybinds = BookmarksTabKeybinds::default();
+        let details_keybinds = DetailsPanelKeybinds::default();
 
         Self {
             bookmarks_output: Ok(Vec::new()),
@@ -154,6 +158,7 @@ impl BookmarksTab {
 
             config,
             keybinds,
+            details_keybinds,
             pane_divider,
 
             stale: true,
@@ -249,19 +254,7 @@ impl Tab for BookmarksTab {
     }
 
     fn make_details_panel_help(&self) -> Vec<(String, String)> {
-        vec![
-            ("Ctrl+e/Ctrl+y".to_owned(), "scroll down/up".to_owned()),
-            (
-                "Ctrl+d/Ctrl+u".to_owned(),
-                "scroll down/up by ½ page".to_owned(),
-            ),
-            (
-                "Ctrl+f/Ctrl+b".to_owned(),
-                "scroll down/up by page".to_owned(),
-            ),
-            ("w".to_owned(), "toggle diff format".to_owned()),
-            ("W".to_owned(), "toggle wrapping".to_owned()),
-        ]
+        self.details_keybinds.make_help()
     }
 }
 
@@ -494,15 +487,20 @@ impl Component for BookmarksTab {
                 return Ok(ComponentInputResult::Handled);
             }
 
-            if self.bookmark_panel.input(key) {
-                return Ok(ComponentInputResult::Handled);
+            match self.details_keybinds.match_event(key) {
+                DetailsPanelEvent::Unbound => {}
+                DetailsPanelEvent::ToggleDiffFormat => {
+                    self.diff_format = self.diff_format.get_next(self.config.diff_tool());
+                    self.refresh_bookmark();
+                    return Ok(ComponentInputResult::Handled);
+                }
+                ev => {
+                    self.bookmark_panel.handle_event(ev);
+                    return Ok(ComponentInputResult::Handled);
+                }
             }
 
             match self.keybinds.match_event(key) {
-                BookmarksTabEvent::ToggleDiffFormat => {
-                    self.diff_format = self.diff_format.get_next(self.config.diff_tool());
-                    self.refresh_bookmark();
-                }
                 BookmarksTabEvent::ToggleShowAll => {
                     self.show_all = !self.show_all;
                     self.refresh_bookmarks();

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -16,6 +16,8 @@ use crate::commander::new_commander;
 use crate::env::DiffFormat;
 use crate::env::JjConfig;
 use crate::env::get_env;
+use crate::keybinds::DetailsPanelEvent;
+use crate::keybinds::DetailsPanelKeybinds;
 use crate::keybinds::FilesTabEvent;
 use crate::keybinds::FilesTabKeybinds;
 use crate::ui::AppAction;
@@ -46,6 +48,7 @@ pub struct FilesTab {
 
     config: JjConfig,
     keybinds: FilesTabKeybinds,
+    details_keybinds: DetailsPanelKeybinds,
     pane_divider: PaneDivider,
 
     stale: bool,
@@ -73,6 +76,7 @@ impl FilesTab {
         let config = get_env().jj_config.clone();
         let pane_divider = PaneDivider::new(config.layout_percent());
         let keybinds = FilesTabKeybinds::default();
+        let details_keybinds = DetailsPanelKeybinds::default();
 
         Self {
             head: current_head.clone(),
@@ -91,6 +95,7 @@ impl FilesTab {
 
             config,
             keybinds,
+            details_keybinds,
             pane_divider,
 
             stale: true,
@@ -233,19 +238,7 @@ impl Tab for FilesTab {
     }
 
     fn make_details_panel_help(&self) -> Vec<(String, String)> {
-        vec![
-            ("Ctrl+e/Ctrl+y".to_owned(), "scroll down/up".to_owned()),
-            (
-                "Ctrl+d/Ctrl+u".to_owned(),
-                "scroll down/up by ½ page".to_owned(),
-            ),
-            (
-                "Ctrl+f/Ctrl+b".to_owned(),
-                "scroll down/up by page".to_owned(),
-            ),
-            ("w".to_owned(), "toggle diff format".to_owned()),
-            ("W".to_owned(), "toggle wrapping".to_owned()),
-        ]
+        self.details_keybinds.make_help()
     }
 }
 
@@ -382,15 +375,20 @@ impl Component for FilesTab {
                 return Ok(ComponentInputResult::Handled);
             }
 
-            if self.diff_panel.input(key) {
-                return Ok(ComponentInputResult::Handled);
+            match self.details_keybinds.match_event(key) {
+                DetailsPanelEvent::Unbound => {}
+                DetailsPanelEvent::ToggleDiffFormat => {
+                    self.diff_format = self.diff_format.get_next(self.config.diff_tool());
+                    self.refresh_diff()?;
+                    return Ok(ComponentInputResult::Handled);
+                }
+                ev => {
+                    self.diff_panel.handle_event(ev);
+                    return Ok(ComponentInputResult::Handled);
+                }
             }
 
             match self.keybinds.match_event(key) {
-                FilesTabEvent::ToggleDiffFormat => {
-                    self.diff_format = self.diff_format.get_next(self.config.diff_tool());
-                    self.refresh_diff()?;
-                }
                 FilesTabEvent::Untrack => {
                     // this works even for deleted files because jj doesn't return error in that case
                     if self.untrack_file().is_err() {

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -32,6 +32,8 @@ use crate::env::DiffFormat;
 use crate::env::JjConfig;
 use crate::env::get_env;
 use crate::event::AppEvent;
+use crate::keybinds::DetailsPanelEvent;
+use crate::keybinds::DetailsPanelKeybinds;
 use crate::keybinds::LogTabEvent;
 use crate::keybinds::LogTabKeybinds;
 use crate::ui::AppAction;
@@ -114,6 +116,7 @@ pub struct LogTab<'a> {
     config: JjConfig,
     pane_divider: PaneDivider,
     keybinds: LogTabKeybinds,
+    details_keybinds: DetailsPanelKeybinds,
 
     stale: bool,
 }
@@ -178,8 +181,15 @@ impl<'a> LogTab<'a> {
         let (popup_tx, popup_rx) = std::sync::mpsc::channel();
 
         let mut keybinds = LogTabKeybinds::default();
+        let mut details_keybinds = DetailsPanelKeybinds::default();
         if let Some(keybinds_config) = get_env().jj_config.keybinds() {
             keybinds.extend_from_config(keybinds_config);
+            details_keybinds.extend_from_config(
+                keybinds_config
+                    .log_tab
+                    .as_ref()
+                    .and_then(|c| c.toggle_diff_format.as_ref()),
+            );
         }
 
         let config = get_env().jj_config.clone();
@@ -216,6 +226,7 @@ impl<'a> LogTab<'a> {
             config,
             pane_divider,
             keybinds,
+            details_keybinds,
 
             stale: true,
         }
@@ -574,10 +585,6 @@ impl<'a> LogTab<'a> {
                 self.log_panel.handle_event(log_tab_event)?;
                 self.sync_head_output();
             }
-            LogTabEvent::ToggleDiffFormat => {
-                self.diff_format = self.diff_format.get_next(self.config.diff_tool());
-                self.refresh_head_output();
-            }
             LogTabEvent::Duplicate => {
                 let _ = new_commander().run_duplicate(&self.head.change_id.to_string());
                 return Ok(ComponentInputResult::HandledAction(AppAction::RefreshTab));
@@ -833,19 +840,7 @@ impl Tab for LogTab<'_> {
     }
 
     fn make_details_panel_help(&self) -> Vec<(String, String)> {
-        vec![
-            ("Ctrl+e/Ctrl+y".to_owned(), "scroll down/up".to_owned()),
-            (
-                "Ctrl+d/Ctrl+u".to_owned(),
-                "scroll down/up by ½ page".to_owned(),
-            ),
-            (
-                "Ctrl+f/Ctrl+b".to_owned(),
-                "scroll down/up by page".to_owned(),
-            ),
-            ("w".to_owned(), "toggle diff format".to_owned()),
-            ("W".to_owned(), "toggle wrapping".to_owned()),
-        ]
+        self.details_keybinds.make_help()
     }
 }
 
@@ -1030,8 +1025,17 @@ impl Component for LogTab<'_> {
                 return Ok(ComponentInputResult::Handled);
             }
 
-            if self.head_panel.input(key) {
-                return Ok(ComponentInputResult::Handled);
+            match self.details_keybinds.match_event(key) {
+                DetailsPanelEvent::Unbound => {}
+                DetailsPanelEvent::ToggleDiffFormat => {
+                    self.diff_format = self.diff_format.get_next(self.config.diff_tool());
+                    self.refresh_head_output();
+                    return Ok(ComponentInputResult::Handled);
+                }
+                ev => {
+                    self.head_panel.handle_event(ev);
+                    return Ok(ComponentInputResult::Handled);
+                }
             }
 
             let input_result = self.log_panel.input(event)?;

--- a/src/ui/panel/details_panel.rs
+++ b/src/ui/panel/details_panel.rs
@@ -12,9 +12,6 @@ To make this efficient there are two implementations of DetailContent.
 
 */
 
-use ratatui::crossterm::event::KeyCode;
-use ratatui::crossterm::event::KeyEvent;
-use ratatui::crossterm::event::KeyModifiers;
 use ratatui::crossterm::event::MouseEvent;
 use ratatui::crossterm::event::MouseEventKind;
 use ratatui::layout::Margin;
@@ -32,6 +29,7 @@ use ratatui::widgets::ScrollbarState;
 use ratatui::widgets::Wrap;
 use tracing::trace;
 
+use crate::keybinds::DetailsPanelEvent;
 use crate::ui::utils::LargeString;
 
 /// Details panel used for the right side of each tab.
@@ -73,17 +71,6 @@ where
     panel: &'a mut DetailsPanel,
     title: Option<Line<'a>>,
     content: Content,
-}
-
-/// Commands that can be handled by the details panel
-pub enum DetailsPanelEvent {
-    ScrollDown,
-    ScrollUp,
-    ScrollDownHalfPage,
-    ScrollUpHalfPage,
-    ScrollDownPage,
-    ScrollUpPage,
-    ToggleWrap,
 }
 
 //
@@ -252,8 +239,8 @@ impl DetailsPanel {
         self.scroll_to(self.scroll.saturating_add_signed(scroll as i16))
     }
 
-    pub fn handle_event(&mut self, details_panel_event: DetailsPanelEvent) {
-        match details_panel_event {
+    pub fn handle_event(&mut self, event: DetailsPanelEvent) {
+        match event {
             DetailsPanelEvent::ScrollDown => self.scroll(1),
             DetailsPanelEvent::ScrollUp => self.scroll(-1),
             DetailsPanelEvent::ScrollDownHalfPage => self.scroll(self.rows() as isize / 2),
@@ -263,35 +250,8 @@ impl DetailsPanel {
             DetailsPanelEvent::ScrollDownPage => self.scroll(self.rows() as isize),
             DetailsPanelEvent::ScrollUpPage => self.scroll((self.rows() as isize).saturating_neg()),
             DetailsPanelEvent::ToggleWrap => self.wrap = !self.wrap,
+            DetailsPanelEvent::ToggleDiffFormat | DetailsPanelEvent::Unbound => {}
         }
-    }
-
-    /// Handle input. Returns bool of if event was handled
-    pub fn input(&mut self, key: KeyEvent) -> bool {
-        match key.code {
-            KeyCode::Char('e') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                self.handle_event(DetailsPanelEvent::ScrollDown)
-            }
-            KeyCode::Char('y') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                self.handle_event(DetailsPanelEvent::ScrollUp)
-            }
-            KeyCode::Char('d') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                self.handle_event(DetailsPanelEvent::ScrollDownHalfPage)
-            }
-            KeyCode::Char('u') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                self.handle_event(DetailsPanelEvent::ScrollUpHalfPage)
-            }
-            KeyCode::Char('f') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                self.handle_event(DetailsPanelEvent::ScrollDownPage)
-            }
-            KeyCode::Char('b') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                self.handle_event(DetailsPanelEvent::ScrollUpPage)
-            }
-            KeyCode::Char('W') => self.handle_event(DetailsPanelEvent::ToggleWrap),
-            _ => return false,
-        };
-
-        true
     }
 
     /// Handle input. Returns bool of if event was handled


### PR DESCRIPTION
The details panel matches its own keys inside DetailsPanel::input(), while "w" for toggling the diff format sits in each tab's keybind store, and the panel's help text is written out by hand in every tab. Giving the panel a keybind layer of its own puts all three in one place and lets the help be generated from the live bindings, so a customized binding shows up in the popup. The log tab keeps reading `toggle-diff-format` from its own config section, as that is where it has always been configured.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
