### PR TITLE
Fix the help popup's layout on cramped terminals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The help popup no longer drops the global keybindings when the terminal is too
   short to hold them next to the details panel ones
+- The help popup now scrolls its three keybinding lists as a whole rather than
+  each of them within its own box
 - Describing a commit with a message starting with a dash no longer fails
 - A copied file in the files list is now colored like the other changes
 - Running a command from the log tab no longer moves the selection to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   each of them within its own box
 - The help popup no longer cuts the last two characters off its longest
   descriptions
+- The help popup now stacks all three keybinding lists in a single column when
+  the terminal is too narrow to hold two of them side by side
 - Describing a commit with a message starting with a dash no longer fails
 - A copied file in the files list is now colored like the other changes
 - Running a command from the log tab no longer moves the selection to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   short to hold them next to the details panel ones
 - The help popup now scrolls its three keybinding lists as a whole rather than
   each of them within its own box
+- The help popup no longer cuts the last two characters off its longest
+  descriptions
 - Describing a commit with a message starting with a dash no longer fails
 - A copied file in the files list is now colored like the other changes
 - Running a command from the log tab no longer moves the selection to the

--- a/src/ui/dialog/help.rs
+++ b/src/ui/dialog/help.rs
@@ -38,38 +38,32 @@ fn description_width(items: &[(String, String)]) -> u16 {
         .unwrap_or(0) as u16
 }
 
-/// How far the tables have to scroll for the last item of the longest one to
-/// come into view.
-fn max_scroll(tables: [(usize, Rect); 3]) -> usize {
-    tables
-        .into_iter()
-        // A table spends its first row on its title.
-        .map(|(items, area)| items.saturating_sub(area.height.saturating_sub(1) as usize))
-        .max()
-        .unwrap_or(0)
-}
+/// Where a part of the popup's contents that is `height` rows tall and starts
+/// at row `top` of them lands in `viewport`, and how many of its rows `scroll`
+/// has taken off the top. `None` once it has scrolled out of view entirely.
+fn place(viewport: Rect, scroll: u16, top: u16, height: u16) -> Option<(Rect, u16)> {
+    let skipped = scroll.saturating_sub(top);
+    let y = viewport.y + top.saturating_sub(scroll);
+    let height = height
+        .saturating_sub(skipped)
+        .min(viewport.bottom().saturating_sub(y));
 
-/// How to split the `height` available to two stacked tables of `top` and
-/// `bottom` rows between them, leaving a line between the tables. Tables that
-/// do not both fit shrink in proportion to their length, so that neither is
-/// left without rows to scroll through.
-fn stacked_heights(height: u16, top: u16, bottom: u16) -> [u16; 2] {
-    let available = height.saturating_sub(1);
-    let total = top + bottom;
-    if total <= available {
-        return [top, bottom];
-    }
-
-    let top = (u32::from(available) * u32::from(top) / u32::from(total)) as u16;
-    [top, available - top]
+    (height > 0).then_some((
+        Rect {
+            y,
+            height,
+            ..viewport
+        },
+        skipped,
+    ))
 }
 
 pub struct HelpPopup {
     pub main_items: Vec<(String, String)>,
     pub details_items: Vec<(String, String)>,
     pub global_items: Vec<(String, String)>,
-    max_scroll: usize,
-    scroll: usize,
+    max_scroll: u16,
+    scroll: u16,
 }
 
 impl HelpPopup {
@@ -88,26 +82,37 @@ impl HelpPopup {
         }
     }
 
-    fn create_table(&self, items: &[(String, String)], title: String, key_width: u16) -> Table<'_> {
+    /// A table of `items` under its `title`, with `skipped` of its rows taken
+    /// off the top. The title is the first of those rows.
+    fn create_table(
+        &self,
+        items: &[(String, String)],
+        title: &'static str,
+        key_width: u16,
+        skipped: u16,
+    ) -> Table<'_> {
         let rows: Vec<Row> = items
             .iter()
-            .skip(self.scroll)
+            .skip(skipped.saturating_sub(1) as usize)
             .map(|(key, description)| Row::new([description.clone(), key.clone()]))
             .collect();
         let widths = [Constraint::Fill(1), Constraint::Length(key_width)];
+        let table = Table::new(rows, widths).column_spacing(COLUMN_SPACING);
 
-        Table::new(rows, widths)
-            .column_spacing(COLUMN_SPACING)
-            .block(
-                Block::new()
-                    .title(Span::from(title).bold().underlined())
-                    .title_alignment(Alignment::Center),
-            )
+        if skipped > 0 {
+            return table;
+        }
+
+        table.block(
+            Block::new()
+                .title(Span::from(title).bold().underlined())
+                .title_alignment(Alignment::Center),
+        )
     }
 
