### PR TITLE
ui/dialog: Size the message popup to its message 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - The help popup is now sized to fit what it lists
+- The message popup is now sized to fit its message, rather than always
+  taking up most of the screen
 - The help popup now lists the keybindings next to what they do rather than in
   front of it
 - Pressing `s` on the working copy now offers to squash into the parent (when there is exactly one)

--- a/src/ui/dialog/help.rs
+++ b/src/ui/dialog/help.rs
@@ -20,6 +20,7 @@ use crate::ui::Component;
 use crate::ui::ComponentInputResult;
 use crate::ui::styles::create_popup_block;
 use crate::ui::utils::centered_rect_fixed;
+use crate::ui::utils::chrome;
 
 /// Space between the description and the key column of a table
 const COLUMN_SPACING: u16 = 4;
@@ -94,17 +95,6 @@ fn columns<'a>([main, details, global]: [Section<'a>; 3], width: u16) -> Vec<Vec
     }
 
     vec![vec![main, details, global]]
-}
-
-/// How much wider and taller than its contents a `block` is, in the `area` it
-/// has to draw itself in. Its border is not all of it, it also pads.
-fn chrome(block: &Block, area: Rect) -> [u16; 2] {
-    let inner = block.inner(area);
-
-    [
-        area.width.saturating_sub(inner.width),
-        area.height.saturating_sub(inner.height),
-    ]
 }
 
 /// Renders the `sections` stacked in `area`, with a rule between them and

--- a/src/ui/dialog/message.rs
+++ b/src/ui/dialog/message.rs
@@ -27,6 +27,8 @@ use crate::ui::Component;
 use crate::ui::ComponentInputResult;
 use crate::ui::utils::LargeString;
 use crate::ui::utils::centered_rect;
+use crate::ui::utils::centered_rect_fixed;
+use crate::ui::utils::chrome;
 
 pub struct MessagePopup<'a> {
     title: Line<'a>,
@@ -68,6 +70,22 @@ impl<'a> MessagePopup<'a> {
         })
     }
 
+    /// Where to put the popup in `area`: centered, and no larger than the
+    /// message needs, up to the share of the screen we are willing to take.
+    fn popup_rect(&self, area: Rect, block: &Block, title_width: u16) -> Rect {
+        let max = centered_rect(area, 80, 80);
+        let [extra_width, extra_height] = chrome(block, max);
+
+        // The two rows the scroll indicators live in are there whether or
+        // not they are, and the title has to fit on the top border.
+        let width = (self.messages.width() as u16 + extra_width)
+            .max(title_width + 2)
+            .min(max.width);
+        let height = (self.lines as u16 + 2 + extra_height).min(max.height);
+
+        centered_rect_fixed(area, width, height)
+    }
+
     fn max_scroll(&self) -> usize {
         self.lines.saturating_sub(self.content_height as usize)
     }
@@ -80,19 +98,19 @@ impl<'a> MessagePopup<'a> {
 
 impl Component for MessagePopup<'_> {
     fn draw(&mut self, f: &mut Frame<'_>, area: Rect) -> Result<()> {
-        let popup_rect = centered_rect(area, 80, 80);
-        f.render_widget(Clear, popup_rect);
-
         let mut title = self.title.clone();
         title.spans = [vec![Span::raw(" ")], title.spans, vec![Span::raw(" ")]].concat();
         title = title.fg(Color::Cyan).bold();
 
         let block = Block::bordered()
-            .title(title)
+            .title(title.clone())
             .title_alignment(Alignment::Center)
             .border_type(BorderType::Rounded)
             .border_style(Style::default().fg(Color::Green))
             .padding(Padding::horizontal(1));
+
+        let popup_rect = self.popup_rect(area, &block, title.width() as u16);
+        f.render_widget(Clear, popup_rect);
 
         let inner = block.inner(popup_rect);
         let content_rect = inner.inner(Margin {
@@ -182,5 +200,44 @@ impl Component for MessagePopup<'_> {
             },
             _ => Ok(ComponentInputResult::NotHandled),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn popup_rect(title: &'static str, message: &str, area: Rect) -> Rect {
+        let popup = MessagePopup::new(title, message);
+        let block = Block::bordered().padding(Padding::horizontal(1));
+        let title_width = title.chars().count() as u16 + 2;
+
+        popup.popup_rect(area, &block, title_width)
+    }
+
+    #[test]
+    fn a_short_message_gets_a_popup_its_own_size() {
+        let rect = popup_rect("New", "one\ntwo", Rect::new(0, 0, 100, 40));
+
+        // The two lines plus the scroll indicator gaps and the border
+        assert_eq!(rect.height, 6);
+        // The widest line plus the padding and the border
+        assert_eq!(rect.width, 7);
+    }
+
+    #[test]
+    fn the_title_holds_the_popup_open() {
+        let rect = popup_rect("A rather long title", "hi", Rect::new(0, 0, 100, 40));
+
+        assert_eq!(rect.width, 23);
+    }
+
+    #[test]
+    fn a_long_message_stops_at_the_share_of_the_screen_we_take() {
+        let long = "x".repeat(200);
+        let rect = popup_rect("New", &vec![long; 100].join("\n"), Rect::new(0, 0, 100, 40));
+
+        assert_eq!(rect.width, 80);
+        assert_eq!(rect.height, 32);
     }
 }

--- a/src/ui/utils.rs
+++ b/src/ui/utils.rs
@@ -17,6 +17,7 @@ use ratatui::style::Color;
 use ratatui::style::Stylize;
 use ratatui::text::Line;
 use ratatui::text::Text;
+use ratatui::widgets::Block;
 
 use crate::env::JJLayout;
 
@@ -167,6 +168,17 @@ pub fn centered_rect_line_height(r: Rect, percent_x: u16, lines_y: u16) -> Rect 
             Constraint::Percentage((100 - percent_x) / 2),
         ])
         .split(popup_layout[1])[1]
