### PR TITLE
ui/dialog: Extract a choice popup and let the mouse drive it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The dedicated `Menu` key can now be used in keybindings, spelled `menu`
 - Keybinding to move the log tab selection to the parent commit (`-`), asking
   which one when a merge has more than one parent in the log view; parents
-  outside it are listed alongside but cannot be selected
+  outside it are listed alongside but cannot be selected. The popup takes the
+  mouse as well: the wheel scrolls it, a click picks a parent, and a click
+  outside dismisses it
 
 ### Changed
 

--- a/src/ui/dialog/choice.rs
+++ b/src/ui/dialog/choice.rs
@@ -33,8 +33,13 @@ use crate::ui::Component;
 use crate::ui::ComponentInputResult;
 use crate::ui::styles::create_popup_block;
 use crate::ui::utils::centered_rect;
+use crate::ui::utils::centered_rect_fixed;
+use crate::ui::utils::chrome;
 
 const HELP: &str = "j/k: scroll | Enter: select | Escape: cancel";
+
+/// The help line and the border it sits under
+const HELP_HEIGHT: u16 = 2;
 
 pub struct ChoicePopup<T> {
     title: &'static str,
@@ -80,6 +85,36 @@ impl<T> ChoicePopup<T> {
         ));
     }
 
+    /// Every row the list holds, pickable or not
+    fn rows(&self) -> impl Iterator<Item = &Line<'static>> {
+        self.items
+            .iter()
+            .map(|(label, _)| label)
+            .chain(self.footnote.iter())
+    }
+
+    /// Where to put the popup in `area`: centered, and no larger than the
+    /// list needs, up to the share of the screen we are willing to take.
+    fn popup_rect(&self, area: Rect, block: &Block) -> Rect {
+        let max = centered_rect(area, 50, 60);
+        let [extra_width, extra_height] = chrome(block, max);
+
+        let rows_width = self.rows().map(Line::width).max().unwrap_or(0) as u16;
+        // The title sits in the top border, padded by a space on either
+        // side and between the two corners.
+        let title_width = Line::raw(self.title).width() as u16 + 4;
+        let width = rows_width
+            .max(Line::raw(HELP).width() as u16)
+            .saturating_add(extra_width)
+            .max(title_width)
+            .min(max.width);
+        let height = (self.rows().count() as u16 + HELP_HEIGHT)
+            .saturating_add(extra_height)
+            .min(max.height);
+
+        centered_rect_fixed(area, width, height)
+    }
+
     fn close() -> Result<ComponentInputResult> {
         Ok(ComponentInputResult::HandledAction(
             AppAction::PopupCanceled,
@@ -102,21 +137,16 @@ impl<T> ChoicePopup<T> {
 impl<T: Clone> Component for ChoicePopup<T> {
     fn draw(&mut self, f: &mut Frame<'_>, area: Rect) -> Result<()> {
         let block = create_popup_block(self.title);
-        let area = centered_rect(area, 50, 60);
+        let area = self.popup_rect(area, &block);
         f.render_widget(Clear, area);
         f.render_widget(&block, area);
 
         let chunks = Layout::default()
             .direction(Direction::Vertical)
-            .constraints([Constraint::Fill(1), Constraint::Length(2)])
+            .constraints([Constraint::Fill(1), Constraint::Length(HELP_HEIGHT)])
             .split(block.inner(area));
 
-        let rows: Vec<Line<'_>> = self
-            .items
-            .iter()
-            .map(|(label, _)| label.clone())
-            .chain(self.footnote.iter().cloned())
-            .collect();
+        let rows: Vec<Line<'static>> = self.rows().cloned().collect();
         let list = List::new(rows)
             .scroll_padding(3)
             .highlight_style(Style::default().bg(self.config.highlight_color()));
@@ -204,6 +234,71 @@ mod tests {
         ));
 
         assert_eq!(rx.try_recv(), Ok(1));
+    }
+
+    #[test]
+    fn the_popup_is_no_larger_than_the_list() {
+        let (popup, _rx) = popup(3, 2);
+        let block = create_popup_block("Choose");
+
+        let rect = popup.popup_rect(Rect::new(0, 0, 100, 40), &block);
+
+        // The five rows, plus the popup border around them
+        assert_eq!(rect.height, 5 + HELP_HEIGHT + 2);
+        // The help line is wider than any row, and the popup borders and
+        // pads around it
+        assert_eq!(rect.width, Line::raw(HELP).width() as u16 + 4);
+    }
+
+    #[test]
+    fn a_row_wider_than_the_help_line_widens_the_popup() {
+        let (tx, _rx) = channel();
+        let label = "x".repeat(Line::raw(HELP).width() + 10);
+        let popup = ChoicePopup::new(
+            JjConfig::default(),
+            tx,
+            "Choose",
+            vec![(Line::raw(label.clone()), 0u8)],
+        );
+
+        let rect = popup.popup_rect(Rect::new(0, 0, 200, 40), &create_popup_block("Choose"));
+
+        assert_eq!(rect.width, label.len() as u16 + 4);
+    }
+
+    #[test]
+    fn a_long_list_stops_at_the_share_of_the_screen_we_take() {
+        let (popup, _rx) = popup(200, 0);
+
+        let rect = popup.popup_rect(Rect::new(0, 0, 100, 40), &create_popup_block("Choose"));
+
+        assert_eq!(rect.height, 24);
+    }
+
+    #[test]
+    fn a_wide_row_stops_at_the_share_of_the_screen_we_take() {
+        let (tx, _rx) = channel();
+        let popup = ChoicePopup::new(
+            JjConfig::default(),
+            tx,
+            "Choose",
+            vec![(Line::raw("x".repeat(200)), 0u8)],
+        );
+
+        let rect = popup.popup_rect(Rect::new(0, 0, 100, 40), &create_popup_block("Choose"));
+
+        assert_eq!(rect.width, 50);
+    }
+
+    #[test]
+    fn a_title_wider_than_the_rows_still_fits_between_the_corners() {
+        let (tx, _rx) = channel();
+        let title = "A rather wordy popup title that outgrows its help line";
+        let popup = ChoicePopup::new(JjConfig::default(), tx, title, vec![(Line::raw("x"), 0u8)]);
+
+        let rect = popup.popup_rect(Rect::new(0, 0, 200, 40), &create_popup_block(title));
+
+        assert_eq!(rect.width, title.len() as u16 + 4);
     }
 
     #[test]

--- a/src/ui/dialog/choice.rs
+++ b/src/ui/dialog/choice.rs
@@ -1,0 +1,220 @@
+/*! A popup that lists labelled choices and sends the one picked over a
+channel, leaving it to whoever put the popup up to act on it in its own
+`update`.
+*/
+
+use std::sync::mpsc::Sender;
+
+use anyhow::Result;
+use anyhow::anyhow;
+use ratatui::Frame;
+use ratatui::crossterm::event::Event;
+use ratatui::crossterm::event::KeyCode;
+use ratatui::layout::Alignment;
+use ratatui::layout::Constraint;
+use ratatui::layout::Direction;
+use ratatui::layout::Layout;
+use ratatui::layout::Rect;
+use ratatui::style::Color;
+use ratatui::style::Style;
+use ratatui::style::Stylize;
+use ratatui::text::Line;
+use ratatui::widgets::Block;
+use ratatui::widgets::BorderType;
+use ratatui::widgets::Borders;
+use ratatui::widgets::Clear;
+use ratatui::widgets::List;
+use ratatui::widgets::ListState;
+use ratatui::widgets::Paragraph;
+
+use crate::env::JjConfig;
+use crate::ui::AppAction;
+use crate::ui::Component;
+use crate::ui::ComponentInputResult;
+use crate::ui::styles::create_popup_block;
+use crate::ui::utils::centered_rect;
+
+const HELP: &str = "j/k: scroll | Enter: select | Escape: cancel";
+
+pub struct ChoicePopup<T> {
+    title: &'static str,
+    items: Vec<(Line<'static>, T)>,
+    /// Rows listed under the choices that cannot be picked
+    footnote: Vec<Line<'static>>,
+    list_state: ListState,
+    list_height: u16,
+    config: JjConfig,
+    tx: Sender<T>,
+}
+
+impl<T> ChoicePopup<T> {
+    pub fn new(
+        config: JjConfig,
+        tx: Sender<T>,
+        title: &'static str,
+        items: Vec<(Line<'static>, T)>,
+    ) -> Self {
+        Self {
+            title,
+            items,
+            footnote: vec![],
+            list_state: ListState::default().with_selected(Some(0)),
+            list_height: 0,
+            config,
+            tx,
+        }
+    }
+
+    pub fn footnote(mut self, footnote: Vec<Line<'static>>) -> Self {
+        self.footnote = footnote;
+        self
+    }
+
+    fn scroll(&mut self, delta: isize) {
+        self.list_state.select(Some(
+            self.list_state
+                .selected()
+                .map(|selected| selected.saturating_add_signed(delta))
+                .unwrap_or(0)
+                .min(self.items.len().saturating_sub(1)),
+        ));
+    }
+
+    fn close() -> Result<ComponentInputResult> {
+        Ok(ComponentInputResult::HandledAction(
+            AppAction::PopupCanceled,
+        ))
+    }
+
+    fn confirm(&self) -> Result<ComponentInputResult>
+    where
+        T: Clone,
+    {
+        if let Some((_, choice)) = self.list_state.selected().and_then(|i| self.items.get(i)) {
+            self.tx
+                .send(choice.clone())
+                .map_err(|_| anyhow!("Nothing is listening for the choice"))?;
+        }
+        Self::close()
+    }
+}
+
+impl<T: Clone> Component for ChoicePopup<T> {
+    fn draw(&mut self, f: &mut Frame<'_>, area: Rect) -> Result<()> {
+        let block = create_popup_block(self.title);
+        let area = centered_rect(area, 50, 60);
+        f.render_widget(Clear, area);
+        f.render_widget(&block, area);
+
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Fill(1), Constraint::Length(2)])
+            .split(block.inner(area));
+
+        let rows: Vec<Line<'_>> = self
+            .items
+            .iter()
+            .map(|(label, _)| label.clone())
+            .chain(self.footnote.iter().cloned())
+            .collect();
+        let list = List::new(rows)
+            .scroll_padding(3)
+            .highlight_style(Style::default().bg(self.config.highlight_color()));
+
+        f.render_stateful_widget(list, chunks[0], &mut self.list_state);
+        self.list_height = chunks[0].height;
+
+        let help = Paragraph::new(vec![HELP.into()])
+            .fg(Color::DarkGray)
+            .alignment(Alignment::Center)
+            .block(
+                Block::default()
+                    .borders(Borders::TOP)
+                    .border_type(BorderType::Rounded)
+                    .border_style(Style::default().fg(Color::DarkGray)),
+            );
+
+        f.render_widget(help, chunks[1]);
+        Ok(())
+    }
+
+    fn input(&mut self, event: Event) -> Result<ComponentInputResult> {
+        if let Event::Key(key) = event {
+            match key.code {
+                KeyCode::Char('j') | KeyCode::Down => self.scroll(1),
+                KeyCode::Char('k') | KeyCode::Up => self.scroll(-1),
+                KeyCode::Char('J') => self.scroll(self.list_height as isize / 2),
+                KeyCode::Char('K') => self.scroll((self.list_height as isize / 2).saturating_neg()),
+                KeyCode::Enter => return self.confirm(),
+                KeyCode::Char('q') | KeyCode::Esc => return Self::close(),
+                _ => {}
+            }
+        }
+        Ok(ComponentInputResult::Handled)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc::Receiver;
+    use std::sync::mpsc::channel;
+
+    use super::*;
+
+    fn popup(count: u8, footnote: usize) -> (ChoicePopup<u8>, Receiver<u8>) {
+        let (tx, rx) = channel();
+        let items = (0..count)
+            .map(|i| (Line::raw(format!("item {i}")), i))
+            .collect();
+        let popup = ChoicePopup::new(JjConfig::default(), tx, "Choose", items)
+            .footnote(vec![Line::raw("footnote"); footnote]);
+
+        (popup, rx)
+    }
+
+    fn press(popup: &mut ChoicePopup<u8>, key: KeyCode) -> ComponentInputResult {
+        popup
+            .input(Event::Key(key.into()))
+            .expect("the popup handles key presses")
+    }
+
+    #[test]
+    fn scrolling_is_clamped_to_the_choices() {
+        let (mut popup, _rx) = popup(3, 2);
+
+        for _ in 0..5 {
+            press(&mut popup, KeyCode::Char('j'));
+        }
+        assert_eq!(popup.list_state.selected(), Some(2));
+
+        for _ in 0..5 {
+            press(&mut popup, KeyCode::Char('k'));
+        }
+        assert_eq!(popup.list_state.selected(), Some(0));
+    }
+
+    #[test]
+    fn enter_sends_the_selected_choice() {
+        let (mut popup, rx) = popup(3, 0);
+
+        press(&mut popup, KeyCode::Char('j'));
+        assert!(matches!(
+            press(&mut popup, KeyCode::Enter),
+            ComponentInputResult::HandledAction(AppAction::PopupCanceled)
+        ));
+
+        assert_eq!(rx.try_recv(), Ok(1));
+    }
+
+    #[test]
+    fn cancelling_sends_no_choice() {
+        let (mut popup, rx) = popup(3, 0);
+
+        assert!(matches!(
+            press(&mut popup, KeyCode::Esc),
+            ComponentInputResult::HandledAction(AppAction::PopupCanceled)
+        ));
+
+        assert!(rx.try_recv().is_err());
+    }
+}

--- a/src/ui/dialog/choice.rs
+++ b/src/ui/dialog/choice.rs
@@ -10,10 +10,13 @@ use anyhow::anyhow;
 use ratatui::Frame;
 use ratatui::crossterm::event::Event;
 use ratatui::crossterm::event::KeyCode;
+use ratatui::crossterm::event::MouseButton;
+use ratatui::crossterm::event::MouseEventKind;
 use ratatui::layout::Alignment;
 use ratatui::layout::Constraint;
 use ratatui::layout::Direction;
 use ratatui::layout::Layout;
+use ratatui::layout::Position;
 use ratatui::layout::Rect;
 use ratatui::style::Color;
 use ratatui::style::Style;
@@ -47,7 +50,10 @@ pub struct ChoicePopup<T> {
     /// Rows listed under the choices that cannot be picked
     footnote: Vec<Line<'static>>,
     list_state: ListState,
-    list_height: u16,
+    /// Whole popup area, updated on every draw
+    popup_area: Rect,
+    /// List area inside the popup, updated on every draw
+    list_area: Rect,
     config: JjConfig,
     tx: Sender<T>,
 }
@@ -64,7 +70,8 @@ impl<T> ChoicePopup<T> {
             items,
             footnote: vec![],
             list_state: ListState::default().with_selected(Some(0)),
-            list_height: 0,
+            popup_area: Rect::ZERO,
+            list_area: Rect::ZERO,
             config,
             tx,
         }
@@ -115,6 +122,18 @@ impl<T> ChoicePopup<T> {
         centered_rect_fixed(area, width, height)
     }
 
+    /// The choice `pos` points at, if it points at one at all. The
+    /// footnote rows are listed below the choices and cannot be picked.
+    fn item_at(&self, pos: Position) -> Option<usize> {
+        if !self.list_area.contains(pos) {
+            return None;
+        }
+        let row = (pos.y - self.list_area.y) as usize;
+        let index = self.list_state.offset() + row;
+
+        (index < self.items.len()).then_some(index)
+    }
+
     fn close() -> Result<ComponentInputResult> {
         Ok(ComponentInputResult::HandledAction(
             AppAction::PopupCanceled,
@@ -138,6 +157,7 @@ impl<T: Clone> Component for ChoicePopup<T> {
     fn draw(&mut self, f: &mut Frame<'_>, area: Rect) -> Result<()> {
         let block = create_popup_block(self.title);
         let area = self.popup_rect(area, &block);
+        self.popup_area = area;
         f.render_widget(Clear, area);
         f.render_widget(&block, area);
 
@@ -145,6 +165,7 @@ impl<T: Clone> Component for ChoicePopup<T> {
             .direction(Direction::Vertical)
             .constraints([Constraint::Fill(1), Constraint::Length(HELP_HEIGHT)])
             .split(block.inner(area));
+        self.list_area = chunks[0];
 
         let rows: Vec<Line<'static>> = self.rows().cloned().collect();
         let list = List::new(rows)
@@ -152,7 +173,6 @@ impl<T: Clone> Component for ChoicePopup<T> {
             .highlight_style(Style::default().bg(self.config.highlight_color()));
 
         f.render_stateful_widget(list, chunks[0], &mut self.list_state);
-        self.list_height = chunks[0].height;
 
         let help = Paragraph::new(vec![HELP.into()])
             .fg(Color::DarkGray)
@@ -169,16 +189,39 @@ impl<T: Clone> Component for ChoicePopup<T> {
     }
 
     fn input(&mut self, event: Event) -> Result<ComponentInputResult> {
-        if let Event::Key(key) = event {
-            match key.code {
+        match event {
+            Event::Key(key) => match key.code {
                 KeyCode::Char('j') | KeyCode::Down => self.scroll(1),
                 KeyCode::Char('k') | KeyCode::Up => self.scroll(-1),
-                KeyCode::Char('J') => self.scroll(self.list_height as isize / 2),
-                KeyCode::Char('K') => self.scroll((self.list_height as isize / 2).saturating_neg()),
+                KeyCode::Char('J') => self.scroll(self.list_area.height as isize / 2),
+                KeyCode::Char('K') => {
+                    self.scroll((self.list_area.height as isize / 2).saturating_neg())
+                }
                 KeyCode::Enter => return self.confirm(),
                 KeyCode::Char('q') | KeyCode::Esc => return Self::close(),
                 _ => {}
+            },
+            // Where the popup sits is only known once it has been drawn,
+            // and events are handled in batches without a draw between
+            // them, so the one that opened us may be in this very batch.
+            Event::Mouse(mouse) if !self.popup_area.is_empty() => {
+                let pos = Position::new(mouse.column, mouse.row);
+                match mouse.kind {
+                    MouseEventKind::ScrollUp => self.scroll(-1),
+                    MouseEventKind::ScrollDown => self.scroll(1),
+                    MouseEventKind::Down(MouseButton::Left) => {
+                        if !self.popup_area.contains(pos) {
+                            return Self::close();
+                        }
+                        if let Some(index) = self.item_at(pos) {
+                            self.list_state.select(Some(index));
+                            return self.confirm();
+                        }
+                    }
+                    _ => {}
+                }
             }
+            _ => {}
         }
         Ok(ComponentInputResult::Handled)
     }
@@ -188,6 +231,11 @@ impl<T: Clone> Component for ChoicePopup<T> {
 mod tests {
     use std::sync::mpsc::Receiver;
     use std::sync::mpsc::channel;
+
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use ratatui::crossterm::event::KeyModifiers;
+    use ratatui::crossterm::event::MouseEvent;
 
     use super::*;
 
@@ -234,6 +282,155 @@ mod tests {
         ));
 
         assert_eq!(rx.try_recv(), Ok(1));
+    }
+
+    fn mouse(
+        popup: &mut ChoicePopup<u8>,
+        kind: MouseEventKind,
+        column: u16,
+        row: u16,
+    ) -> ComponentInputResult {
+        popup
+            .input(Event::Mouse(MouseEvent {
+                kind,
+                column,
+                row,
+                modifiers: KeyModifiers::NONE,
+            }))
+            .expect("the popup handles mouse events")
+    }
+
+    fn click(popup: &mut ChoicePopup<u8>, column: u16, row: u16) -> ComponentInputResult {
+        mouse(popup, MouseEventKind::Down(MouseButton::Left), column, row)
+    }
+
+    /// A wheel notch over the middle of a popup drawn by `draw`
+    fn wheel(popup: &mut ChoicePopup<u8>, kind: MouseEventKind) -> ComponentInputResult {
+        mouse(popup, kind, 50, 20)
+    }
+
+    /// Put the popup on a 100x40 screen, so that it knows where it is
+    fn draw(popup: &mut ChoicePopup<u8>) {
+        Terminal::new(TestBackend::new(100, 40))
+            .expect("the test backend")
+            .draw(|f| popup.draw(f, f.area()).expect("the popup draws"))
+            .expect("the frame is drawn");
+    }
+
+    #[test]
+    fn the_hit_test_looks_where_the_popup_was_drawn() {
+        let (mut popup, _rx) = popup(3, 2);
+
+        draw(&mut popup);
+
+        // Five rows and the help line under its own border, centered
+        assert_eq!(popup.popup_area, Rect::new(26, 15, 48, 9));
+        // Inside the popup border and its padding, above the help line
+        assert_eq!(popup.list_area, Rect::new(28, 16, 44, 5));
+    }
+
+    #[test]
+    fn clicking_a_choice_sends_it() {
+        let (mut popup, rx) = popup(3, 2);
+        draw(&mut popup);
+
+        // The third row of the list
+        assert!(matches!(
+            click(&mut popup, 30, 18),
+            ComponentInputResult::HandledAction(AppAction::PopupCanceled)
+        ));
+
+        assert_eq!(rx.try_recv(), Ok(2));
+    }
+
+    #[test]
+    fn clicking_a_choice_in_a_scrolled_list_sends_it() {
+        let (mut popup, rx) = popup(30, 0);
+        draw(&mut popup);
+        for _ in 0..29 {
+            press(&mut popup, KeyCode::Char('j'));
+        }
+        // The list is scrolled only when it is drawn again
+        draw(&mut popup);
+        assert_eq!(popup.list_state.offset(), 10);
+
+        // The topmost row on show, which is the eleventh choice
+        let top = popup.list_area.y;
+        assert!(matches!(
+            click(&mut popup, 30, top),
+            ComponentInputResult::HandledAction(AppAction::PopupCanceled)
+        ));
+
+        assert_eq!(rx.try_recv(), Ok(10));
+    }
+
+    #[test]
+    fn clicking_the_footnote_sends_nothing() {
+        let (mut popup, rx) = popup(3, 2);
+        draw(&mut popup);
+
+        // The first row below the three choices
+        assert!(matches!(
+            click(&mut popup, 30, 19),
+            ComponentInputResult::Handled
+        ));
+
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn clicking_the_help_line_sends_nothing_and_stays_open() {
+        let (mut popup, rx) = popup(3, 2);
+        draw(&mut popup);
+
+        // Below the list, inside the popup
+        assert!(matches!(
+            click(&mut popup, 30, 21),
+            ComponentInputResult::Handled
+        ));
+
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn clicking_outside_the_popup_cancels() {
+        let (mut popup, rx) = popup(3, 0);
+        draw(&mut popup);
+
+        assert!(matches!(
+            click(&mut popup, 0, 0),
+            ComponentInputResult::HandledAction(AppAction::PopupCanceled)
+        ));
+
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn the_wheel_moves_the_selection_over_the_choices() {
+        let (mut popup, _rx) = popup(3, 2);
+        draw(&mut popup);
+
+        for _ in 0..5 {
+            wheel(&mut popup, MouseEventKind::ScrollDown);
+        }
+        assert_eq!(popup.list_state.selected(), Some(2));
+
+        for _ in 0..5 {
+            wheel(&mut popup, MouseEventKind::ScrollUp);
+        }
+        assert_eq!(popup.list_state.selected(), Some(0));
+    }
+
+    #[test]
+    fn clicking_before_the_popup_is_drawn_does_not_cancel_it() {
+        let (mut popup, rx) = popup(3, 0);
+
+        assert!(matches!(
+            click(&mut popup, 0, 0),
+            ComponentInputResult::Handled
+        ));
+
+        assert!(rx.try_recv().is_err());
     }
 
     #[test]

--- a/src/ui/dialog/mod.rs
+++ b/src/ui/dialog/mod.rs
@@ -10,6 +10,7 @@ until it sends [`AppAction::PopupDone`](crate::ui::AppAction) or
 
 mod bookmark_name;
 mod bookmark_set;
+mod choice;
 mod command;
 mod describe;
 mod help;
@@ -20,10 +21,11 @@ mod rebase;
 
 pub use bookmark_name::BookmarkNamePopup;
 pub use bookmark_set::BookmarkSetPopup;
+pub use choice::ChoicePopup;
 pub use command::CommandPopup;
 pub use describe::DescribePopup;
 pub use help::HelpPopup;
 pub use loader::LoaderPopup;
 pub use message::MessagePopup;
-pub use parent_select::ParentSelectPopup;
+pub use parent_select::parent_select;
 pub use rebase::RebasePopup;

--- a/src/ui/dialog/parent_select.rs
+++ b/src/ui/dialog/parent_select.rs
@@ -1,32 +1,18 @@
-use anyhow::Result;
-use ratatui::Frame;
-use ratatui::crossterm::event::Event;
-use ratatui::crossterm::event::KeyCode;
-use ratatui::layout::Alignment;
-use ratatui::layout::Constraint;
-use ratatui::layout::Direction;
-use ratatui::layout::Layout;
-use ratatui::layout::Rect;
+/*! The parents of a change, as the choices for moving the log's
+selection onto one of them.
+*/
+
+use std::sync::mpsc::Sender;
+
 use ratatui::style::Color;
 use ratatui::style::Style;
-use ratatui::style::Stylize;
 use ratatui::text::Line;
 use ratatui::text::Span;
-use ratatui::widgets::Block;
-use ratatui::widgets::BorderType;
-use ratatui::widgets::Borders;
-use ratatui::widgets::Clear;
-use ratatui::widgets::List;
-use ratatui::widgets::ListState;
-use ratatui::widgets::Paragraph;
 
+use crate::commander::log::Head;
 use crate::commander::log::Parent;
 use crate::env::JjConfig;
-use crate::ui::AppAction;
-use crate::ui::Component;
-use crate::ui::ComponentInputResult;
-use crate::ui::styles::create_popup_block;
-use crate::ui::utils::centered_rect;
+use crate::ui::dialog::ChoicePopup;
 
 /// The row a parent gets in the list, dimmed when it cannot be selected.
 fn parent_line(parent: &Parent, dimmed: bool) -> Line<'static> {
@@ -47,131 +33,52 @@ fn parent_line(parent: &Parent, dimmed: bool) -> Line<'static> {
     Line::from(vec![Span::styled(change_id, change_id_style), description])
 }
 
-pub struct ParentSelectPopup {
-    parents: Vec<Parent>,
-    /// The parents the log does not hold. We list them so that the merge
-    /// is shown in full, but they cannot be selected.
-    out_of_view: Vec<Parent>,
-    list_state: ListState,
-    list_height: u16,
+/// A popup offering the `parents` to pick from. Those `out_of_view` are
+/// listed underneath so that the merge is shown in full, but cannot be
+/// picked.
+pub fn parent_select(
     config: JjConfig,
-}
+    tx: Sender<Head>,
+    parents: &[Parent],
+    out_of_view: &[Parent],
+) -> ChoicePopup<Head> {
+    let items = parents
+        .iter()
+        .map(|parent| (parent_line(parent, false), parent.head.clone()))
+        .collect();
+    let popup = ChoicePopup::new(config, tx, "Select parent", items);
 
-impl ParentSelectPopup {
-    pub fn new(parents: Vec<Parent>, out_of_view: Vec<Parent>, config: JjConfig) -> Self {
-        Self {
-            parents,
-            out_of_view,
-            list_state: ListState::default().with_selected(Some(0)),
-            list_height: 0,
-            config,
-        }
+    if out_of_view.is_empty() {
+        return popup;
     }
 
-    fn scroll(&mut self, scroll: isize) {
-        self.list_state.select(Some(
-            self.list_state
-                .selected()
-                .map(|selected| selected.saturating_add_signed(scroll))
-                .unwrap_or(0)
-                .min(self.parents.len().saturating_sub(1)),
-        ));
-    }
-}
+    let mut footnote = vec![
+        Line::default(),
+        Line::from(Span::styled(
+            " ── Not in the log view ──",
+            Style::default().fg(Color::DarkGray),
+        )),
+    ];
+    footnote.extend(out_of_view.iter().map(|parent| parent_line(parent, true)));
 
-impl Component for ParentSelectPopup {
-    fn draw(&mut self, f: &mut Frame<'_>, area: Rect) -> Result<()> {
-        let block = create_popup_block("Select parent");
-        let area = centered_rect(area, 50, 60);
-        f.render_widget(Clear, area);
-        f.render_widget(&block, area);
-
-        let popup_chunks = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([Constraint::Fill(1), Constraint::Length(2)])
-            .split(block.inner(area));
-
-        let mut list_items: Vec<Line<'_>> = self
-            .parents
-            .iter()
-            .map(|parent| parent_line(parent, false))
-            .collect();
-
-        if !self.out_of_view.is_empty() {
-            list_items.push(Line::default());
-            list_items.push(Line::from(Span::styled(
-                " ── Not in the log view ──",
-                Style::default().fg(Color::DarkGray),
-            )));
-            list_items.extend(
-                self.out_of_view
-                    .iter()
-                    .map(|parent| parent_line(parent, true)),
-            );
-        }
-
-        let list = List::new(list_items)
-            .scroll_padding(3)
-            .highlight_style(Style::default().bg(self.config.highlight_color()));
-
-        f.render_stateful_widget(list, popup_chunks[0], &mut self.list_state);
-        self.list_height = popup_chunks[0].height;
-
-        let help = Paragraph::new(vec!["j/k: scroll | Enter: select | Escape: cancel".into()])
-            .fg(Color::DarkGray)
-            .alignment(Alignment::Center)
-            .block(
-                Block::default()
-                    .borders(Borders::TOP)
-                    .border_type(BorderType::Rounded)
-                    .border_style(Style::default().fg(Color::DarkGray)),
-            );
-
-        f.render_widget(help, popup_chunks[1]);
-        Ok(())
-    }
-
-    fn input(&mut self, event: Event) -> Result<ComponentInputResult> {
-        if let Event::Key(key) = event {
-            match key.code {
-                KeyCode::Char('j') | KeyCode::Down => self.scroll(1),
-                KeyCode::Char('k') | KeyCode::Up => self.scroll(-1),
-                KeyCode::Char('J') => self.scroll(self.list_height as isize / 2),
-                KeyCode::Char('K') => self.scroll((self.list_height as isize / 2).saturating_neg()),
-                KeyCode::Enter => {
-                    if let Some(parent) = self
-                        .list_state
-                        .selected()
-                        .and_then(|index| self.parents.get(index))
-                    {
-                        // Moving the selection leaves the repo as it is, so
-                        // we take the popup down without a refresh.
-                        return Ok(ComponentInputResult::HandledAction(AppAction::Multiple(
-                            vec![
-                                AppAction::PopupCanceled,
-                                AppAction::ViewLog(parent.head.clone()),
-                            ],
-                        )));
-                    }
-                }
-                KeyCode::Char('q') | KeyCode::Esc => {
-                    return Ok(ComponentInputResult::HandledAction(
-                        AppAction::PopupCanceled,
-                    ));
-                }
-                _ => {}
-            }
-        }
-        Ok(ComponentInputResult::Handled)
-    }
+    popup.footnote(footnote)
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::mpsc::Receiver;
+    use std::sync::mpsc::channel;
+
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use ratatui::buffer::Buffer;
+    use ratatui::crossterm::event::Event;
+    use ratatui::crossterm::event::KeyCode;
+
     use super::*;
     use crate::commander::ids::ChangeId;
     use crate::commander::ids::CommitId;
-    use crate::commander::log::Head;
+    use crate::ui::Component;
 
     fn parents(range: std::ops::Range<usize>) -> Vec<Parent> {
         range
@@ -187,60 +94,115 @@ mod tests {
             .collect()
     }
 
-    fn popup(count: usize, out_of_view: usize) -> ParentSelectPopup {
-        ParentSelectPopup::new(
-            parents(0..count),
-            parents(count..count + out_of_view),
-            JjConfig::default(),
+    fn popup(in_view: usize, out_of_view: usize) -> (ChoicePopup<Head>, Receiver<Head>) {
+        let (tx, rx) = channel();
+        let all = parents(0..in_view + out_of_view);
+
+        (
+            parent_select(JjConfig::default(), tx, &all[..in_view], &all[in_view..]),
+            rx,
         )
     }
 
-    fn press(popup: &mut ParentSelectPopup, key: KeyCode) -> ComponentInputResult {
+    /// What the popup puts on a 100x40 screen
+    fn render(popup: &mut ChoicePopup<Head>) -> Buffer {
+        let mut terminal = Terminal::new(TestBackend::new(100, 40)).expect("the test backend");
+        terminal
+            .draw(|f| popup.draw(f, f.area()).expect("the popup draws"))
+            .expect("the frame is drawn");
+
+        terminal.backend().buffer().clone()
+    }
+
+    fn rows(buffer: &Buffer) -> Vec<String> {
+        (0..buffer.area.height)
+            .map(|y| {
+                (0..buffer.area.width)
+                    .map(|x| buffer[(x, y)].symbol())
+                    .collect::<String>()
+            })
+            .collect()
+    }
+
+    fn press(popup: &mut ChoicePopup<Head>, key: KeyCode) {
         popup
             .input(Event::Key(key.into()))
-            .expect("the popup handles key presses")
+            .expect("the popup handles key presses");
     }
 
     #[test]
-    fn scrolling_is_clamped_to_the_parents_in_view() {
-        let mut popup = popup(3, 2);
+    fn picking_a_parent_sends_its_head() {
+        let (mut popup, rx) = popup(3, 0);
+
+        press(&mut popup, KeyCode::Char('j'));
+        press(&mut popup, KeyCode::Enter);
+
+        assert_eq!(
+            rx.try_recv().map(|head| head.change_id.0),
+            Ok("change1".into())
+        );
+    }
+
+    #[test]
+    fn parents_out_of_view_are_listed_below_a_separator() {
+        let (mut popup, _rx) = popup(2, 1);
+
+        let buffer = render(&mut popup);
+        let listed: Vec<String> = rows(&buffer)
+            .into_iter()
+            .filter(|row| row.contains("change") || row.contains("Not in the log view"))
+            .collect();
+
+        assert!(listed[0].contains("change0"), "{listed:?}");
+        assert!(listed[1].contains("change1"), "{listed:?}");
+        assert!(
+            listed[2].contains("── Not in the log view ──"),
+            "{listed:?}"
+        );
+        assert!(listed[3].contains("change2"), "{listed:?}");
+    }
+
+    #[test]
+    fn parents_out_of_view_cannot_be_picked() {
+        let (mut popup, rx) = popup(2, 2);
 
         for _ in 0..5 {
             press(&mut popup, KeyCode::Char('j'));
         }
-        assert_eq!(popup.list_state.selected(), Some(2));
+        press(&mut popup, KeyCode::Enter);
 
-        for _ in 0..5 {
-            press(&mut popup, KeyCode::Char('k'));
-        }
-        assert_eq!(popup.list_state.selected(), Some(0));
+        assert_eq!(
+            rx.try_recv().map(|head| head.change_id.0),
+            Ok("change1".into())
+        );
     }
 
     #[test]
-    fn enter_shows_the_selected_parent_in_the_log() {
-        let mut popup = popup(3, 0);
+    fn nothing_is_listed_below_the_parents_when_they_are_all_in_view() {
+        let (mut popup, _rx) = popup(2, 0);
 
-        press(&mut popup, KeyCode::Char('j'));
+        let buffer = render(&mut popup);
 
-        let ComponentInputResult::HandledAction(AppAction::Multiple(actions)) =
-            press(&mut popup, KeyCode::Enter)
-        else {
-            panic!("selecting a parent should take the popup down and show it");
-        };
-        let [AppAction::PopupCanceled, AppAction::ViewLog(head)] = actions.as_slice() else {
-            panic!("selecting a parent should take the popup down and show it");
-        };
-
-        assert_eq!(head.commit_id, CommitId("commit1".to_owned()));
+        assert!(
+            !rows(&buffer)
+                .iter()
+                .any(|row| row.contains("Not in the log view"))
+        );
     }
 
     #[test]
-    fn cancelling_selects_no_parent() {
-        let mut popup = popup(3, 0);
+    fn a_parent_without_a_description_says_so() {
+        let (tx, _rx) = channel();
+        let mut parent = parents(0..1);
+        parent[0].description = String::new();
+        let mut popup = parent_select(JjConfig::default(), tx, &parent, &[]);
 
-        assert!(matches!(
-            press(&mut popup, KeyCode::Esc),
-            ComponentInputResult::HandledAction(AppAction::PopupCanceled)
-        ));
+        let buffer = render(&mut popup);
+
+        assert!(
+            rows(&buffer)
+                .iter()
+                .any(|row| row.contains("change0 (no description)"))
+        );
     }
 }

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -38,8 +38,8 @@ use crate::ui::dialog::BookmarkSetPopup;
 use crate::ui::dialog::DescribePopup;
 use crate::ui::dialog::LoaderPopup;
 use crate::ui::dialog::MessagePopup;
-use crate::ui::dialog::ParentSelectPopup;
 use crate::ui::dialog::RebasePopup;
+use crate::ui::dialog::parent_select;
 use crate::ui::panel::CommitShowPanel;
 use crate::ui::panel::LogPanel;
 use crate::ui::panel::MouseInput;
@@ -74,6 +74,9 @@ pub struct LogTab<'a> {
     popup: ConfirmDialogState,
     popup_tx: std::sync::mpsc::Sender<Listener>,
     popup_rx: std::sync::mpsc::Receiver<Listener>,
+
+    goto_parent_tx: std::sync::mpsc::Sender<Head>,
+    goto_parent_rx: std::sync::mpsc::Receiver<Head>,
 
     describe_after_new: bool,
 
@@ -113,6 +116,7 @@ impl<'a> LogTab<'a> {
     #[instrument(level = "info", name = "Initializing log tab", parent = None, skip(background_tasks))]
     pub fn new(background_tasks: BackgroundTasks, head: Head) -> Self {
         let (popup_tx, popup_rx) = std::sync::mpsc::channel();
+        let (goto_parent_tx, goto_parent_rx) = std::sync::mpsc::channel();
 
         let mut keybinds = LogTabKeybinds::default();
         let mut details_keybinds = DetailsPanelKeybinds::default();
@@ -142,6 +146,9 @@ impl<'a> LogTab<'a> {
             popup: ConfirmDialogState::default(),
             popup_tx,
             popup_rx,
+
+            goto_parent_tx,
+            goto_parent_rx,
 
             describe_after_new: false,
 
@@ -360,10 +367,11 @@ impl<'a> LogTab<'a> {
                 Ok(ComponentInputResult::Handled)
             }
             _ => Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
-                Box::new(ParentSelectPopup::new(
-                    parents,
-                    out_of_view,
+                Box::new(parent_select(
                     self.config.clone(),
+                    self.goto_parent_tx.clone(),
+                    &parents,
+                    &out_of_view,
                 )),
             ))),
         }
@@ -673,6 +681,12 @@ impl Component for LogTab<'_> {
                 }
                 _ => {}
             }
+        }
+
+        // Moving the selection leaves the repo as it is, so we do not
+        // ask for a refresh.
+        if let Ok(head) = self.goto_parent_rx.try_recv() {
+            return Ok(Some(AppAction::ViewLog(head)));
         }
 
         Ok(None)


### PR DESCRIPTION
Picking one of a list of labelled things and telling the tab which one
was picked is not specific to parents, so the next dialog that wants it
would have to copy the parent-select popup wholesale. Lift it into a
`ChoicePopup` that carries whatever type its owner wants back and
reports over a channel, leaving `parent_select` with just the
presentation of a parent, then size the popup to what it lists and let
the wheel and a click drive it the way the list panes behind it already
do.
