### PR TITLE
Run git fetch and push as background tasks

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -375,8 +375,18 @@ impl<'a> App<'a> {
     fn handle_task_result(&mut self, result: TaskResult) -> Result<()> {
         self.background_tasks.finish(&result);
 
-        let consumer: &mut dyn Component = match result.slot {
-            TaskSlot::CommitShow(tab, _) => self.get_tab(tab),
+        let consumer: Option<&mut dyn Component> = match result.slot {
+            TaskSlot::CommitShow(tab, _) => Some(self.get_tab(tab)),
+            // The cast reborrows the popup for the body rather than for
+            // the lifetime the app is tied to.
+            TaskSlot::GitPush | TaskSlot::GitFetch => self
+                .popup
+                .as_deref_mut()
+                .map(|popup| popup as &mut dyn Component),
+        };
+        let Some(consumer) = consumer else {
+            trace!("Dropping task result, its consumer is gone");
+            return Ok(());
         };
 
         if let Some(app_action) = consumer.task_done(result)? {

--- a/src/background_tasks.rs
+++ b/src/background_tasks.rs
@@ -61,6 +61,8 @@ pub enum TaskSlot {
     /// same change at once, and each keeps its own copy of the output, so
     /// the tab is part of the slot.
     CommitShow(TabId, CommitShowRequest),
+    GitPush,
+    GitFetch,
 }
 
 /// Which run of a slot a task is. Unique for the lifetime of the app,
@@ -107,6 +109,8 @@ struct RunningTask {
     id: TaskId,
     slot: TaskSlot,
     cancel: CancelToken,
+    /// Whether we may kill this task to make room for newer work.
+    evictable: bool,
 }
 
 impl BackgroundTasks {
@@ -145,6 +149,22 @@ impl BackgroundTasks {
     /// flight. If we later need room for newer work, the task may be
     /// killed, in which case its result is discarded.
     pub fn submit<F>(&self, slot: TaskSlot, task: F)
+    where
+        F: FnOnce(&CancelToken) -> TaskOutput + Send + 'static,
+    {
+        self.start(slot, true, task);
+    }
+
+    /// Like [Self::submit], but the task keeps its slot until it is done
+    /// and is never killed to make room.
+    pub fn submit_uninterruptible<F>(&self, slot: TaskSlot, task: F)
+    where
+        F: FnOnce() -> TaskOutput + Send + 'static,
+    {
+        self.start(slot, false, move |_cancel| task());
+    }
+
+    fn start<F>(&self, slot: TaskSlot, evictable: bool, task: F)
     where
         F: FnOnce(&CancelToken) -> TaskOutput + Send + 'static,
     {
@@ -188,7 +208,12 @@ impl BackgroundTasks {
             });
 
         match thread {
-            Ok(_) => running.tasks.push(RunningTask { id, slot, cancel }),
+            Ok(_) => running.tasks.push(RunningTask {
+                id,
+                slot,
+                cancel,
+                evictable,
+            }),
             // The consumer is waiting for this slot, so it has to hear
             // about the failure rather than wait for a result forever.
             Err(err) => {
@@ -223,12 +248,18 @@ impl BackgroundTasks {
     }
 }
 
-/// Kill tasks until there is room for one more. The tasks are in
-/// submission order, so the first one has had the longest to produce
-/// something and is the one we can least expect to still be wanted.
+/// Kill tasks that may be killed until there is room for one more. The
+/// tasks are in submission order, so the first one that may be killed has
+/// had the longest to produce something and is the one we can least expect
+/// to still be wanted. Leaves us over [MAX_RUNNING] when none of them may
+/// be killed.
 fn evict_for_room(running: &mut Vec<RunningTask>) {
     while running.len() >= MAX_RUNNING {
-        let task = running.remove(0);
+        let Some(index) = running.iter().position(|task| task.evictable) else {
+            break;
+        };
+
+        let task = running.remove(index);
         debug!("Killing slow task to make room: {:?}", task.slot);
         task.cancel.cancel();
     }
@@ -374,6 +405,50 @@ mod tests {
 
         assert!(!tasks.contains(&slot(0)), "oldest task should be evicted");
         assert!(tasks.contains(&slot(1)), "younger tasks should be left be");
+        assert_eq!(tasks.running_count(), MAX_RUNNING);
+    }
+
+    #[test]
+    fn never_evicts_an_uninterruptible_task() {
+        let (tasks, _receiver) = tasks();
+        let mut gates: Vec<_> = (0..MAX_RUNNING)
+            .map(|index| {
+                let (gate, task) = gated_task();
+                tasks.submit_uninterruptible(slot(index), task);
+                gate
+            })
+            .collect();
+
+        let (gate, task) = gated_task();
+        gates.push(gate);
+        tasks.submit(slot(MAX_RUNNING), move |_cancel| task());
+
+        assert_eq!(tasks.running_count(), MAX_RUNNING + 1);
+        assert!(tasks.contains(&slot(0)));
+    }
+
+    #[test]
+    fn evicts_the_oldest_task_behind_an_uninterruptible_one() {
+        let (tasks, _receiver) = tasks();
+        // A push is the oldest task, so making room has to look past it
+        // instead of giving up on the one task it may not kill.
+        let (push_gate, push) = gated_task();
+        tasks.submit_uninterruptible(TaskSlot::GitPush, push);
+        let mut gates: Vec<_> = (1..MAX_RUNNING)
+            .map(|index| {
+                let (gate, task) = gated_task();
+                tasks.submit(slot(index), move |_cancel| task());
+                gate
+            })
+            .collect();
+        gates.push(push_gate);
+
+        let (gate, task) = gated_task();
+        gates.push(gate);
+        tasks.submit(slot(MAX_RUNNING), move |_cancel| task());
+
+        assert!(tasks.contains(&TaskSlot::GitPush), "a push is never killed");
+        assert!(!tasks.contains(&slot(1)), "oldest task should be evicted");
         assert_eq!(tasks.running_count(), MAX_RUNNING);
     }
 

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -351,8 +351,9 @@ impl Component for BookmarksTab {
     }
 
     fn task_done(&mut self, result: TaskResult) -> Result<Option<AppAction>> {
-        let TaskSlot::CommitShow(_, request) = result.slot;
-        self.bookmark_panel.task_done(request, result.output);
+        if let TaskSlot::CommitShow(_, request) = result.slot {
+            self.bookmark_panel.task_done(request, result.output);
+        }
         Ok(None)
     }
 

--- a/src/ui/dialog/loader.rs
+++ b/src/ui/dialog/loader.rs
@@ -1,10 +1,6 @@
 //! The loader popup presents a cute little animation and an operation name and should be used for
 //! operations known to possibly take some time.
 
-use std::sync::mpsc::Receiver;
-use std::sync::mpsc::Sender;
-use std::sync::mpsc::{self};
-use std::thread;
 use std::time::Duration;
 use std::time::Instant;
 
@@ -20,42 +16,32 @@ use ratatui::widgets::Clear;
 use throbber_widgets_tui::Throbber;
 use throbber_widgets_tui::ThrobberState;
 
-use crate::commander::CommandError;
+use crate::background_tasks::TaskResult;
+use crate::background_tasks::TaskSlot;
 use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
 use crate::ui::dialog::MessagePopup;
 use crate::ui::utils::centered_rect_fixed;
 
-type OperationResult = Result<String, CommandError>;
-
 /// A transient popup to be shown during possibly time consuming actions
+///
+/// The operation itself runs as a background task; the popup shows that
+/// it is running and closes when its result arrives.
 pub struct LoaderPopup {
     operation_name: String,
-    result_rx: Receiver<OperationResult>,
+    /// The task slot this popup is waiting for
+    slot: TaskSlot,
     throbber_state: ThrobberState,
     last_animation_update: Instant,
 }
 
 impl LoaderPopup {
-    /// Create a new loader popup for the given operation
-    ///
-    /// The operation is started immediately and runs in a background thread.
-    pub fn new<F>(operation_name: String, operation: F) -> Self
-    where
-        F: FnOnce() -> OperationResult + Send + 'static,
-    {
-        let (tx, rx): (Sender<OperationResult>, Receiver<OperationResult>) = mpsc::channel();
-
-        // Spawn thread to run the operation
-        thread::spawn(move || {
-            let result = operation();
-            tx.send(result)
-        });
-
+    /// Create a new loader popup for the operation running in `slot`
+    pub fn new(operation_name: String, slot: TaskSlot) -> Self {
         Self {
             operation_name,
-            result_rx: rx,
+            slot,
             throbber_state: ThrobberState::default(),
             last_animation_update: Instant::now(),
         }
@@ -63,21 +49,26 @@ impl LoaderPopup {
 }
 
 impl Component for LoaderPopup {
-    /// Update the state of the popup
-    ///
-    /// This updates the animation and also polls the running operation to see if the popup may be
-    /// closed. In case of an error, that will be displayed in a new popup.
+    /// Advance the animation
     fn update(&mut self) -> Result<Option<AppAction>> {
         if self.last_animation_update.elapsed() >= Duration::from_millis(100) {
             self.throbber_state.calc_next();
             self.last_animation_update = Instant::now();
         }
 
-        let Ok(result) = self.result_rx.try_recv() else {
-            return Ok(None);
-        };
+        Ok(None)
+    }
 
-        let action = match result {
+    /// Close the popup, showing whatever the operation had to say. In
+    /// case of an error, that is displayed in a new popup.
+    fn task_done(&mut self, result: TaskResult) -> Result<Option<AppAction>> {
+        // Another operation's result says nothing about this one, and
+        // closing on it would leave the popup's own task unattended.
+        if result.slot != self.slot {
+            return Ok(None);
+        }
+
+        let action = match result.output {
             Ok(output) if !output.is_empty() => AppAction::Multiple(vec![
                 AppAction::SetPopup(Box::new(MessagePopup::new(
                     format!("{} message", self.operation_name),

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -17,6 +17,7 @@ use tui_confirm_dialog::Listener;
 
 use crate::app::TabId;
 use crate::background_tasks::BackgroundTasks;
+use crate::background_tasks::TaskOutput;
 use crate::background_tasks::TaskResult;
 use crate::background_tasks::TaskSlot;
 use crate::commander::log::Head;
@@ -52,6 +53,10 @@ const SQUASH_POPUP_ID: u16 = 4;
 
 /// Log tab. Shows `jj log` in main panel and shows selected change details of in details panel.
 pub struct LogTab<'a> {
+    /// Where the commands the tab runs itself go, so they do not block
+    /// the UI thread
+    background_tasks: BackgroundTasks,
+
     /// The revset filter to apply to jj log
     log_revset_textarea: Option<TextArea<'a>>,
 
@@ -129,7 +134,9 @@ impl<'a> LogTab<'a> {
             log_panel: LogPanel::new(head.clone()),
 
             head,
-            head_panel: CommitShowPanel::new(TabId::Log, background_tasks),
+            head_panel: CommitShowPanel::new(TabId::Log, background_tasks.clone()),
+
+            background_tasks,
 
             popup: ConfirmDialogState::default(),
             popup_tx,
@@ -171,6 +178,19 @@ impl<'a> LogTab<'a> {
         self.head = self.log_panel.head.clone();
         let title = format!(" Details for {} ", self.head.change_id);
         self.head_panel.show(Some(self.head.clone()), title);
+    }
+
+    /// Run `operation` in `slot` and put up a loader popup for it, which
+    /// stays until that slot's result arrives. The popup swallows all
+    /// input, so the slot it waits for has to be the one submitted here.
+    fn run_with_loader<F>(&self, operation_name: &str, slot: TaskSlot, operation: F) -> AppAction
+    where
+        F: FnOnce() -> TaskOutput + Send + 'static,
+    {
+        self.background_tasks
+            .submit_uninterruptible(slot.clone(), operation);
+
+        AppAction::SetPopup(Box::new(LoaderPopup::new(operation_name.to_owned(), slot)))
     }
 }
 
@@ -495,21 +515,17 @@ impl<'a> LogTab<'a> {
             } => {
                 let commit_id = self.head.commit_id.clone();
 
-                let loader = LoaderPopup::new("Pushing".to_string(), move || {
-                    new_commander().git_push(all_bookmarks, allow_new, &commit_id)
-                });
-
-                return Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
-                    Box::new(loader),
+                return Ok(ComponentInputResult::HandledAction(self.run_with_loader(
+                    "Pushing",
+                    TaskSlot::GitPush,
+                    move || Ok(new_commander().git_push(all_bookmarks, allow_new, &commit_id)?),
                 )));
             }
             LogTabEvent::Fetch { all_remotes } => {
-                let loader = LoaderPopup::new("Fetching".to_string(), move || {
-                    new_commander().git_fetch(all_remotes)
-                });
-
-                return Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
-                    Box::new(loader),
+                return Ok(ComponentInputResult::HandledAction(self.run_with_loader(
+                    "Fetching",
+                    TaskSlot::GitFetch,
+                    move || Ok(new_commander().git_fetch(all_remotes)?),
                 )));
             }
             LogTabEvent::Save
@@ -617,8 +633,9 @@ impl Component for LogTab<'_> {
     }
 
     fn task_done(&mut self, result: TaskResult) -> Result<Option<AppAction>> {
-        let TaskSlot::CommitShow(_, request) = result.slot;
-        self.head_panel.task_done(request, result.output);
+        if let TaskSlot::CommitShow(_, request) = result.slot {
+            self.head_panel.task_done(request, result.output);
+        }
         Ok(None)
     }
 


### PR DESCRIPTION
The loader popup runs its operation on a thread of its own and polls a private channel for the result in `update()`, which is a second way of doing what the task registry now does. With the operation submitted as a task, the popup is left with what it is actually for: showing that something is running. Since it swallows all input while it does, its operation's result is the only thing that can close it again, so it is told which slot to wait for and submitting that slot happens in the same place rather than at each call site. Fetch and push keep their slot for as long as they take, since we cannot tell whether cutting one short would leave the remote half updated.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
