### PR TITLE
Add left-click selection to list panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Command popup output now preserves ANSI color
 - Drag to resize pane divider in all tabs
 - Mouse scrolling in the file and bookmark list panes
+- Left-click to select items in all list panes; log tab click now fires on press rather than release
 
 ### Changed
 

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -647,6 +647,13 @@ impl Component for BookmarksTab {
                 &mut [&mut self.bookmarks_pane, &mut self.bookmark_panel],
             ) {
                 MouseInput::Scroll(delta) => self.scroll_bookmarks(delta),
+                MouseInput::Select(index) => {
+                    let bookmarks = self.bookmarks_output.as_deref().unwrap_or_default();
+                    if let Some(bookmark) = bookmarks.get(index).cloned() {
+                        self.bookmark = Some(bookmark);
+                        self.refresh_bookmark();
+                    }
+                }
                 MouseInput::Handled => {}
                 MouseInput::NotHandled => return Ok(ComponentInputResult::NotHandled),
             }

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -403,6 +403,14 @@ impl Component for FilesTab {
             }
             match route_mouse(mouse, &mut [&mut self.files_pane, &mut self.diff_panel]) {
                 MouseInput::Scroll(delta) => self.scroll_files(delta)?,
+                MouseInput::Select(index) => {
+                    if let Ok(files) = self.files_output.as_ref()
+                        && let Some(file) = files.get(index).cloned()
+                    {
+                        self.file = Some(file);
+                        self.refresh_diff()?;
+                    }
+                }
                 MouseInput::Handled => {}
                 MouseInput::NotHandled => return Ok(ComponentInputResult::NotHandled),
             }

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -814,7 +814,7 @@ impl Tab for LogTab<'_> {
     }
 
     fn scroll_main_panel(&mut self, scroll: Scroll) -> Result<()> {
-        let half_page = self.log_panel.visible_heads() as isize / 2;
+        let half_page = self.log_panel.visible_heads() / 2;
         self.log_panel.scroll_relative(match scroll {
             Scroll::Down => 1,
             Scroll::Up => -1,
@@ -1043,6 +1043,11 @@ impl Component for LogTab<'_> {
                 &mut [&mut self.log_panel, &mut self.head_panel],
             ) {
                 MouseInput::Scroll(delta) => self.log_panel.scroll_relative(delta),
+                MouseInput::Select(index) => {
+                    if let Some(head) = self.log_panel.head_at_log_line(index) {
+                        self.log_panel.set_head(head);
+                    }
+                }
                 MouseInput::Handled => {}
                 MouseInput::NotHandled => return Ok(ComponentInputResult::NotHandled),
             }

--- a/src/ui/panel/list_pane.rs
+++ b/src/ui/panel/list_pane.rs
@@ -1,4 +1,5 @@
 use ratatui::Frame;
+use ratatui::crossterm::event::MouseButton;
 use ratatui::crossterm::event::MouseEvent;
 use ratatui::crossterm::event::MouseEventKind;
 use ratatui::layout::Margin;
@@ -31,6 +32,9 @@ pub struct ListPane {
 
     /// Number of items the list held when it was drawn.
     item_count: usize,
+
+    /// Index of the first item drawn, as chosen by the list itself.
+    offset: usize,
 }
 
 impl ListPane {
@@ -54,6 +58,9 @@ impl ListPane {
         self.content_rect = block.inner(area);
         self.item_count = widget.len();
         f.render_stateful_widget(&widget.block(block), area, list_state);
+        // The list picks the offset it needs to keep the selection on
+        // screen, so it is only known once it has been drawn.
+        self.offset = list_state.offset();
         if self.item_count > self.content_rect.height as usize {
             let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight);
             let mut scrollbar_state = ScrollbarState::default()
@@ -68,19 +75,31 @@ impl ListPane {
             f.render_stateful_widget(scrollbar, scrollbar_rect, &mut scrollbar_state);
         }
     }
+
+    /// Index of the item drawn at `pos`, if any.
+    fn item_at(&self, pos: Position) -> Option<usize> {
+        if !self.content_rect.contains(pos) {
+            return None;
+        }
+        let index = self.offset + (pos.y - self.content_rect.y) as usize;
+        (index < self.item_count).then_some(index)
+    }
 }
 
 impl PanelMouseInput for ListPane {
     fn input_mouse(&mut self, mouse: MouseEvent) -> MouseInput {
-        if !self
-            .panel_rect
-            .contains(Position::new(mouse.column, mouse.row))
-        {
+        let pos = Position::new(mouse.column, mouse.row);
+        if !self.panel_rect.contains(pos) {
             return MouseInput::NotHandled;
         }
         match mouse.kind {
             MouseEventKind::ScrollDown => MouseInput::Scroll(1),
             MouseEventKind::ScrollUp => MouseInput::Scroll(-1),
+            MouseEventKind::Down(MouseButton::Left) => match self.item_at(pos) {
+                Some(index) => MouseInput::Select(index),
+                // A click in the pane is ours even when it hits no item.
+                None => MouseInput::Handled,
+            },
             _ => MouseInput::NotHandled,
         }
     }

--- a/src/ui/panel/log_panel.rs
+++ b/src/ui/panel/log_panel.rs
@@ -6,12 +6,11 @@ use std::collections::HashSet;
 use ansi_to_tui::IntoText;
 use anyhow::Result;
 use ratatui::crossterm::event::MouseEvent;
-use ratatui::crossterm::event::MouseEventKind;
 use ratatui::layout::Rect;
 use ratatui::prelude::*;
-use ratatui::text::ToText;
 use ratatui::widgets::*;
 
+use super::ListPane;
 use super::MouseInput;
 use super::PanelMouseInput;
 use crate::commander::CommandError;
@@ -52,9 +51,6 @@ pub struct LogPanel<'a> {
     /// Scroll offset and cursor position
     log_list_state: ListState,
 
-    /// Area were log content was drawn. This excludes the border.
-    pub log_rect: Rect,
-
     /// The revision filter used for the log
     pub log_revset: Option<String>,
 
@@ -64,8 +60,7 @@ pub struct LogPanel<'a> {
     /// Currently marked commits
     pub marked_heads: HashSet<CommitId>,
 
-    /// Area where panel was drawn. This includes the border.
-    panel_rect: Rect,
+    list_pane: ListPane,
 
     /// Configuration of colours
     config: JjConfig,
@@ -118,14 +113,12 @@ impl<'a> LogPanel<'a> {
             log_output_text: Text::default(),
             log_output: Ok(LogOutput::default()),
             log_list_state: ListState::default(),
-            log_rect: Rect::ZERO,
-
             log_revset: new_commander().env.default_revset.clone(),
 
             head,
             marked_heads: HashSet::new(),
 
-            panel_rect: Rect::ZERO,
+            list_pane: ListPane::default(),
 
             config: get_env().jj_config.clone(),
         }
@@ -225,7 +218,7 @@ impl<'a> LogPanel<'a> {
     }
 
     /// Find head of the provided log_output line
-    fn head_at_log_line(&self, log_line: usize) -> Option<Head> {
+    pub fn head_at_log_line(&self, log_line: usize) -> Option<Head> {
         self.log_output.as_ref().ok()?.head_at(log_line).cloned()
     }
 
@@ -234,13 +227,13 @@ impl<'a> LogPanel<'a> {
         get_head_index(&self.head, &self.log_output)
     }
 
-    /// Number of log list items that fit on screen. Think of this as
-    /// in unit head-index. Moving the head-index this much causes a
-    /// full page scroll.
-    pub fn visible_heads(&self) -> u16 {
-        // Every item in the log list is 2 lines high, so divide screen rows
-        // by 2 to get the number of log items that fit in it.
-        self.log_rect.height / 2
+    /// Number of heads that fit on screen. Think of this as in unit
+    /// head-index. Moving the head-index this much causes a full page
+    /// scroll.
+    pub fn visible_heads(&self) -> isize {
+        // Every item in the log list is one line and every head spans two
+        // of them.
+        self.list_pane.visible_items() / 2
     }
 
     /// Move selection to a specific head. This may cause the next draw to
@@ -333,40 +326,19 @@ impl Component for LogPanel<'_> {
     }
 
     fn draw(&mut self, f: &mut Frame<'_>, area: Rect) -> Result<()> {
-        self.panel_rect = area;
-
         let title = match &self.log_revset {
             Some(log_revset) => &format!(" Log for: {log_revset} "),
             None => " Log ",
         };
 
         let log_lines = self.log_lines();
-        let log_length: usize = log_lines.len();
         let log_block = Block::bordered()
             .title(title)
             .border_type(BorderType::Rounded);
-        self.log_rect = log_block.inner(area);
         self.log_list_state.select(self.selected_log_line());
-        let log = List::new(log_lines).block(log_block).scroll_padding(7);
-        f.render_stateful_widget(log, area, &mut self.log_list_state);
-
-        // Show scrollbar if lines don't fit the screen height
-        if log_length > self.log_rect.height.into() {
-            let index = self.log_list_state.selected().unwrap_or(0);
-            let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight);
-            let mut scrollbar_state = ScrollbarState::default()
-                .content_length(log_length)
-                .position(index);
-
-            f.render_stateful_widget(
-                scrollbar,
-                area.inner(Margin {
-                    vertical: 1,
-                    horizontal: 0,
-                }),
-                &mut scrollbar_state,
-            );
-        }
+        let log = List::new(log_lines).scroll_padding(7);
+        self.list_pane
+            .render(f, area, log_block, log, &mut self.log_list_state);
 
         Ok(())
     }
@@ -374,61 +346,6 @@ impl Component for LogPanel<'_> {
 
 impl PanelMouseInput for LogPanel<'_> {
     fn input_mouse(&mut self, mouse: MouseEvent) -> MouseInput {
-        if !self
-            .panel_rect
-            .contains(Position::new(mouse.column, mouse.row))
-        {
-            return MouseInput::NotHandled;
-        }
-        match mouse.kind {
-            MouseEventKind::ScrollUp => MouseInput::Scroll(-1),
-            MouseEventKind::ScrollDown => MouseInput::Scroll(1),
-            MouseEventKind::Up(_) => {
-                // Check all items in list
-
-                // TODO make a function that constructs the log list
-                let log_lines = self.log_lines();
-                let log_items: Vec<ListItem> = log_lines
-                    .iter()
-                    .map(|line| ListItem::from(line.to_text()))
-                    .collect();
-
-                // Select the clicked change
-                if let Some(inx) = list_item_from_mouse_event(
-                    &log_items,
-                    self.log_rect,
-                    &self.log_list_state,
-                    &mouse,
-                ) && let Some(head) = self.head_at_log_line(inx)
-                {
-                    self.set_head(head);
-                    return MouseInput::Handled;
-                }
-                MouseInput::NotHandled
-            }
-            _ => MouseInput::NotHandled,
-        }
+        self.list_pane.input_mouse(mouse)
     }
-}
-
-// Determine which list item a mouse event is related to
-fn list_item_from_mouse_event(
-    list: &[ListItem],
-    list_rect: Rect,
-    list_state: &ListState,
-    mouse_event: &MouseEvent,
-) -> Option<usize> {
-    let mouse_pos = Position::new(mouse_event.column, mouse_event.row);
-    if !list_rect.contains(mouse_pos) {
-        return None;
-    }
-
-    // Assume that each item is exactly one line.
-    // This is not true in the general case, but it is in this module.
-    let mouse_offset = mouse_pos.y - list_rect.y;
-    let item_index = list_state.offset() + mouse_offset as usize;
-    if item_index >= list.len() {
-        return None;
-    }
-    Some(item_index)
 }

--- a/src/ui/panel/mod.rs
+++ b/src/ui/panel/mod.rs
@@ -16,6 +16,10 @@ pub(crate) enum MouseInput {
     /// The panel wants to be scrolled by this many items, negative
     /// meaning towards the top.
     Scroll(isize),
+    /// The item at this index was clicked. A panel has no knowledge of
+    /// what its items represent, so it is up to the caller to map the
+    /// index onto its own domain type.
+    Select(usize),
 }
 
 pub(crate) trait PanelMouseInput {


### PR DESCRIPTION
The files and bookmarks panes react to scrolling but ignore clicks, so selecting an item there needs the keyboard, while the log panel handles clicks with its own copy of the hit-testing.

A pane has no knowledge of what its items represent, so it reports a bare item index and leaves mapping that onto a domain type to the caller. Translating a click row into an index needs the scroll offset the list picked for itself, which is only known once it has been drawn. As a side-effect of folding the log panel into the pane, its click now fires on press rather than release.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
