### PR TITLE
ui/utils: Extract the message shown while a panel waits

### DIFF
--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -57,6 +57,7 @@ use crate::ui::utils::PaneDivider;
 use crate::ui::utils::Timer;
 use crate::ui::utils::centered_rect_line_height;
 use crate::ui::utils::tabs_to_spaces;
+use crate::ui::utils::waiting_message;
 
 const NEW_POPUP_ID: u16 = 1;
 const EDIT_POPUP_ID: u16 = 2;
@@ -913,18 +914,13 @@ impl Component for LogTab<'_> {
                 .title(format!(" Details for {} ", key.id.change_id))
                 .draw(f, chunks[1]);
             self.shown_key = Some(key);
-        } else if let Some(pjj) = &self.pending_jj_show {
-            let duration = pjj.timer.elapsed();
-            let message = if duration < LOADING_GRACE {
-                "".to_string()
-            } else {
-                let mut sec = duration.as_secs();
-                let min = sec / 60;
-                sec %= 60;
-                format!("Waiting for 'jj show' .. {:02}:{:02}", min, sec)
-            };
+        } else if let Some(pjs) = &self.pending_jj_show {
             self.head_panel
-                .render_context::<TextContent>(message)
+                .render_context::<TextContent>(waiting_message(
+                    Some(pjs.timer.elapsed()),
+                    "jj show",
+                    LOADING_GRACE,
+                ))
                 .title(format!(" Details for {} ", self.head.change_id))
                 .draw(f, chunks[1])
         }

--- a/src/ui/utils.rs
+++ b/src/ui/utils.rs
@@ -1,4 +1,7 @@
 mod large_string;
+
+use std::time::Duration;
+
 pub use large_string::LargeString;
 mod timer;
 use ratatui::crossterm::event::MouseButton;
@@ -174,6 +177,25 @@ pub fn centered_rect_fixed(area: Rect, width: u16, height: u16) -> Rect {
     }
 }
 
+/// What a panel shows instead of its content while `command` is still
+/// running, given how long the wait has been going on. A wait shorter
+/// than `grace` stays blank, since a message that flashes by is only
+/// noise.
+pub fn waiting_message(waited: Option<Duration>, command: &str, grace: Duration) -> String {
+    let Some(waited) = waited else {
+        return String::new();
+    };
+    if waited < grace {
+        return String::new();
+    }
+    let seconds = waited.as_secs();
+    format!(
+        "Waiting for '{command}' .. {:02}:{:02}",
+        seconds / 60,
+        seconds % 60
+    )
+}
+
 /// replaces tabs in a string by spaces
 ///
 /// ratatui doesn't work well displaying tabs, so any
@@ -235,4 +257,33 @@ pub fn tabs_to_spaces(line: &str) -> String {
         }
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GRACE: Duration = Duration::from_secs(1);
+
+    #[test]
+    fn nothing_is_waited_for() {
+        assert_eq!(waiting_message(None, "jj show", GRACE), "");
+    }
+
+    #[test]
+    fn a_short_wait_stays_blank() {
+        assert_eq!(waiting_message(Some(Duration::ZERO), "jj show", GRACE), "");
+    }
+
+    #[test]
+    fn a_long_wait_names_the_command_and_its_runtime() {
+        assert_eq!(
+            waiting_message(Some(Duration::from_secs(1)), "jj show", GRACE),
+            "Waiting for 'jj show' .. 00:01"
+        );
+        assert_eq!(
+            waiting_message(Some(Duration::from_secs(62)), "jj diff", GRACE),
+            "Waiting for 'jj diff' .. 01:02"
+        );
+    }
 }


### PR DESCRIPTION
The details panel formats its own "Waiting for 'jj show'" message inside `draw()`, where the grace period before it appears, the minutes and seconds, and the panel it goes into are all one block. Pulling the formatting out gives it tests and leaves `draw()` with the choice of what to render, and the details panel is not going to be the only panel that has to say it is waiting for something.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