-    fn do_scroll(&mut self, delta: isize) {
-        let max = self.max_scroll as isize;
-        self.scroll = (self.scroll as isize + delta).clamp(0, max) as usize;
+    fn do_scroll(&mut self, delta: i32) {
+        let max = i32::from(self.max_scroll);
+        self.scroll = (i32::from(self.scroll) + delta).clamp(0, max) as u16;
     }
 }
 
@@ -149,27 +154,9 @@ impl Component for HelpPopup {
             ])
             .split(block_inner);
 
-        // Each table spends its first row on its title.
-        let [details_height, global_height] = stacked_heights(
-            chunks[2].height,
-            self.details_items.len() as u16 + 1,
-            self.global_items.len() as u16 + 1,
-        );
-
-        let right_chunks = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([
-                Constraint::Length(details_height),
-                Constraint::Length(1),
-                Constraint::Length(global_height),
-            ])
-            .split(chunks[2]);
-
-        self.max_scroll = max_scroll([
-            (self.main_items.len(), chunks[0]),
-            (self.details_items.len(), right_chunks[0]),
-            (self.global_items.len(), right_chunks[2]),
-        ]);
+        self.max_scroll = left_height
+            .max(right_height)
+            .saturating_sub(block_inner.height);
         self.scroll = self.scroll.min(self.max_scroll);
 
         f.render_widget(
@@ -179,20 +166,37 @@ impl Component for HelpPopup {
                 ..chunks[1]
             },
         );
-        f.render_widget(Block::new().borders(Borders::TOP), right_chunks[1]);
 
-        f.render_widget(
-            self.create_table(&self.main_items, "Main panel".into(), left_key_width),
-            chunks[0],
-        );
-        f.render_widget(
-            self.create_table(&self.details_items, "Details panel".into(), right_key_width),
-            right_chunks[0],
-        );
-        f.render_widget(
-            self.create_table(&self.global_items, "Global".into(), right_key_width),
-            right_chunks[2],
-        );
+        if let Some((area, skipped)) = place(chunks[0], self.scroll, 0, left_height) {
+            let table = self.create_table(&self.main_items, "Main panel", left_key_width, skipped);
+            f.render_widget(table, area);
+        }
+
+        // Both halves scroll as one, so the right one lays its two tables and
+        // the rule between them out at their full height and lets the scroll
+        // take them out of view.
+        let details_height = self.details_items.len() as u16 + 1;
+        if let Some((area, skipped)) = place(chunks[2], self.scroll, 0, details_height) {
+            let table = self.create_table(
+                &self.details_items,
+                "Details panel",
+                right_key_width,
+                skipped,
+            );
+            f.render_widget(table, area);
+        }
+        if let Some((area, _)) = place(chunks[2], self.scroll, details_height, 1) {
+            f.render_widget(Block::new().borders(Borders::TOP), area);
+        }
+        if let Some((area, skipped)) = place(
+            chunks[2],
+            self.scroll,
+            details_height + 1,
+            self.global_items.len() as u16 + 1,
+        ) {
+            let table = self.create_table(&self.global_items, "Global", right_key_width, skipped);
+            f.render_widget(table, area);
+        }
 
         Ok(())
     }
@@ -236,6 +240,10 @@ mod tests {
         Rect::new(0, 0, 40, height)
     }
 
