### PR TITLE
ui: Add mouse scrolling to the file and bookmark list panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Message popup now supports scrolling with a scrollbar
 - Command popup output now preserves ANSI color
 - Drag to resize pane divider in all tabs
+- Mouse scrolling in the file and bookmark list panes
 
 ### Changed
 

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -642,7 +642,10 @@ impl Component for BookmarksTab {
             if self.pane_divider.handle_mouse(mouse, self.config.layout()) {
                 return Ok(ComponentInputResult::Handled);
             }
-            match route_mouse(mouse, &mut [&mut self.bookmark_panel]) {
+            match route_mouse(
+                mouse,
+                &mut [&mut self.bookmarks_pane, &mut self.bookmark_panel],
+            ) {
                 MouseInput::Scroll(delta) => self.scroll_bookmarks(delta),
                 MouseInput::Handled => {}
                 MouseInput::NotHandled => return Ok(ComponentInputResult::NotHandled),

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -401,7 +401,7 @@ impl Component for FilesTab {
             if self.pane_divider.handle_mouse(mouse, self.config.layout()) {
                 return Ok(ComponentInputResult::Handled);
             }
-            match route_mouse(mouse, &mut [&mut self.diff_panel]) {
+            match route_mouse(mouse, &mut [&mut self.files_pane, &mut self.diff_panel]) {
                 MouseInput::Scroll(delta) => self.scroll_files(delta)?,
                 MouseInput::Handled => {}
                 MouseInput::NotHandled => return Ok(ComponentInputResult::NotHandled),

--- a/src/ui/panel/list_pane.rs
+++ b/src/ui/panel/list_pane.rs
@@ -1,5 +1,8 @@
 use ratatui::Frame;
+use ratatui::crossterm::event::MouseEvent;
+use ratatui::crossterm::event::MouseEventKind;
 use ratatui::layout::Margin;
+use ratatui::layout::Position;
 use ratatui::layout::Rect;
 use ratatui::widgets::Block;
 use ratatui::widgets::List;
@@ -8,7 +11,11 @@ use ratatui::widgets::Scrollbar;
 use ratatui::widgets::ScrollbarOrientation;
 use ratatui::widgets::ScrollbarState;
 
-/// The list a tab shows in its main panel, with a scrollbar.
+use super::MouseInput;
+use super::PanelMouseInput;
+
+/// The list a tab shows in its main panel, with a scrollbar and mouse
+/// handling.
 ///
 /// The list itself is built by the caller, which also owns the
 /// [`ListState`] so that scroll offset and selection have a single source
@@ -16,6 +23,9 @@ use ratatui::widgets::ScrollbarState;
 /// which is what lets row and item counts be used interchangeably.
 #[derive(Default)]
 pub struct ListPane {
+    /// Area the pane was drawn in, borders included.
+    panel_rect: Rect,
+
     /// Area the items were drawn in, borders excluded.
     content_rect: Rect,
 
@@ -30,7 +40,8 @@ impl ListPane {
     }
 
     /// Draw `widget` inside `block`, plus a scrollbar if the items do not
-    /// all fit.
+    /// all fit, and record the geometry that mouse input is resolved
+    /// against.
     pub fn render<'a>(
         &mut self,
         f: &mut Frame,
@@ -39,6 +50,7 @@ impl ListPane {
         widget: List<'a>,
         list_state: &mut ListState,
     ) {
+        self.panel_rect = area;
         self.content_rect = block.inner(area);
         self.item_count = widget.len();
         f.render_stateful_widget(&widget.block(block), area, list_state);
@@ -54,6 +66,22 @@ impl ListPane {
                 horizontal: 0,
             });
             f.render_stateful_widget(scrollbar, scrollbar_rect, &mut scrollbar_state);
+        }
+    }
+}
+
+impl PanelMouseInput for ListPane {
+    fn input_mouse(&mut self, mouse: MouseEvent) -> MouseInput {
+        if !self
+            .panel_rect
+            .contains(Position::new(mouse.column, mouse.row))
+        {
+            return MouseInput::NotHandled;
+        }
+        match mouse.kind {
+            MouseEventKind::ScrollDown => MouseInput::Scroll(1),
+            MouseEventKind::ScrollUp => MouseInput::Scroll(-1),
+            _ => MouseInput::NotHandled,
         }
     }
 }


### PR DESCRIPTION
Mouse scroll in the files and bookmarks tabs has no effect on the list pane; only the diff panel on the right responds. Now that the pane knows the area it was drawn in, it can claim the events landing there and ask its tab to move the selection, which keeps the tab owning the list the one that decides what scrolling means.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
