### PR TITLE
ui/panel: Report mouse events instead of acting on them

### DIFF
--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -34,7 +34,9 @@ use crate::ui::dialog::DescribePopup;
 use crate::ui::dialog::MessagePopup;
 use crate::ui::panel::DetailsPanel;
 use crate::ui::panel::ListPane;
+use crate::ui::panel::MouseInput;
 use crate::ui::panel::TextContent;
+use crate::ui::panel::route_mouse;
 use crate::ui::utils::PaneDivider;
 use crate::ui::utils::tabs_to_spaces;
 
@@ -640,10 +642,12 @@ impl Component for BookmarksTab {
             if self.pane_divider.handle_mouse(mouse, self.config.layout()) {
                 return Ok(ComponentInputResult::Handled);
             }
-            if self.bookmark_panel.input_mouse(mouse) {
-                return Ok(ComponentInputResult::Handled);
+            match route_mouse(mouse, &mut [&mut self.bookmark_panel]) {
+                MouseInput::Scroll(delta) => self.scroll_bookmarks(delta),
+                MouseInput::Handled => {}
+                MouseInput::NotHandled => return Ok(ComponentInputResult::NotHandled),
             }
-            return Ok(ComponentInputResult::NotHandled);
+            return Ok(ComponentInputResult::Handled);
         }
 
         Ok(ComponentInputResult::Handled)

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -28,7 +28,9 @@ use crate::ui::Tab;
 use crate::ui::dialog::MessagePopup;
 use crate::ui::panel::DetailsPanel;
 use crate::ui::panel::ListPane;
+use crate::ui::panel::MouseInput;
 use crate::ui::panel::TextContent;
+use crate::ui::panel::route_mouse;
 use crate::ui::utils::PaneDivider;
 use crate::ui::utils::tabs_to_spaces;
 
@@ -399,10 +401,12 @@ impl Component for FilesTab {
             if self.pane_divider.handle_mouse(mouse, self.config.layout()) {
                 return Ok(ComponentInputResult::Handled);
             }
-            if self.diff_panel.input_mouse(mouse) {
-                return Ok(ComponentInputResult::Handled);
+            match route_mouse(mouse, &mut [&mut self.diff_panel]) {
+                MouseInput::Scroll(delta) => self.scroll_files(delta)?,
+                MouseInput::Handled => {}
+                MouseInput::NotHandled => return Ok(ComponentInputResult::NotHandled),
             }
-            return Ok(ComponentInputResult::NotHandled);
+            return Ok(ComponentInputResult::Handled);
         }
 
         Ok(ComponentInputResult::Handled)

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -52,7 +52,9 @@ use crate::ui::dialog::RebasePopup;
 use crate::ui::panel::DetailsPanel;
 use crate::ui::panel::LargeStringContent;
 use crate::ui::panel::LogPanel;
+use crate::ui::panel::MouseInput;
 use crate::ui::panel::TextContent;
+use crate::ui::panel::route_mouse;
 use crate::ui::utils::PaneDivider;
 use crate::ui::utils::Timer;
 use crate::ui::utils::centered_rect_line_height;
@@ -1036,15 +1038,16 @@ impl Component for LogTab<'_> {
             {
                 return Ok(ComponentInputResult::Handled);
             }
-            let input_result = self.log_panel.input(event.clone())?;
-            if input_result.is_handled() {
-                self.sync_head_output();
-                return Ok(input_result);
+            match route_mouse(
+                mouse_event,
+                &mut [&mut self.log_panel, &mut self.head_panel],
+            ) {
+                MouseInput::Scroll(delta) => self.log_panel.scroll_relative(delta),
+                MouseInput::Handled => {}
+                MouseInput::NotHandled => return Ok(ComponentInputResult::NotHandled),
             }
-            if self.head_panel.input_mouse(mouse_event) {
-                return Ok(ComponentInputResult::Handled);
-            }
-            return Ok(ComponentInputResult::NotHandled);
+            self.sync_head_output();
+            return Ok(ComponentInputResult::Handled);
         }
 
         Ok(ComponentInputResult::Handled)

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -41,16 +41,6 @@ pub enum ComponentInputResult {
     NotHandled,
 }
 
-impl ComponentInputResult {
-    pub fn is_handled(&self) -> bool {
-        match self {
-            Self::Handled => true,
-            Self::HandledAction(_) => true,
-            Self::NotHandled => false,
-        }
-    }
-}
-
 /// How far to move the selection in a tab's main panel.
 #[derive(Debug, Clone, Copy)]
 pub enum Scroll {
@@ -67,7 +57,9 @@ pub trait Component {
 
     fn draw(&mut self, f: &mut Frame<'_>, area: Rect) -> Result<()>;
 
-    fn input(&mut self, event: Event) -> Result<ComponentInputResult>;
+    fn input(&mut self, _event: Event) -> Result<ComponentInputResult> {
+        Ok(ComponentInputResult::NotHandled)
+    }
 }
 
 /// A top-level tab, showing what it reads from the repo.

--- a/src/ui/panel/details_panel.rs
+++ b/src/ui/panel/details_panel.rs
@@ -29,6 +29,8 @@ use ratatui::widgets::ScrollbarState;
 use ratatui::widgets::Wrap;
 use tracing::trace;
 
+use super::MouseInput;
+use super::PanelMouseInput;
 use crate::keybinds::DetailsPanelEvent;
 use crate::ui::utils::LargeString;
 
@@ -253,15 +255,16 @@ impl DetailsPanel {
             DetailsPanelEvent::ToggleDiffFormat | DetailsPanelEvent::Unbound => {}
         }
     }
+}
 
-    /// Handle input. Returns bool of if event was handled
-    pub fn input_mouse(&mut self, mouse: MouseEvent) -> bool {
-        if !self.panel_rect.contains(Position {
-            y: mouse.row,
-            x: mouse.column,
-        }) {
+impl PanelMouseInput for DetailsPanel {
+    fn input_mouse(&mut self, mouse: MouseEvent) -> MouseInput {
+        if !self
+            .panel_rect
+            .contains(Position::new(mouse.column, mouse.row))
+        {
             trace!("mouse {:?} not in rect {:?}", &mouse, &self.panel_rect);
-            return false;
+            return MouseInput::NotHandled;
         }
         trace!("mouse {:?} inside  rect {:?}", &mouse, &self.panel_rect);
         match mouse.kind {
@@ -275,9 +278,9 @@ impl DetailsPanel {
                 self.handle_event(DetailsPanelEvent::ScrollDown);
                 self.handle_event(DetailsPanelEvent::ScrollDown);
             }
-            _ => return false,
+            _ => return MouseInput::NotHandled,
         }
-        true
+        MouseInput::Handled
     }
 }
 

--- a/src/ui/panel/log_panel.rs
+++ b/src/ui/panel/log_panel.rs
@@ -5,7 +5,6 @@ use std::collections::HashSet;
 
 use ansi_to_tui::IntoText;
 use anyhow::Result;
-use ratatui::crossterm::event::Event;
 use ratatui::crossterm::event::MouseEvent;
 use ratatui::crossterm::event::MouseEventKind;
 use ratatui::layout::Rect;
@@ -13,6 +12,8 @@ use ratatui::prelude::*;
 use ratatui::text::ToText;
 use ratatui::widgets::*;
 
+use super::MouseInput;
+use super::PanelMouseInput;
 use crate::commander::CommandError;
 use crate::commander::ids::CommitId;
 use crate::commander::log::Head;
@@ -224,7 +225,7 @@ impl<'a> LogPanel<'a> {
     }
 
     /// Find head of the provided log_output line
-    fn head_at_log_line(&mut self, log_line: usize) -> Option<Head> {
+    fn head_at_log_line(&self, log_line: usize) -> Option<Head> {
         self.log_output.as_ref().ok()?.head_at(log_line).cloned()
     }
 
@@ -369,52 +370,44 @@ impl Component for LogPanel<'_> {
 
         Ok(())
     }
+}
 
-    fn input(&mut self, event: Event) -> Result<ComponentInputResult> {
-        if let Event::Mouse(mouse_event) = event {
-            // Determine if mouse event is inside log-view
-            let mouse_pos = Position::new(mouse_event.column, mouse_event.row);
-            if !self.panel_rect.contains(mouse_pos) {
-                return Ok(ComponentInputResult::NotHandled);
-            }
-
-            // Execute command dependent on panel and event kind
-            match mouse_event.kind {
-                MouseEventKind::ScrollUp => {
-                    self.scroll_relative(-1);
-                    return Ok(ComponentInputResult::Handled);
-                }
-                MouseEventKind::ScrollDown => {
-                    self.scroll_relative(1);
-                    return Ok(ComponentInputResult::Handled);
-                }
-                MouseEventKind::Up(_) => {
-                    // Check all items in list
-
-                    // TODO make a function that constructs the log list
-                    let log_lines = self.log_lines();
-                    let log_items: Vec<ListItem> = log_lines
-                        .iter()
-                        .map(|line| ListItem::from(line.to_text()))
-                        .collect();
-
-                    // Select the clicked change
-                    if let Some(inx) = list_item_from_mouse_event(
-                        &log_items,
-                        self.log_rect,
-                        &self.log_list_state,
-                        &mouse_event,
-                    ) && let Some(head) = self.head_at_log_line(inx)
-                    {
-                        self.set_head(head);
-                        return Ok(ComponentInputResult::Handled);
-                    }
-                }
-                _ => {} // Handle other mouse events if necessary
-            }
+impl PanelMouseInput for LogPanel<'_> {
+    fn input_mouse(&mut self, mouse: MouseEvent) -> MouseInput {
+        if !self
+            .panel_rect
+            .contains(Position::new(mouse.column, mouse.row))
+        {
+            return MouseInput::NotHandled;
         }
+        match mouse.kind {
+            MouseEventKind::ScrollUp => MouseInput::Scroll(-1),
+            MouseEventKind::ScrollDown => MouseInput::Scroll(1),
+            MouseEventKind::Up(_) => {
+                // Check all items in list
 
-        Ok(ComponentInputResult::NotHandled)
+                // TODO make a function that constructs the log list
+                let log_lines = self.log_lines();
+                let log_items: Vec<ListItem> = log_lines
+                    .iter()
+                    .map(|line| ListItem::from(line.to_text()))
+                    .collect();
+
+                // Select the clicked change
+                if let Some(inx) = list_item_from_mouse_event(
+                    &log_items,
+                    self.log_rect,
+                    &self.log_list_state,
+                    &mouse,
+                ) && let Some(head) = self.head_at_log_line(inx)
+                {
+                    self.set_head(head);
+                    return MouseInput::Handled;
+                }
+                MouseInput::NotHandled
+            }
+            _ => MouseInput::NotHandled,
+        }
     }
 }
 

--- a/src/ui/panel/mod.rs
+++ b/src/ui/panel/mod.rs
@@ -7,3 +7,32 @@ pub use details_panel::LargeStringContent;
 pub use details_panel::TextContent;
 pub use list_pane::ListPane;
 pub use log_panel::LogPanel;
+use ratatui::crossterm::event::MouseEvent;
+
+/// What a panel did with a mouse event.
+pub(crate) enum MouseInput {
+    NotHandled,
+    Handled,
+    /// The panel wants to be scrolled by this many items, negative
+    /// meaning towards the top.
+    Scroll(isize),
+}
+
+pub(crate) trait PanelMouseInput {
+    fn input_mouse(&mut self, mouse: MouseEvent) -> MouseInput;
+}
+
+/// Offer `mouse` to each panel in turn and report what the first one that
+/// takes it did with it.
+pub(crate) fn route_mouse(
+    mouse: MouseEvent,
+    panels: &mut [&mut dyn PanelMouseInput],
+) -> MouseInput {
+    for panel in panels {
+        match panel.input_mouse(mouse) {
+            MouseInput::NotHandled => {}
+            result => return result,
+        }
+    }
+    MouseInput::NotHandled
+}


### PR DESCRIPTION
Each tab pokes its panels one at a time, and the two panel kinds answer differently: the details panel returns a bool from an inherent input_mouse(), while the log panel implements Component::input() and scrolls itself. Neither shape lets a panel ask its tab to do something, which a list pane has to be able to do, since the tab owns the selection a list shows. MouseInput and PanelMouseInput give every panel one way to report what it did, and route_mouse() offers an event to the panels in the order the tab lists them. The log panel is left with only draw() out of Component, so that trait's input() gains a default, and nothing calls ComponentInputResult::is_handled() any more.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