+    fn rect(y: u16, height: u16) -> Rect {
+        Rect::new(0, y, 40, height)
+    }
+
     fn wheel(kind: MouseEventKind) -> Event {
         Event::Mouse(MouseEvent {
             kind,
@@ -246,27 +254,23 @@ mod tests {
     }
 
     #[test]
-    fn test_no_scroll_when_every_table_fits() {
-        assert_eq!(max_scroll([(3, area(10)), (5, area(6)), (14, area(15))]), 0);
+    fn test_unscrolled_contents_keep_their_place() {
+        assert_eq!(place(area(10), 0, 0, 6), Some((rect(0, 6), 0)));
+        // What does not fit is cut off at the bottom of the viewport.
+        assert_eq!(place(area(10), 0, 8, 5), Some((rect(8, 2), 0)));
     }
 
     #[test]
-    fn test_scroll_follows_the_table_that_overflows_most() {
-        // The global list is 14 items in 9 rows, one of which holds its title.
-        assert_eq!(max_scroll([(3, area(22)), (5, area(6)), (14, area(9))]), 6);
-        // The main panel overflows further than the global list does.
-        assert_eq!(max_scroll([(30, area(22)), (5, area(6)), (14, area(9))]), 9);
+    fn test_scrolling_takes_rows_off_the_top() {
+        // The scroll eats into a part of the contents ...
+        assert_eq!(place(area(10), 3, 0, 6), Some((rect(0, 3), 3)));
+        // ... only once it has consumed everything above it.
+        assert_eq!(place(area(10), 3, 5, 4), Some((rect(2, 4), 0)));
     }
 
     #[test]
-    fn test_stacked_tables_get_their_rows_when_they_fit() {
-        assert_eq!(stacked_heights(20, 6, 8), [6, 8]);
-    }
-
-    #[test]
-    fn test_stacked_tables_shrink_in_proportion() {
-        assert_eq!(stacked_heights(10, 6, 12), [3, 6]);
-        assert_eq!(stacked_heights(0, 6, 12), [0, 0]);
+    fn test_parts_scrolled_past_are_gone() {
+        assert_eq!(place(area(10), 8, 0, 6), None);
     }
 
     #[test]

--- a/src/ui/dialog/help.rs
+++ b/src/ui/dialog/help.rs
@@ -1,3 +1,4 @@
+use ratatui::Frame;
 use ratatui::crossterm::event::Event;
 use ratatui::crossterm::event::KeyCode;
 use ratatui::crossterm::event::MouseEventKind;
@@ -23,19 +24,76 @@ use crate::ui::utils::centered_rect_fixed;
 /// Space between the description and the key column of a table
 const COLUMN_SPACING: u16 = 4;
 
-/// Width of the gap holding the vertical rule between the two halves
+/// Width of the gap holding the vertical rule between two columns
 const SEPARATOR_WIDTH: u16 = 3;
 
-fn key_width(items: &[(String, String)]) -> u16 {
-    items.iter().map(|(key, _)| key.len()).max().unwrap_or(0) as u16
+/// A titled list of keybindings shown in the popup
+#[derive(Clone, Copy)]
+struct Section<'a> {
+    title: &'static str,
+    items: &'a [(String, String)],
 }
 
-fn description_width(items: &[(String, String)]) -> u16 {
-    items
+impl Section<'_> {
+    /// Rows the section takes, the first of which holds its title
+    fn height(&self) -> u16 {
+        self.items.len() as u16 + 1
+    }
+
+    fn key_width(&self) -> u16 {
+        self.items
+            .iter()
+            .map(|(key, _)| key.len())
+            .max()
+            .unwrap_or(0) as u16
+    }
+
+    fn description_width(&self) -> u16 {
+        self.items
+            .iter()
+            .map(|(_, description)| description.len())
+            .max()
+            .unwrap_or(0) as u16
+    }
+}
+
+/// Rows a column of `sections` takes, with a rule between them
+fn stack_height(sections: &[Section]) -> u16 {
+    sections.iter().map(Section::height).sum::<u16>() + sections.len().saturating_sub(1) as u16
+}
+
+/// The width of the key column shared by the `sections` of a column, and the
+/// width of the column as a whole. Sharing the key column lines up the rows of
+/// the sections stacked in it.
+fn stack_width(sections: &[Section]) -> (u16, u16) {
+    let key = sections.iter().map(Section::key_width).max().unwrap_or(0);
+    let description = sections
         .iter()
-        .map(|(_, description)| description.len())
+        .map(Section::description_width)
         .max()
-        .unwrap_or(0) as u16
+        .unwrap_or(0);
+
+    (key, key + COLUMN_SPACING + description)
+}
+
+/// Width the `columns` take side by side, with a separator between them
+fn contents_width(columns: &[Vec<Section>]) -> u16 {
+    let columns_width: u16 = columns.iter().map(|column| stack_width(column).1).sum();
+
+    columns_width + SEPARATOR_WIDTH * columns.len().saturating_sub(1) as u16
+}
+
+/// How to arrange the popup's sections in the `width` available for them: the
+/// main panel bindings beside the details panel and global ones, or, when that
+/// does not fit, all of them stacked in a single column, which only needs the
+/// width of the widest of them.
+fn columns<'a>([main, details, global]: [Section<'a>; 3], width: u16) -> Vec<Vec<Section<'a>>> {
+    let halves = vec![vec![main], vec![details, global]];
+    if contents_width(&halves) <= width {
+        return halves;
+    }
+
+    vec![vec![main, details, global]]
 }
 
 /// How much wider and taller than its contents a `block` is, in the `area` it
@@ -47,6 +105,50 @@ fn chrome(block: &Block, area: Rect) -> [u16; 2] {
         area.width.saturating_sub(inner.width),
         area.height.saturating_sub(inner.height),
     ]
+}
+
+/// Renders the `sections` stacked in `area`, with a rule between them and
+/// `scroll` rows taken off the top of the stack as a whole.
+fn render_stack(f: &mut Frame<'_>, area: Rect, scroll: u16, sections: &[Section]) {
+    let (key_width, _) = stack_width(sections);
+    let mut top = 0;
+
+    for (index, section) in sections.iter().enumerate() {
+        if index > 0 {
+            if let Some((rule, _)) = place(area, scroll, top, 1) {
+                f.render_widget(Block::new().borders(Borders::TOP), rule);
+            }
+            top += 1;
+        }
+
+        if let Some((table, skipped)) = place(area, scroll, top, section.height()) {
+            f.render_widget(create_table(section, key_width, skipped), table);
+        }
+        top += section.height();
+    }
+}
+
+/// The table of a `section`, with `skipped` of its rows taken off the top. Its
+/// title is the first of those rows.
+fn create_table<'a>(section: &Section<'a>, key_width: u16, skipped: u16) -> Table<'a> {
+    let rows: Vec<Row> = section
+        .items
+        .iter()
+        .skip(skipped.saturating_sub(1) as usize)
+        .map(|(key, description)| Row::new([description.clone(), key.clone()]))
+        .collect();
+    let widths = [Constraint::Fill(1), Constraint::Length(key_width)];
+    let table = Table::new(rows, widths).column_spacing(COLUMN_SPACING);
+
+    if skipped > 0 {
+        return table;
+    }
+
+    table.block(
+        Block::new()
+            .title(Span::from(section.title).bold().underlined())
+            .title_alignment(Alignment::Center),
+    )
 }
 
 /// Where a part of the popup's contents that is `height` rows tall and starts
