### PR TITLE
keybinds: Allow binding the Menu key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Drag to resize pane divider in all tabs
 - Mouse scrolling in the file and bookmark list panes
 - Left-click to select items in all list panes; log tab click now fires on press rather than release
+- The dedicated `Menu` key can now be used in keybindings, spelled `menu`
 - Keybinding to move the log tab selection to the parent commit (`-`), asking
   which one when a merge has more than one parent in the log view; parents
   outside it are listed alongside but cannot be selected

--- a/src/keybinds/mod.rs
+++ b/src/keybinds/mod.rs
@@ -128,6 +128,7 @@ impl FromStr for Shortcut {
                 "end" => key = Some(KeyCode::End),
                 "pagedown" => key = Some(KeyCode::PageDown),
                 "pageup" => key = Some(KeyCode::PageUp),
+                "menu" => key = Some(KeyCode::Menu),
                 s if s.starts_with('f') && s.chars().count() > 1 => {
                     let s = s.trim_start_matches('f');
                     match s.parse::<u8>() {
@@ -171,6 +172,7 @@ impl Display for Shortcut {
             KeyCode::F(n) => format!("F{n}"),
             KeyCode::Char(c) => c.to_string(),
             KeyCode::Esc => "Esc".to_string(),
+            KeyCode::Menu => "Menu".to_string(),
             _ => "Unknown".to_string(),
         };
         parts.push(k);


### PR DESCRIPTION
Terminals report the dedicated context-menu key as `KeyCode::Menu`, but our keybind parser has no name for it, so it can neither be bound in the config nor rendered in the help. Spell it `menu`.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
