### PR TITLE
ui/utils: Render error text where it is displayed

### DIFF
--- a/src/commander/mod.rs
+++ b/src/commander/mod.rs
@@ -44,14 +44,9 @@ use std::string::FromUtf8Error;
 use std::thread;
 use std::thread::JoinHandle;
 
-use ansi_to_tui::IntoText;
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::bail;
-use ratatui::style::Color;
-use ratatui::style::Stylize;
-use ratatui::text::Line;
-use ratatui::text::Text;
 use thiserror::Error;
 use tracing::error;
 use tracing::instrument;
@@ -99,20 +94,6 @@ pub enum CommandError {
     Status(String, Option<i32>),
     #[error("Error parsing UTF-8 output: {0}")]
     FromUtf8(#[from] FromUtf8Error),
-}
-
-impl CommandError {
-    #[expect(clippy::wrong_self_convention)]
-    pub fn into_text<'a>(&self, title: &'a str) -> Result<Text<'a>, ansi_to_tui::Error> {
-        let mut lines = vec![];
-        if !title.is_empty() {
-            lines.push(Line::raw(title).bold().fg(Color::Red));
-            lines.append(&mut vec![Line::raw(""), Line::raw("")]);
-        }
-        lines.append(&mut self.to_string().into_text()?.lines);
-
-        Ok(Text::from(lines))
-    }
 }
 
 /// Reusable handle to a repository.

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -32,6 +32,7 @@ use crate::ui::panel::MouseInput;
 use crate::ui::panel::TextContent;
 use crate::ui::panel::route_mouse;
 use crate::ui::utils::PaneDivider;
+use crate::ui::utils::error_text;
 use crate::ui::utils::tabs_to_spaces;
 
 /// Files tab. Shows files in selected change in main panel and selected file diff in details panel
@@ -309,7 +310,7 @@ impl Component for FilesTab {
                         files_lines
                     }
                 }
-                Err(err) => err.into_text("Error getting files")?.lines,
+                Err(err) => error_text("Error getting files", err)?.lines,
             };
 
             let title_change = if self.is_current_head {
@@ -340,7 +341,7 @@ impl Component for FilesTab {
             let diff_content = match self.diff_output.as_ref() {
                 Ok(Some(diff_content)) => diff_content.into_text()?,
                 Ok(None) => Text::default(),
-                Err(err) => err.into_text("Error getting diff")?,
+                Err(err) => error_text("Error getting diff", err)?,
             };
             self.diff_panel
                 .render_context::<TextContent>(diff_content)

--- a/src/ui/panel/log_panel.rs
+++ b/src/ui/panel/log_panel.rs
@@ -25,6 +25,7 @@ use crate::keybinds::LogTabKeybinds;
 use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
+use crate::ui::utils::error_text;
 
 /**
     A panel that displays the output of jj log.
@@ -191,7 +192,7 @@ impl<'a> LogPanel<'a> {
     fn log_lines(&self) -> Vec<Line<'a>> {
         match self.log_output.as_ref() {
             Ok(log_output) => self.output_to_lines(log_output),
-            Err(err) => err.into_text("Error getting log").unwrap().lines,
+            Err(err) => error_text("Error getting log", err).unwrap().lines,
         }
     }
 

--- a/src/ui/utils.rs
+++ b/src/ui/utils.rs
@@ -1,8 +1,10 @@
 mod large_string;
 
+use std::fmt;
 use std::time::Duration;
 use std::time::Instant;
 
+use ansi_to_tui::IntoText;
 pub use large_string::LargeString;
 use ratatui::crossterm::event::MouseButton;
 use ratatui::crossterm::event::MouseEvent;
@@ -11,6 +13,10 @@ use ratatui::layout::Constraint;
 use ratatui::layout::Direction;
 use ratatui::layout::Layout;
 use ratatui::layout::Rect;
+use ratatui::style::Color;
+use ratatui::style::Stylize;
+use ratatui::text::Line;
+use ratatui::text::Text;
 
 use crate::env::JJLayout;
 
@@ -176,6 +182,22 @@ pub fn centered_rect_fixed(area: Rect, width: u16, height: u16) -> Rect {
     }
 }
 
+/// An error under a red title, with any ANSI escape sequences in its
+/// message honoured.
+pub fn error_text<'a>(
+    title: &'a str,
+    error: &impl fmt::Display,
+) -> Result<Text<'a>, ansi_to_tui::Error> {
+    let mut lines = vec![
+        Line::raw(title).bold().fg(Color::Red),
+        Line::raw(""),
+        Line::raw(""),
+    ];
+    lines.append(&mut error.to_string().into_text()?.lines);
+
+    Ok(Text::from(lines))
+}
+
 /// How long a panel keeps quiet about the command it is waiting for.
 const LOADING_GRACE: Duration = Duration::from_secs(1);
 
@@ -308,6 +330,19 @@ pub fn tabs_to_spaces(line: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn an_error_is_shown_under_its_title() -> Result<(), ansi_to_tui::Error> {
+        let text = error_text("Error getting diff", &"no such \x1b[31mrevision\x1b[0m")?;
+
+        let lines: Vec<String> = text.lines.iter().map(ToString::to_string).collect();
+        assert_eq!(lines, ["Error getting diff", "", "", "no such revision"]);
+        assert_eq!(text.lines[0].style.fg, Some(Color::Red));
+        // The escape sequence is a style rather than something to read.
+        assert_eq!(text.lines[3].spans.len(), 2);
+
+        Ok(())
+    }
 
     #[test]
     fn a_long_wait_names_the_command_and_its_runtime() {


### PR DESCRIPTION
`CommandError::into_text()` turns an error into a red title and the ANSI-coloured stderr below it, which is a rendering decision sitting in the layer that runs the commands, and it is reachable only from an error that a command produced. As a function next to the other things a panel draws, it also serves errors that a command did not produce.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