@@ -93,34 +195,6 @@ impl HelpPopup {
         }
     }
 
-    /// A table of `items` under its `title`, with `skipped` of its rows taken
-    /// off the top. The title is the first of those rows.
-    fn create_table(
-        &self,
-        items: &[(String, String)],
-        title: &'static str,
-        key_width: u16,
-        skipped: u16,
-    ) -> Table<'_> {
-        let rows: Vec<Row> = items
-            .iter()
-            .skip(skipped.saturating_sub(1) as usize)
-            .map(|(key, description)| Row::new([description.clone(), key.clone()]))
-            .collect();
-        let widths = [Constraint::Fill(1), Constraint::Length(key_width)];
-        let table = Table::new(rows, widths).column_spacing(COLUMN_SPACING);
-
-        if skipped > 0 {
-            return table;
-        }
-
-        table.block(
-            Block::new()
-                .title(Span::from(title).bold().underlined())
-                .title_alignment(Alignment::Center),
-        )
-    }
-
     fn do_scroll(&mut self, delta: i32) {
         let max = i32::from(self.max_scroll);
         self.scroll = (i32::from(self.scroll) + delta).clamp(0, max) as u16;
@@ -133,25 +207,34 @@ impl Component for HelpPopup {
         f: &mut ratatui::prelude::Frame<'_>,
         area: ratatui::prelude::Rect,
     ) -> anyhow::Result<()> {
-        let left_key_width = key_width(&self.main_items);
-        let left_width = left_key_width + COLUMN_SPACING + description_width(&self.main_items);
-
-        // The stacked tables share a key column so that their rows line up
-        let right_key_width = key_width(&self.details_items).max(key_width(&self.global_items));
-        let right_width = right_key_width
-            + COLUMN_SPACING
-            + description_width(&self.details_items).max(description_width(&self.global_items));
-
-        // Each table takes a line for its title, the right half one for its rule
-        let left_height = self.main_items.len() as u16 + 1;
-        let right_height = self.details_items.len() as u16 + self.global_items.len() as u16 + 3;
-
         let block = create_popup_block("Help");
         let [extra_width, extra_height] = chrome(&block, area);
-        // The two halves and the separator between them
-        let contents_width = left_width + SEPARATOR_WIDTH + right_width;
-        let width = (contents_width + extra_width).min(area.width);
-        let height = (left_height.max(right_height) + extra_height).min(area.height);
+
+        let columns = columns(
+            [
+                Section {
+                    title: "Main panel",
+                    items: &self.main_items,
+                },
+                Section {
+                    title: "Details panel",
+                    items: &self.details_items,
+                },
+                Section {
+                    title: "Global",
+                    items: &self.global_items,
+                },
+            ],
+            area.width.saturating_sub(extra_width),
+        );
+
+        let contents_height = columns
+            .iter()
+            .map(|column| stack_height(column))
+            .max()
+            .unwrap_or(0);
+        let width = (contents_width(&columns) + extra_width).min(area.width);
+        let height = (contents_height + extra_height).min(area.height);
 
         let area = centered_rect_fixed(area, width, height);
         f.render_widget(Clear, area);
@@ -159,57 +242,39 @@ impl Component for HelpPopup {
         let block_inner = block.inner(area);
         f.render_widget(&block, area);
 
-        let chunks = Layout::default()
-            .direction(Direction::Horizontal)
-            .constraints([
-                Constraint::Length(left_width),
-                Constraint::Length(SEPARATOR_WIDTH),
-                Constraint::Length(right_width),
-            ])
-            .split(block_inner);
-
-        self.max_scroll = left_height
-            .max(right_height)
-            .saturating_sub(block_inner.height);
+        self.max_scroll = contents_height.saturating_sub(block_inner.height);
         self.scroll = self.scroll.min(self.max_scroll);
 
-        f.render_widget(
-            Block::new().borders(Borders::LEFT),
-            Rect {
-                x: chunks[1].x + chunks[1].width / 2,
-                ..chunks[1]
-            },
-        );
+        // A separator goes in front of every column but the first
+        let constraints: Vec<Constraint> = columns
+            .iter()
+            .enumerate()
+            .flat_map(|(index, column)| {
+                let separator = (index > 0).then_some(Constraint::Length(SEPARATOR_WIDTH));
+                separator
+                    .into_iter()
+                    .chain([Constraint::Length(stack_width(column).1)])
+            })
+            .collect();
+        let chunks = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints(constraints)
+            .split(block_inner);
 
-        if let Some((area, skipped)) = place(chunks[0], self.scroll, 0, left_height) {
-            let table = self.create_table(&self.main_items, "Main panel", left_key_width, skipped);
-            f.render_widget(table, area);
-        }
+        for (index, column) in columns.iter().enumerate() {
+            let area = chunks[2 * index];
+            if index > 0 {
+                let separator = chunks[2 * index - 1];
+                f.render_widget(
+                    Block::new().borders(Borders::LEFT),
+                    Rect {
+                        x: separator.x + separator.width / 2,
+                        ..separator
+                    },
+                );
+            }
 
-        // Both halves scroll as one, so the right one lays its two tables and
-        // the rule between them out at their full height and lets the scroll
-        // take them out of view.
-        let details_height = self.details_items.len() as u16 + 1;
-        if let Some((area, skipped)) = place(chunks[2], self.scroll, 0, details_height) {
-            let table = self.create_table(
-                &self.details_items,
-                "Details panel",
-                right_key_width,
-                skipped,
-            );
-            f.render_widget(table, area);
-        }
-        if let Some((area, _)) = place(chunks[2], self.scroll, details_height, 1) {
-            f.render_widget(Block::new().borders(Borders::TOP), area);
-        }
-        if let Some((area, skipped)) = place(
-            chunks[2],
-            self.scroll,
-            details_height + 1,
-            self.global_items.len() as u16 + 1,
-        ) {
-            let table = self.create_table(&self.global_items, "Global", right_key_width, skipped);
-            f.render_widget(table, area);
+            render_stack(f, area, self.scroll, column);
         }
 
         Ok(())
@@ -258,6 +323,11 @@ mod tests {
         Rect::new(0, y, 40, height)
     }
 
+    /// A section whose rows are `key_width` and `description_width` wide
+    fn section(items: usize, key_width: usize, description_width: usize) -> Vec<(String, String)> {
+        vec![("k".repeat(key_width), "d".repeat(description_width)); items]
+    }
+
     fn wheel(kind: MouseEventKind) -> Event {
         Event::Mouse(MouseEvent {
             kind,
@@ -265,6 +335,41 @@ mod tests {
             row: 0,
             modifiers: KeyModifiers::empty(),
         })
+    }
+
+    #[test]
+    fn test_the_halves_go_side_by_side_only_while_they_fit() {
+        let main = section(2, 1, 10);
+        let details = section(2, 2, 8);
+        let global = section(3, 2, 6);
+        let sections = [
+            Section {
+                title: "Main panel",
+                items: &main,
+            },
+            Section {
+                title: "Details panel",
+                items: &details,
+            },
+            Section {
+                title: "Global",
+                items: &global,
+            },
+        ];
+
+        // The main panel bindings need 15 columns, the other two 14 together
+        let halves = columns(sections, 32);
+        assert_eq!(halves.len(), 2);
+        assert_eq!(contents_width(&halves), 32);
+
+        // A column short of that, everything stacks up in a single column,
+        // which only has to hold the widest keys next to the widest
+        // description.
+        let stacked = columns(sections, 31);
+        assert_eq!(stacked.len(), 1);
+        assert_eq!(contents_width(&stacked), 16);
+        // Every section spends a row on its title, with a rule between them
+        assert_eq!(stack_height(&stacked[0]), 12);
     }
 
     #[test]

--- a/src/ui/dialog/help.rs
+++ b/src/ui/dialog/help.rs
@@ -38,6 +38,17 @@ fn description_width(items: &[(String, String)]) -> u16 {
         .unwrap_or(0) as u16
 }
 
+/// How much wider and taller than its contents a `block` is, in the `area` it
+/// has to draw itself in. Its border is not all of it, it also pads.
+fn chrome(block: &Block, area: Rect) -> [u16; 2] {
+    let inner = block.inner(area);
+
+    [
+        area.width.saturating_sub(inner.width),
+        area.height.saturating_sub(inner.height),
+    ]
+}
+
 /// Where a part of the popup's contents that is `height` rows tall and starts
 /// at row `top` of them lands in `viewport`, and how many of its rows `scroll`
 /// has taken off the top. `None` once it has scrolled out of view entirely.
@@ -131,17 +142,20 @@ impl Component for HelpPopup {
             + COLUMN_SPACING
             + description_width(&self.details_items).max(description_width(&self.global_items));
 
-        // The two halves and the separator between them, plus the block border
-        let width = (left_width + SEPARATOR_WIDTH + right_width + 2).min(area.width);
         // Each table takes a line for its title, the right half one for its rule
         let left_height = self.main_items.len() as u16 + 1;
         let right_height = self.details_items.len() as u16 + self.global_items.len() as u16 + 3;
-        let height = (left_height.max(right_height) + 2).min(area.height);
+
+        let block = create_popup_block("Help");
+        let [extra_width, extra_height] = chrome(&block, area);
+        // The two halves and the separator between them
+        let contents_width = left_width + SEPARATOR_WIDTH + right_width;
+        let width = (contents_width + extra_width).min(area.width);
+        let height = (left_height.max(right_height) + extra_height).min(area.height);
 
         let area = centered_rect_fixed(area, width, height);
         f.render_widget(Clear, area);
 
-        let block = create_popup_block("Help");
         let block_inner = block.inner(area);
         f.render_widget(&block, area);
 


### PR DESCRIPTION
The help popup does not hold up when it does not fit: each of its three
keybinding lists scrolls inside a box of its own, so a scroll reads as
three lists moving past each other rather than as one popup, and on a
narrow terminal the main panel half is squeezed down to a description
column a character or two wide while the other half stays readable. Lay
the contents out as columns of stacked sections and scroll them as one,
and drop to a single column below the width the two halves need.

Sizing the popup also never accounted for the padding its block adds
next to the border, cutting two characters off the longest description
at any width, so ask the block what it takes instead of counting it.