### PR TITLE
ui/panel: Extract ListPane for the files and bookmarks lists

### DIFF
--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -33,6 +33,7 @@ use crate::ui::dialog::BookmarkNamePopup;
 use crate::ui::dialog::DescribePopup;
 use crate::ui::dialog::MessagePopup;
 use crate::ui::panel::DetailsPanel;
+use crate::ui::panel::ListPane;
 use crate::ui::panel::TextContent;
 use crate::ui::utils::PaneDivider;
 use crate::ui::utils::tabs_to_spaces;
@@ -53,8 +54,8 @@ const EDIT_POPUP_ID: u16 = 4;
 /// Bookmarks tab. Shows bookmarks in main panel and selected bookmark current change in details panel.
 pub struct BookmarksTab {
     bookmarks_output: Result<Vec<BookmarkLine>, CommandError>,
+    bookmarks_pane: ListPane,
     bookmarks_list_state: ListState,
-    bookmarks_height: u16,
 
     show_all: bool,
 
@@ -132,8 +133,8 @@ impl BookmarksTab {
         Self {
             bookmarks_output: Ok(Vec::new()),
             bookmark: None,
+            bookmarks_pane: ListPane::default(),
             bookmarks_list_state: ListState::default(),
-            bookmarks_height: 0,
 
             show_all: false,
 
@@ -239,7 +240,7 @@ impl Tab for BookmarksTab {
     }
 
     fn scroll_main_panel(&mut self, scroll: Scroll) -> Result<()> {
-        let half_page = self.bookmarks_height as isize / 2;
+        let half_page = self.bookmarks_pane.visible_items() / 2;
         self.scroll_bookmarks(match scroll {
             Scroll::Down => 1,
             Scroll::Up => -1,
@@ -410,32 +411,18 @@ impl Component for BookmarksTab {
                 bookmark_lines
             };
 
-            let bookmarks_block = Block::bordered()
+            let block = Block::bordered()
                 .title(" Bookmarks ")
                 .border_type(BorderType::Rounded);
-            self.bookmarks_height = bookmarks_block.inner(chunks[0]).height;
-            let bookmark_count = lines.len();
-            let bookmarks = List::new(lines).block(bookmarks_block).scroll_padding(3);
+            let bookmarks = List::new(lines).scroll_padding(3);
             *self.bookmarks_list_state.selected_mut() = current_bookmark_index;
-            f.render_stateful_widget(bookmarks, chunks[0], &mut self.bookmarks_list_state);
-
-            // Draw scrollbar on left panel
-            if bookmark_count > self.bookmarks_height.into() {
-                let index = current_bookmark_index.unwrap_or(0);
-                let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight);
-                let mut scrollbar_state = ScrollbarState::default()
-                    .content_length(bookmark_count)
-                    .position(index);
-
-                f.render_stateful_widget(
-                    scrollbar,
-                    chunks[0].inner(Margin {
-                        vertical: 1,
-                        horizontal: 0,
-                    }),
-                    &mut scrollbar_state,
-                );
-            }
+            self.bookmarks_pane.render(
+                f,
+                chunks[0],
+                block,
+                bookmarks,
+                &mut self.bookmarks_list_state,
+            );
         }
 
         // Draw bookmark

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -27,6 +27,7 @@ use crate::ui::Scroll;
 use crate::ui::Tab;
 use crate::ui::dialog::MessagePopup;
 use crate::ui::panel::DetailsPanel;
+use crate::ui::panel::ListPane;
 use crate::ui::panel::TextContent;
 use crate::ui::utils::PaneDivider;
 use crate::ui::utils::tabs_to_spaces;
@@ -38,8 +39,8 @@ pub struct FilesTab {
 
     files_output: Result<Vec<File>, CommandError>,
     conflicts_output: Vec<Conflict>,
+    files_pane: ListPane,
     files_list_state: ListState,
-    files_height: u16,
 
     pub file: Option<File>,
     diff_panel: DetailsPanel,
@@ -84,8 +85,8 @@ impl FilesTab {
 
             files_output: Ok(Vec::new()),
             file: None,
+            files_pane: ListPane::default(),
             files_list_state: ListState::default(),
-            files_height: 0,
 
             conflicts_output: Vec::new(),
 
@@ -220,7 +221,7 @@ impl Tab for FilesTab {
     }
 
     fn scroll_main_panel(&mut self, scroll: Scroll) -> Result<()> {
-        let half_page = self.files_height as isize / 2;
+        let half_page = self.files_pane.visible_items() / 2;
         self.scroll_files(match scroll {
             Scroll::Down => 1,
             Scroll::Up => -1,
@@ -323,34 +324,13 @@ impl Component for FilesTab {
                 }
             }
 
-            let files = List::new(lines)
-                .block(
-                    Block::bordered()
-                        .title(" Files for ".to_owned() + &title_change + " ")
-                        .border_type(BorderType::Rounded),
-                )
-                .scroll_padding(3);
+            let block = Block::bordered()
+                .title(" Files for ".to_owned() + &title_change + " ")
+                .border_type(BorderType::Rounded);
+            let files = List::new(lines).scroll_padding(3);
             *self.files_list_state.selected_mut() = current_file_index;
-            f.render_stateful_widget(&files, chunks[0], &mut self.files_list_state);
-            self.files_height = chunks[0].height - 2;
-
-            if let Some(index) = current_file_index
-                && files.len() > self.files_height as usize
-            {
-                let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight);
-                let mut scrollbar_state = ScrollbarState::default()
-                    .content_length(files.len())
-                    .position(index);
-
-                f.render_stateful_widget(
-                    scrollbar,
-                    chunks[0].inner(Margin {
-                        vertical: 1,
-                        horizontal: 0,
-                    }),
-                    &mut scrollbar_state,
-                );
-            }
+            self.files_pane
+                .render(f, chunks[0], block, files, &mut self.files_list_state);
         }
 
         // Draw diff

--- a/src/ui/panel/list_pane.rs
+++ b/src/ui/panel/list_pane.rs
@@ -1,0 +1,59 @@
+use ratatui::Frame;
+use ratatui::layout::Margin;
+use ratatui::layout::Rect;
+use ratatui::widgets::Block;
+use ratatui::widgets::List;
+use ratatui::widgets::ListState;
+use ratatui::widgets::Scrollbar;
+use ratatui::widgets::ScrollbarOrientation;
+use ratatui::widgets::ScrollbarState;
+
+/// The list a tab shows in its main panel, with a scrollbar.
+///
+/// The list itself is built by the caller, which also owns the
+/// [`ListState`] so that scroll offset and selection have a single source
+/// of truth. Every list drawn through a pane gives each item a single row,
+/// which is what lets row and item counts be used interchangeably.
+#[derive(Default)]
+pub struct ListPane {
+    /// Area the items were drawn in, borders excluded.
+    content_rect: Rect,
+
+    /// Number of items the list held when it was drawn.
+    item_count: usize,
+}
+
+impl ListPane {
+    /// Number of items that fit on screen, as a scroll delta.
+    pub fn visible_items(&self) -> isize {
+        self.content_rect.height as isize
+    }
+
+    /// Draw `widget` inside `block`, plus a scrollbar if the items do not
+    /// all fit.
+    pub fn render<'a>(
+        &mut self,
+        f: &mut Frame,
+        area: Rect,
+        block: Block<'a>,
+        widget: List<'a>,
+        list_state: &mut ListState,
+    ) {
+        self.content_rect = block.inner(area);
+        self.item_count = widget.len();
+        f.render_stateful_widget(&widget.block(block), area, list_state);
+        if self.item_count > self.content_rect.height as usize {
+            let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight);
+            let mut scrollbar_state = ScrollbarState::default()
+                .content_length(self.item_count)
+                .position(list_state.selected().unwrap_or(0));
+            // The scrollbar is drawn onto the right border, so it gets the
+            // full width and only skips the corners.
+            let scrollbar_rect = area.inner(Margin {
+                vertical: 1,
+                horizontal: 0,
+            });
+            f.render_stateful_widget(scrollbar, scrollbar_rect, &mut scrollbar_state);
+        }
+    }
+}

--- a/src/ui/panel/mod.rs
+++ b/src/ui/panel/mod.rs
@@ -1,7 +1,9 @@
 mod details_panel;
+mod list_pane;
 mod log_panel;
 
 pub use details_panel::DetailsPanel;
 pub use details_panel::LargeStringContent;
 pub use details_panel::TextContent;
+pub use list_pane::ListPane;
 pub use log_panel::LogPanel;


### PR DESCRIPTION
The files and bookmarks tabs each open-code the same main-panel list: a bordered block, the list rendered into it, and a scrollbar next to it once the items no longer fit. Both also keep the drawn height in a field of their own to size a half-page scroll, and compute it differently, one from the block's inner area and the other by subtracting the border rows. ListPane takes over that geometry and the rendering while the caller keeps building the list and owning the ListState, so scroll offset and selection stay in one place. The files tab now also gets a scrollbar when nothing is selected, which it previously skipped.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
