### PR TITLE
ui: Drop the log tab's dead call to LogPanel::input()

### DIFF
--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -1025,12 +1025,6 @@ impl Component for LogTab<'_> {
                 }
             }
 
-            let input_result = self.log_panel.input(event)?;
-            if input_result.is_handled() {
-                self.sync_head_output();
-                return Ok(input_result);
-            }
-
             let log_tab_event = self.keybinds.match_event(key);
             return self.handle_event(log_tab_event);
         }


### PR DESCRIPTION
LogPanel::input() only looks at Event::Mouse, but the log tab also calls it from the branch that has already matched a key press, where it can only ever answer NotHandled, so the sync_head_output() behind it never runs.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
