### PR TITLE
ui/log_tab: Add a key to select the parent commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Drag to resize pane divider in all tabs
 - Mouse scrolling in the file and bookmark list panes
 - Left-click to select items in all list panes; log tab click now fires on press rather than release
+- Keybinding to move the log tab selection to the parent commit (`-`), asking
+  which one when a merge has more than one parent in the log view; parents
+  outside it are listed alongside but cannot be selected
 
 ### Changed
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -61,6 +61,8 @@ close-popup = "q"
 
 toggle-diff-format = "w"
 
+goto-parent = "-"
+
 create-new = "n"
 create-new-describe = "shift+n"
 duplicate = "shift+d"

--- a/src/commander/log.rs
+++ b/src/commander/log.rs
@@ -13,6 +13,7 @@ use anyhow::Result;
 use anyhow::bail;
 use itertools::Itertools;
 use serde::Deserialize;
+use serde::de::DeserializeOwned;
 use thiserror::Error;
 use tracing::instrument;
 
@@ -35,6 +36,15 @@ pub struct Head {
     pub immutable: bool,
 }
 
+/// A parent of a commit, as [parents_template] describes it.
+#[derive(Clone, PartialEq, Eq, Debug, Deserialize)]
+pub struct Parent {
+    #[serde(flatten)]
+    pub head: Head,
+    /// The first line of the parent's description, empty if it has none.
+    pub description: String,
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct LogOutput {
     pub graph: String,
@@ -50,11 +60,11 @@ impl LogOutput {
 }
 
 #[derive(Error, Debug)]
-pub struct HeadParseError(String);
+pub struct RecordParseError(String);
 
-impl Display for HeadParseError {
+impl Display for RecordParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Head parse error: {}", self.0)
+        write!(f, "Record parse error: {}", self.0)
     }
 }
 
@@ -66,13 +76,19 @@ impl Display for HeadParseError {
 /// whose `self` is something else point at the commit it holds, as
 /// `jj bookmark list` does.
 pub(super) fn head_template(commit: &str) -> String {
+    let fields = head_fields(commit);
+    format!(r#"'{{' ++ {fields} ++ '}}'"#)
+}
+
+/// The fields [head_template] writes, without the braces around them, so
+/// that a template describing more than a [Head] can add its own.
+fn head_fields(commit: &str) -> String {
     format!(
         r#"
-    '{{"change_id":' ++ stringify({commit}.change_id()).escape_json()
+    '"change_id":' ++ stringify({commit}.change_id()).escape_json()
     ++ ',"commit_id":' ++ stringify({commit}.commit_id()).escape_json()
     ++ ',"divergent":' ++ {commit}.divergent()
     ++ ',"immutable":' ++ {commit}.immutable()
-    ++ '}}'
 "#
     )
 }
@@ -84,16 +100,31 @@ fn head_template_nl() -> String {
     format!(r#"{head} ++ "\n""#)
 }
 
-/// Parse the [Head] one line of [head_template] output describes.
+/// Template writing one [Parent] per line for the parents of the commit
+/// in context, in the order the commit names them.
+fn parents_template() -> String {
+    let fields = head_fields("parent");
+    format!(
+        r#"
+    self.parents().map(|parent|
+        '{{' ++ {fields}
+        ++ ',"description":' ++ parent.description().first_line().escape_json()
+        ++ '}}'
+    ).join("\n")
+"#
+    )
+}
+
+/// Parse the record one line of template output describes.
 ///
 /// jj draws the graph in front of what the template writes, so the object
 /// starts at the first brace of the line. A line the graph draws for edges
 /// alone carries no template output, and neither does one for an elided
-/// revision, so those have no brace and no head.
-fn parse_head(text: &str) -> Result<Head> {
+/// revision, so those have no brace and no record.
+fn parse_record<T: DeserializeOwned>(text: &str) -> Result<T> {
     text.find('{')
         .and_then(|start| serde_json::from_str(&text[start..]).ok())
-        .ok_or_else(|| HeadParseError(text.to_owned()).into())
+        .ok_or_else(|| RecordParseError(text.to_owned()).into())
 }
 
 impl Commander {
@@ -159,7 +190,7 @@ impl Commander {
             .ignore_working_copy()
             .run()?
             .lines()
-            .map(|line| parse_head(line).ok())
+            .map(|line| parse_record(line).ok())
             .collect();
 
         let heads = graph_heads.clone().into_iter().flatten().unique().collect();
@@ -208,7 +239,7 @@ impl Commander {
     /// Maps to `jj log -r @`
     #[instrument(level = "trace", skip(self))]
     pub fn get_current_head(&self) -> Result<Head> {
-        parse_head(
+        parse_record(
             &self
                 .execute_jj_log_one("@", &head_template_nl())
                 .context("Failed getting current head")?
@@ -232,7 +263,7 @@ impl Commander {
         }
         let latest_heads: Vec<Head> = latest_heads_res
             .lines()
-            .map(parse_head)
+            .map(parse_record)
             .collect::<Result<Vec<Head>>>()?;
 
         // If the current head exist, that means it wasn't updated
@@ -274,16 +305,26 @@ impl Commander {
         );
     }
 
-    /// Get a commit's parent.
-    /// Maps to `jj log -r <revision>-`
+    /// Get a commit's parents, in the order the commit names them. The
+    /// root commit has none.
+    /// Maps to `jj log -r <revision> -T 'self.parents()...'`
+    #[instrument(level = "trace", skip(self))]
+    pub fn get_commit_parents(&self, commit_id: &CommitId) -> Result<Vec<Parent>> {
+        self.execute_jj_log_one(commit_id.as_str(), &parents_template())
+            .with_context(|| format!("Failed getting commit parents: {commit_id}"))?
+            .lines()
+            .map(parse_record)
+            .collect()
+    }
+
+    /// Get a commit's first parent.
     #[instrument(level = "trace", skip(self))]
     pub fn get_commit_parent(&self, commit_id: &CommitId) -> Result<Head> {
-        parse_head(
-            &self
-                .execute_jj_log_one(&format!("{commit_id}-"), &head_template_nl())
-                .with_context(|| format!("Failed getting commit parent: {commit_id}"))?
-                .remove_end_line(),
-        )
+        self.get_commit_parents(commit_id)?
+            .into_iter()
+            .next()
+            .map(|parent| parent.head)
+            .with_context(|| format!("Commit has no parent: {commit_id}"))
     }
 
     /// Get commit's description.
@@ -311,7 +352,7 @@ impl Commander {
     /// Maps to `jj log -r <bookmark>[@<remote>]`
     #[instrument(level = "trace", skip(self))]
     pub fn get_bookmark_head(&self, bookmark: &Bookmark) -> Result<Head> {
-        parse_head(
+        parse_record(
             &self
                 .execute_jj_log_one(&bookmark.to_string(), &head_template_nl())
                 .context("Failed getting bookmark head")?
@@ -339,9 +380,9 @@ mod tests {
     }
 
     #[test]
-    fn parse_head_reads_a_record_of_its_own() -> Result<()> {
+    fn parse_record_reads_a_record_of_its_own() -> Result<()> {
         assert_eq!(
-            parse_head(
+            parse_record::<Head>(
                 r#"{"change_id":"kxq","commit_id":"1f2e","divergent":false,"immutable":true}"#
             )?,
             head("kxq", "1f2e", false, true)
@@ -351,9 +392,9 @@ mod tests {
     }
 
     #[test]
-    fn parse_head_reads_a_record_behind_the_graph() -> Result<()> {
+    fn parse_record_reads_a_record_behind_the_graph() -> Result<()> {
         assert_eq!(
-            parse_head(
+            parse_record::<Head>(
                 r#"│ ├─╮  {"change_id":"kxq","commit_id":"1f2e","divergent":true,"immutable":false}"#
             )?,
             head("kxq", "1f2e", true, false)
@@ -364,14 +405,14 @@ mod tests {
 
     #[test]
     fn a_graph_line_without_a_record_has_no_head() {
-        assert!(parse_head("│ ├─╯").is_err());
-        assert!(parse_head("~  (elided revisions)").is_err());
-        assert!(parse_head("").is_err());
+        assert!(parse_record::<Head>("│ ├─╯").is_err());
+        assert!(parse_record::<Head>("~  (elided revisions)").is_err());
+        assert!(parse_record::<Head>("").is_err());
     }
 
     #[test]
     fn a_record_missing_a_field_is_no_head() {
-        assert!(parse_head(r#"{"change_id":"kxq","commit_id":"1f2e"}"#).is_err());
+        assert!(parse_record::<Head>(r#"{"change_id":"kxq","commit_id":"1f2e"}"#).is_err());
     }
 
     #[test]
@@ -433,6 +474,65 @@ mod tests {
                 divergent: false,
                 immutable: true,
             }
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn get_commit_parents_of_a_merge() -> Result<()> {
+        let test_repo = TestRepo::new()?;
+
+        test_repo.commander.jj(["describe", "-m", "left"]).run()?;
+        let left = test_repo.commander.get_current_head()?;
+
+        test_repo
+            .commander
+            .jj(["new", "root()", "-m", "right"])
+            .run()?;
+        let right = test_repo.commander.get_current_head()?;
+
+        test_repo
+            .commander
+            .jj(["new", left.commit_id.as_str(), right.commit_id.as_str()])
+            .run()?;
+        let merge = test_repo.commander.get_current_head()?;
+
+        assert_eq!(
+            test_repo.commander.get_commit_parents(&merge.commit_id)?,
+            vec![
+                Parent {
+                    head: left,
+                    description: "left".to_owned()
+                },
+                Parent {
+                    head: right,
+                    description: "right".to_owned()
+                },
+            ]
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn the_root_commit_has_no_parent() -> Result<()> {
+        let test_repo = TestRepo::new()?;
+
+        let head = test_repo.commander.get_current_head()?;
+        let root = test_repo.commander.get_commit_parent(&head.commit_id)?;
+
+        assert!(
+            test_repo
+                .commander
+                .get_commit_parents(&root.commit_id)?
+                .is_empty()
+        );
+        assert!(
+            test_repo
+                .commander
+                .get_commit_parent(&root.commit_id)
+                .is_err()
         );
 
         Ok(())

--- a/src/keybinds/config.rs
+++ b/src/keybinds/config.rs
@@ -51,6 +51,8 @@ pub struct LogTabKeybindsConfig {
 
     pub toggle_diff_format: Option<Keybind>,
 
+    pub goto_parent: Option<Keybind>,
+
     pub duplicate: Option<Keybind>,
     pub create_new: Option<Keybind>,
     pub create_new_describe: Option<Keybind>,

--- a/src/keybinds/log_tab.rs
+++ b/src/keybinds/log_tab.rs
@@ -28,6 +28,8 @@ pub enum LogTabEvent {
 
     ToggleHeadMark,
 
+    GotoParent,
+
     CreateNew {
         describe: bool,
     },
@@ -70,6 +72,7 @@ impl Default for LogTabKeybinds {
             LogTabEvent::ScrollToBottom => "ctrl+end",
             LogTabEvent::ScrollToTop => "ctrl+home",
             LogTabEvent::ToggleHeadMark => "space",
+            LogTabEvent::GotoParent => "-",
             LogTabEvent::Duplicate => "shift+d",
             LogTabEvent::CreateNew { describe: false } => "n",
             LogTabEvent::CreateNew { describe: true } => "shift+n",
@@ -118,6 +121,7 @@ impl LogTabKeybinds {
             LogTabEvent::Save => config.save,
             LogTabEvent::Cancel => config.cancel,
             LogTabEvent::ClosePopup => config.close_popup,
+            LogTabEvent::GotoParent => config.goto_parent,
             LogTabEvent::Duplicate => config.duplicate,
             LogTabEvent::CreateNew { describe: false } => config.create_new,
             LogTabEvent::CreateNew { describe: true } => config.create_new_describe,
@@ -145,6 +149,7 @@ impl LogTabKeybinds {
     pub fn make_main_panel_help(&self) -> Vec<(String, String)> {
         make_keybinds_help!(
             self.keys,
+            LogTabEvent::GotoParent => "go to parent commit",
             LogTabEvent::OpenFiles => "see files",
             LogTabEvent::EditRevset => "set revset",
             LogTabEvent::Describe => "describe change",

--- a/src/ui/dialog/mod.rs
+++ b/src/ui/dialog/mod.rs
@@ -15,6 +15,7 @@ mod describe;
 mod help;
 mod loader;
 mod message;
+mod parent_select;
 mod rebase;
 
 pub use bookmark_name::BookmarkNamePopup;
@@ -24,4 +25,5 @@ pub use describe::DescribePopup;
 pub use help::HelpPopup;
 pub use loader::LoaderPopup;
 pub use message::MessagePopup;
+pub use parent_select::ParentSelectPopup;
 pub use rebase::RebasePopup;

--- a/src/ui/dialog/parent_select.rs
+++ b/src/ui/dialog/parent_select.rs
@@ -1,0 +1,246 @@
+use anyhow::Result;
+use ratatui::Frame;
+use ratatui::crossterm::event::Event;
+use ratatui::crossterm::event::KeyCode;
+use ratatui::layout::Alignment;
+use ratatui::layout::Constraint;
+use ratatui::layout::Direction;
+use ratatui::layout::Layout;
+use ratatui::layout::Rect;
+use ratatui::style::Color;
+use ratatui::style::Style;
+use ratatui::style::Stylize;
+use ratatui::text::Line;
+use ratatui::text::Span;
+use ratatui::widgets::Block;
+use ratatui::widgets::BorderType;
+use ratatui::widgets::Borders;
+use ratatui::widgets::Clear;
+use ratatui::widgets::List;
+use ratatui::widgets::ListState;
+use ratatui::widgets::Paragraph;
+
+use crate::commander::log::Parent;
+use crate::env::JjConfig;
+use crate::ui::AppAction;
+use crate::ui::Component;
+use crate::ui::ComponentInputResult;
+use crate::ui::styles::create_popup_block;
+use crate::ui::utils::centered_rect;
+
+/// The row a parent gets in the list, dimmed when it cannot be selected.
+fn parent_line(parent: &Parent, dimmed: bool) -> Line<'static> {
+    let dim = Style::default().fg(Color::DarkGray);
+    let (change_id_style, description_style) = if dimmed {
+        (dim, dim)
+    } else {
+        (Style::default().fg(Color::Magenta), Style::default())
+    };
+
+    let change_id: String = parent.head.change_id.as_str().chars().take(8).collect();
+    let description = if parent.description.is_empty() {
+        Span::styled(" (no description)", dim)
+    } else {
+        Span::styled(format!(" {}", parent.description), description_style)
+    };
+
+    Line::from(vec![Span::styled(change_id, change_id_style), description])
+}
+
+pub struct ParentSelectPopup {
+    parents: Vec<Parent>,
+    /// The parents the log does not hold. We list them so that the merge
+    /// is shown in full, but they cannot be selected.
+    out_of_view: Vec<Parent>,
+    list_state: ListState,
+    list_height: u16,
+    config: JjConfig,
+}
+
+impl ParentSelectPopup {
+    pub fn new(parents: Vec<Parent>, out_of_view: Vec<Parent>, config: JjConfig) -> Self {
+        Self {
+            parents,
+            out_of_view,
+            list_state: ListState::default().with_selected(Some(0)),
+            list_height: 0,
+            config,
+        }
+    }
+
+    fn scroll(&mut self, scroll: isize) {
+        self.list_state.select(Some(
+            self.list_state
+                .selected()
+                .map(|selected| selected.saturating_add_signed(scroll))
+                .unwrap_or(0)
+                .min(self.parents.len().saturating_sub(1)),
+        ));
+    }
+}
+
+impl Component for ParentSelectPopup {
+    fn draw(&mut self, f: &mut Frame<'_>, area: Rect) -> Result<()> {
+        let block = create_popup_block("Select parent");
+        let area = centered_rect(area, 50, 60);
+        f.render_widget(Clear, area);
+        f.render_widget(&block, area);
+
+        let popup_chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Fill(1), Constraint::Length(2)])
+            .split(block.inner(area));
+
+        let mut list_items: Vec<Line<'_>> = self
+            .parents
+            .iter()
+            .map(|parent| parent_line(parent, false))
+            .collect();
+
+        if !self.out_of_view.is_empty() {
+            list_items.push(Line::default());
+            list_items.push(Line::from(Span::styled(
+                " ── Not in the log view ──",
+                Style::default().fg(Color::DarkGray),
+            )));
+            list_items.extend(
+                self.out_of_view
+                    .iter()
+                    .map(|parent| parent_line(parent, true)),
+            );
+        }
+
+        let list = List::new(list_items)
+            .scroll_padding(3)
+            .highlight_style(Style::default().bg(self.config.highlight_color()));
+
+        f.render_stateful_widget(list, popup_chunks[0], &mut self.list_state);
+        self.list_height = popup_chunks[0].height;
+
+        let help = Paragraph::new(vec!["j/k: scroll | Enter: select | Escape: cancel".into()])
+            .fg(Color::DarkGray)
+            .alignment(Alignment::Center)
+            .block(
+                Block::default()
+                    .borders(Borders::TOP)
+                    .border_type(BorderType::Rounded)
+                    .border_style(Style::default().fg(Color::DarkGray)),
+            );
+
+        f.render_widget(help, popup_chunks[1]);
+        Ok(())
+    }
+
+    fn input(&mut self, event: Event) -> Result<ComponentInputResult> {
+        if let Event::Key(key) = event {
+            match key.code {
+                KeyCode::Char('j') | KeyCode::Down => self.scroll(1),
+                KeyCode::Char('k') | KeyCode::Up => self.scroll(-1),
+                KeyCode::Char('J') => self.scroll(self.list_height as isize / 2),
+                KeyCode::Char('K') => self.scroll((self.list_height as isize / 2).saturating_neg()),
+                KeyCode::Enter => {
+                    if let Some(parent) = self
+                        .list_state
+                        .selected()
+                        .and_then(|index| self.parents.get(index))
+                    {
+                        // Moving the selection leaves the repo as it is, so
+                        // we take the popup down without a refresh.
+                        return Ok(ComponentInputResult::HandledAction(AppAction::Multiple(
+                            vec![
+                                AppAction::PopupCanceled,
+                                AppAction::ViewLog(parent.head.clone()),
+                            ],
+                        )));
+                    }
+                }
+                KeyCode::Char('q') | KeyCode::Esc => {
+                    return Ok(ComponentInputResult::HandledAction(
+                        AppAction::PopupCanceled,
+                    ));
+                }
+                _ => {}
+            }
+        }
+        Ok(ComponentInputResult::Handled)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commander::ids::ChangeId;
+    use crate::commander::ids::CommitId;
+    use crate::commander::log::Head;
+
+    fn parents(range: std::ops::Range<usize>) -> Vec<Parent> {
+        range
+            .map(|i| Parent {
+                head: Head {
+                    change_id: ChangeId(format!("change{i}")),
+                    commit_id: CommitId(format!("commit{i}")),
+                    divergent: false,
+                    immutable: false,
+                },
+                description: format!("parent {i}"),
+            })
+            .collect()
+    }
+
+    fn popup(count: usize, out_of_view: usize) -> ParentSelectPopup {
+        ParentSelectPopup::new(
+            parents(0..count),
+            parents(count..count + out_of_view),
+            JjConfig::default(),
+        )
+    }
+
+    fn press(popup: &mut ParentSelectPopup, key: KeyCode) -> ComponentInputResult {
+        popup
+            .input(Event::Key(key.into()))
+            .expect("the popup handles key presses")
+    }
+
+    #[test]
+    fn scrolling_is_clamped_to_the_parents_in_view() {
+        let mut popup = popup(3, 2);
+
+        for _ in 0..5 {
+            press(&mut popup, KeyCode::Char('j'));
+        }
+        assert_eq!(popup.list_state.selected(), Some(2));
+
+        for _ in 0..5 {
+            press(&mut popup, KeyCode::Char('k'));
+        }
+        assert_eq!(popup.list_state.selected(), Some(0));
+    }
+
+    #[test]
+    fn enter_shows_the_selected_parent_in_the_log() {
+        let mut popup = popup(3, 0);
+
+        press(&mut popup, KeyCode::Char('j'));
+
+        let ComponentInputResult::HandledAction(AppAction::Multiple(actions)) =
+            press(&mut popup, KeyCode::Enter)
+        else {
+            panic!("selecting a parent should take the popup down and show it");
+        };
+        let [AppAction::PopupCanceled, AppAction::ViewLog(head)] = actions.as_slice() else {
+            panic!("selecting a parent should take the popup down and show it");
+        };
+
+        assert_eq!(head.commit_id, CommitId("commit1".to_owned()));
+    }
+
+    #[test]
+    fn cancelling_selects_no_parent() {
+        let mut popup = popup(3, 0);
+
+        assert!(matches!(
+            press(&mut popup, KeyCode::Esc),
+            ComponentInputResult::HandledAction(AppAction::PopupCanceled)
+        ));
+    }
+}

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -36,6 +36,7 @@ use crate::ui::dialog::BookmarkSetPopup;
 use crate::ui::dialog::DescribePopup;
 use crate::ui::dialog::LoaderPopup;
 use crate::ui::dialog::MessagePopup;
+use crate::ui::dialog::ParentSelectPopup;
 use crate::ui::dialog::RebasePopup;
 use crate::ui::panel::CommitShowPanel;
 use crate::ui::panel::LogPanel;
@@ -306,6 +307,47 @@ impl<'a> LogTab<'a> {
         }
     }
 
+    /// Move the selection to the parent of the current head, asking which
+    /// one unless there is a single parent to go to.
+    fn handle_goto_parent(&mut self) -> Result<ComponentInputResult> {
+        let message = |text: &str| {
+            Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
+                Box::new(MessagePopup::new("Go to parent", text)),
+            )))
+        };
+
+        let parents = match new_commander().get_commit_parents(&self.head.commit_id) {
+            Ok(parents) => parents,
+            Err(err) => return message(&err.to_string()),
+        };
+
+        if parents.is_empty() {
+            return message("The root commit has no parent");
+        }
+
+        // Selecting a change the log does not hold would leave the list
+        // without a highlight, and the next scroll would start over at its
+        // first change.
+        let (mut parents, out_of_view): (Vec<_>, Vec<_>) = parents
+            .into_iter()
+            .partition(|parent| self.log_panel.shows_head(&parent.head));
+
+        match parents.len() {
+            0 => message("The log holds no parent of this change"),
+            1 => {
+                self.set_head(parents.remove(0).head);
+                Ok(ComponentInputResult::Handled)
+            }
+            _ => Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
+                Box::new(ParentSelectPopup::new(
+                    parents,
+                    out_of_view,
+                    self.config.clone(),
+                )),
+            ))),
+        }
+    }
+
     fn handle_event(&mut self, log_tab_event: LogTabEvent) -> Result<ComponentInputResult> {
         match log_tab_event {
             LogTabEvent::ScrollToBottom
@@ -511,6 +553,10 @@ impl<'a> LogTab<'a> {
                     Box::new(loader),
                 )));
             }
+            LogTabEvent::GotoParent => {
+                return self.handle_goto_parent();
+            }
+
             LogTabEvent::Save
             | LogTabEvent::Cancel
             | LogTabEvent::ClosePopup

--- a/src/ui/panel/log_panel.rs
+++ b/src/ui/panel/log_panel.rs
@@ -227,6 +227,12 @@ impl<'a> LogPanel<'a> {
         get_head_index(&self.head, &self.log_output)
     }
 
+    /// Whether the log holds a head, taking a different commit for the
+    /// same change as a match.
+    pub fn shows_head(&self, head: &Head) -> bool {
+        get_head_index(head, &self.log_output).is_some()
+    }
+
     /// Number of heads that fit on screen. Think of this as in unit
     /// head-index. Moving the head-index this much causes a full page
     /// scroll.


### PR DESCRIPTION
Walking down a branch means scrolling the log line by line, which is tedious and easy to get wrong where the graph forks, so we bind `-` to the parent of the selected change. A merge has several parents, so where more than one of them is in the log we show them in a popup and move the selection to the one picked. A filtering revset can leave a parent out of the log, and selecting one would leave the list without a highlight, so those cannot be picked; we still list them, greyed out, so that the merge is shown in full. We take the parents by templating over `self.parents()` rather than by logging the `<commit>-` revset, so that the popup lists them in the order the merge names them rather than in the order the log happens to sort them; that also lets a single jj call carry the descriptions the popup shows. The existing single-parent lookup becomes the first of these, which makes it deterministic on a merge as well.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