+}
+
+/// How much wider and taller than its contents a `block` is, in the `area` it
+/// has to draw itself in. Its border is not all of it, it also pads.
+pub fn chrome(block: &Block, area: Rect) -> [u16; 2] {
+    let inner = block.inner(area);
+
+    [
+        area.width.saturating_sub(inner.width),
+        area.height.saturating_sub(inner.height),
+    ]
 }
 
 /// Center a rect of fixed width and height within an outside rect

--- a/src/ui/utils/large_string.rs
+++ b/src/ui/utils/large_string.rs
@@ -15,6 +15,32 @@ pub struct LargeString {
     content: String,
     /// First byte of each line in content
     line_start: Vec<usize>,
+    /// Characters in the widest line
+    width: usize,
+}
+
+/// The characters `line` puts on screen, leaving out its terminator and
+/// any ANSI escape sequences.
+fn line_width(line: &str) -> usize {
+    let mut width = 0;
+    let mut chars = line.chars();
+    while let Some(c) = chars.next() {
+        match c {
+            '\x1b' => {
+                // Past the introducer, everything up to and including the
+                // first character in 0x40..=0x7e belongs to the sequence.
+                chars.next();
+                for c in chars.by_ref() {
+                    if ('\x40'..='\x7e').contains(&c) {
+                        break;
+                    }
+                }
+            }
+            '\n' | '\r' => {}
+            _ => width += 1,
+        }
+    }
+    width
 }
 
 impl LargeString {
@@ -43,15 +69,27 @@ impl LargeString {
             i += 1;
         }
         // Create object
+        let width = line_start
+            .iter()
+            .zip(line_start.iter().skip(1).chain([&content.len()]))
+            .map(|(&start, &end)| line_width(&content[start..end]))
+            .max()
+            .unwrap_or(0);
         Self {
             content,
             line_start,
+            width,
         }
     }
 
     /// Number of lines in content
     pub fn lines(&self) -> usize {
         self.line_start.len()
+    }
+
+    /// Characters in the widest line
+    pub fn width(&self) -> usize {
+        self.width
     }
 
     /// Render a range of lines of the content as Text
@@ -68,5 +106,23 @@ impl LargeString {
                 Text::from(format!("{}", err))
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn width_is_that_of_the_widest_line() {
+        assert_eq!(LargeString::new("ab\nabcd\nabc".to_owned()).width(), 4);
+        assert_eq!(LargeString::new("abcd\r\nab".to_owned()).width(), 4);
+        assert_eq!(LargeString::new(String::new()).width(), 0);
+    }
+
+    #[test]
+    fn width_leaves_out_ansi_escape_sequences() {
+        let colored = "\x1b[1;31mError\x1b[0m: nope".to_owned();
+        assert_eq!(LargeString::new(colored).width(), "Error: nope".len());
     }
 }


### PR DESCRIPTION
The popup always takes 80% of the screen in both directions, so a
one-line error sits alone in a mostly empty box, and its lines are
centered in a width that has nothing to do with them. We measure the
message instead and only grow to the old size where it does not fit.
Since the content is stored with its ANSI escape sequences intact, the
width has to be counted past those, which we do once when the string
is taken in rather than on every draw.