### PR TITLE
commander: Take revsets in run_edit, describe and absorb

### DIFF
--- a/src/commander/jj.rs
+++ b/src/commander/jj.rs
@@ -35,10 +35,14 @@ impl Commander {
             .context("Failed executing jj duplicate")
     }
 
-    /// Edit change. Maps to `jj edit <commit>`
-    #[instrument(level = "trace", skip(self))]
-    pub fn run_edit(&self, revision: &str, ignore_immutable: bool) -> Result<()> {
-        let mut args = vec!["edit", revision];
+    /// Edit change. Maps to `jj edit <revset>`.
+    pub fn run_edit(&self, revset: impl Into<Revset>, ignore_immutable: bool) -> Result<()> {
+        self.run_edit_inner(revset.into().as_str(), ignore_immutable)
+    }
+
+    #[instrument(level = "trace", name = "run_edit", skip(self))]
+    fn run_edit_inner(&self, revset: &str, ignore_immutable: bool) -> Result<()> {
+        let mut args = vec!["edit", revset];
         if ignore_immutable {
             args.push("--ignore-immutable");
         }
@@ -58,13 +62,17 @@ impl Commander {
             .context("Failed executing jj abandon")
     }
 
-    /// Describe change. Maps to `jj describe <revision> --stdin`
+    /// Describe change. Maps to `jj describe <revset> --stdin`
     ///
     /// The message is passed on stdin rather than via `-m`, since jj would
     /// otherwise mistake a message starting with a dash for a flag.
-    #[instrument(level = "trace", skip(self))]
-    pub fn run_describe(&self, revision: &str, message: &str) -> Result<()> {
-        self.jj(["describe", revision, "--stdin"])
+    pub fn run_describe(&self, revset: impl Into<Revset>, message: &str) -> Result<()> {
+        self.run_describe_inner(revset.into().as_str(), message)
+    }
+
+    #[instrument(level = "trace", name = "run_describe", skip(self))]
+    fn run_describe_inner(&self, revset: &str, message: &str) -> Result<()> {
+        self.jj(["describe", revset, "--stdin"])
             .stdin(message)
             .run_void()
             .context("Failed executing jj describe")
@@ -112,10 +120,14 @@ impl Commander {
             .context("Failed executing jj squash")
     }
 
-    /// Absorb a change's diff into its mutable ancestors. Maps to `jj absorb --from <revision>`
-    #[instrument(level = "trace", skip(self))]
-    pub fn run_absorb(&self, revision: &str) -> Result<()> {
-        self.jj(["absorb", "--from", revision])
+    /// Absorb a change's diff into its mutable ancestors. Maps to `jj absorb --from <revset>`.
+    pub fn run_absorb(&self, revset: impl Into<Revset>) -> Result<()> {
+        self.run_absorb_inner(revset.into().as_str())
+    }
+
+    #[instrument(level = "trace", name = "run_absorb", skip(self))]
+    fn run_absorb_inner(&self, revset: &str) -> Result<()> {
+        self.jj(["absorb", "--from", revset])
             .run_void()
             .context("Failed executing jj absorb")
     }
@@ -259,9 +271,7 @@ mod tests {
         let head = test_repo.commander.get_current_head()?;
         test_repo.commander.run_new(&head.commit_id)?;
         assert_ne!(head, test_repo.commander.get_current_head()?);
-        test_repo
-            .commander
-            .run_edit(head.commit_id.as_str(), false)?;
+        test_repo.commander.run_edit(&head.commit_id, false)?;
         assert_eq!(head, test_repo.commander.get_current_head()?);
 
         Ok(())
@@ -283,9 +293,7 @@ mod tests {
         let test_repo = TestRepo::new()?;
 
         let head = test_repo.commander.get_current_head()?;
-        test_repo
-            .commander
-            .run_describe(head.commit_id.as_str(), "AAA")?;
+        test_repo.commander.run_describe(&head.commit_id, "AAA")?;
 
         let head = test_repo.commander.get_current_head()?.commit_id;
         assert_eq!(test_repo.commander.get_commit_description(&head)?, "AAA");
@@ -299,9 +307,7 @@ mod tests {
 
         // A message starting with a dash must not be mistaken for a flag.
         let head = test_repo.commander.get_current_head()?;
-        test_repo
-            .commander
-            .run_describe(head.commit_id.as_str(), "-AAA")?;
+        test_repo.commander.run_describe(&head.commit_id, "-AAA")?;
 
         let head = test_repo.commander.get_current_head()?.commit_id;
         assert_eq!(test_repo.commander.get_commit_description(&head)?, "-AAA");

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -308,8 +308,10 @@ impl Component for BookmarksTab {
                 }
                 EDIT_POPUP_ID => {
                     if let Some(BookmarkLine::Parsed { bookmark, .. }) = self.bookmark.as_ref() {
-                        new_commander()
-                            .run_edit(&bookmark.to_string(), self.edit_ignore_immutable)?;
+                        new_commander().run_edit(
+                            Revset::expression(bookmark.to_string()),
+                            self.edit_ignore_immutable,
+                        )?;
                         let head = new_commander().get_current_head()?;
                         return Ok(Some(AppAction::ViewLog(head)));
                     }

--- a/src/ui/dialog/describe.rs
+++ b/src/ui/dialog/describe.rs
@@ -88,10 +88,8 @@ impl Component for DescribePopup<'_> {
         {
             match (key.code, key.modifiers) {
                 (KeyCode::Char('s'), m) if m.contains(KeyModifiers::CONTROL) => {
-                    new_commander().run_describe(
-                        self.head.commit_id.as_str(),
-                        &self.textarea.lines().join("\n"),
-                    )?;
+                    new_commander()
+                        .run_describe(&self.head.commit_id, &self.textarea.lines().join("\n"))?;
                     let latest = new_commander().get_head_latest(&self.head)?;
                     return Ok(ComponentInputResult::HandledAction(AppAction::Multiple(
                         vec![AppAction::PopupDone, AppAction::ViewLog(latest)],

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -687,7 +687,7 @@ impl<'a> LogTab<'a> {
                 return self.handle_abandon();
             }
             LogTabEvent::Absorb => {
-                new_commander().run_absorb(self.head.commit_id.as_str())?;
+                new_commander().run_absorb(&self.head.commit_id)?;
                 self.set_head(new_commander().get_head_latest(&self.head)?);
                 return Ok(ComponentInputResult::HandledAction(AppAction::Multiple(
                     vec![
@@ -855,8 +855,7 @@ impl Component for LogTab<'_> {
                     return self.execute_new();
                 }
                 EDIT_POPUP_ID => {
-                    new_commander()
-                        .run_edit(self.head.commit_id.as_str(), self.edit_ignore_immutable)?;
+                    new_commander().run_edit(&self.head.commit_id, self.edit_ignore_immutable)?;
                     return Ok(Some(AppAction::Multiple(vec![
                         AppAction::ChangeHead(self.head.clone()),
                         AppAction::RefreshTab,


### PR DESCRIPTION
These three commands were left behind when the revision arguments moved over to Revset, so they still take a bare &str and their callers hand over raw id strings. The bookmarks tab is the one place that passes something other than a commit id, and it now says so via Revset::expression.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
