### PR TITLE
log: Let the new-change dialog pick the insertion point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   outside it are listed alongside but cannot be selected. The popup takes the
   mouse as well: the wheel scrolls it, a click picks a parent, and a click
   outside dismisses it
+- The new-change dialog now asks where to put the change, so it can also be
+  inserted before or after the selected one rather than only as its child
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ See all key mappings for the current tab with `?`.
 - Display different revset with `r` (`jj log -r`)
 - Change details panel diff format between color words (default) and Git (and diff tool if set) with `w`
 - Toggle details panel wrapping with `W`
-- Create new change after highlighted change with `n` (`jj new`)
+- Create new change with `n`, choosing whether it becomes a child of the
+  highlighted change or is spliced in before or after it
+  (`jj new [--insert-before|--insert-after]`)
   - Create new change and describe with `N` (`jj new -m`)
 - Edit highlighted change with `e` (`jj edit`)
   - Edit highlighted change ignoring immutability with `E` (`jj edit --ignore-immutable`)

--- a/src/commander/jj.rs
+++ b/src/commander/jj.rs
@@ -15,17 +15,42 @@ use crate::commander::bookmarks::Bookmark;
 use crate::commander::ids::CommitId;
 use crate::commander::revset::Revset;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NewInsertMode {
+    /// `jj new <rev>` — leaves children of rev in place.
+    Child,
+    /// `jj new --insert-after <rev>` — splices between rev and its children.
+    After,
+    /// `jj new --insert-before <rev>` — splices between rev and its parents.
+    Before,
+}
+
 impl Commander {
     /// Create a new change. Maps to `jj new <revset>`.
     pub fn run_new(&self, revset: impl Into<Revset>) -> Result<()> {
-        self.run_new_inner(revset.into().as_str())
+        self.run_new_with_insert(revset, NewInsertMode::Child)
+    }
+
+    /// Like [`Self::run_new()`], but with an explicit insertion mode.
+    pub fn run_new_with_insert(
+        &self,
+        revset: impl Into<Revset>,
+        insert: NewInsertMode,
+    ) -> Result<()> {
+        self.run_new_inner(revset.into().as_str(), insert)
     }
 
     #[instrument(level = "trace", name = "run_new", skip(self))]
-    fn run_new_inner(&self, revset: &str) -> Result<()> {
-        self.jj(["new", revset])
-            .run_void()
-            .context("Failed executing jj new")
+    fn run_new_inner(&self, revset: &str, insert: NewInsertMode) -> Result<()> {
+        let mut args = vec!["new"];
+        match insert {
+            NewInsertMode::Child => {}
+            NewInsertMode::After => args.push("--insert-after"),
+            NewInsertMode::Before => args.push("--insert-before"),
+        }
+        args.push(revset);
+
+        self.jj(args).run_void().context("Failed executing jj new")
     }
 
     /// Duplicate a change. Maps to `jj duplicate`
@@ -251,6 +276,8 @@ impl Commander {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commander::ids::ChangeId;
+    use crate::commander::log::Head;
     use crate::commander::tests::TestRepo;
 
     #[test]
@@ -260,6 +287,74 @@ mod tests {
         let head = test_repo.commander.get_current_head()?;
         test_repo.commander.run_new(&head.commit_id)?;
         assert_ne!(head, test_repo.commander.get_current_head()?);
+
+        Ok(())
+    }
+
+    /// A repo holding a described `base` with a described `child` on top,
+    /// so that neither is abandoned for being empty when we move away.
+    fn chain_of_two(test_repo: &TestRepo) -> Result<(Head, Head)> {
+        let commander = &test_repo.commander;
+
+        let base = commander.get_current_head()?;
+        commander.run_describe(&base.commit_id, "base")?;
+        commander.run_new(&base.commit_id)?;
+        let child = commander.get_current_head()?;
+        commander.run_describe(&child.commit_id, "child")?;
+
+        Ok((base, child))
+    }
+
+    fn parent_change_id(test_repo: &TestRepo, head: &Head) -> Result<ChangeId> {
+        let head = test_repo.commander.get_head_latest(head)?;
+        Ok(test_repo
+            .commander
+            .get_commit_parent(&head.commit_id)?
+            .change_id)
+    }
+
+    #[test]
+    fn run_new_insert_after() -> Result<()> {
+        let test_repo = TestRepo::new()?;
+        let (base, child) = chain_of_two(&test_repo)?;
+
+        test_repo
+            .commander
+            .run_new_with_insert(&base.commit_id, NewInsertMode::After)?;
+
+        let inserted = test_repo.commander.get_current_head()?;
+        assert_eq!(parent_change_id(&test_repo, &inserted)?, base.change_id);
+        assert_eq!(parent_change_id(&test_repo, &child)?, inserted.change_id);
+
+        Ok(())
+    }
+
+    #[test]
+    fn run_new_insert_before() -> Result<()> {
+        let test_repo = TestRepo::new()?;
+        let (base, child) = chain_of_two(&test_repo)?;
+
+        test_repo
+            .commander
+            .run_new_with_insert(&child.commit_id, NewInsertMode::Before)?;
+
+        let inserted = test_repo.commander.get_current_head()?;
+        assert_eq!(parent_change_id(&test_repo, &inserted)?, base.change_id);
+        assert_eq!(parent_change_id(&test_repo, &child)?, inserted.change_id);
+
+        Ok(())
+    }
+
+    #[test]
+    fn run_new_leaves_the_children_in_place() -> Result<()> {
+        let test_repo = TestRepo::new()?;
+        let (base, child) = chain_of_two(&test_repo)?;
+
+        test_repo.commander.run_new(&base.commit_id)?;
+
+        let sibling = test_repo.commander.get_current_head()?;
+        assert_eq!(parent_change_id(&test_repo, &sibling)?, base.change_id);
+        assert_eq!(parent_change_id(&test_repo, &child)?, base.change_id);
 
         Ok(())
     }

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -20,6 +20,7 @@ use crate::background_tasks::BackgroundTasks;
 use crate::background_tasks::TaskOutput;
 use crate::background_tasks::TaskResult;
 use crate::background_tasks::TaskSlot;
+use crate::commander::jj::NewInsertMode;
 use crate::commander::log::Head;
 use crate::commander::new_commander;
 use crate::commander::revset::Revset;
@@ -35,6 +36,7 @@ use crate::ui::ComponentInputResult;
 use crate::ui::Scroll;
 use crate::ui::Tab;
 use crate::ui::dialog::BookmarkSetPopup;
+use crate::ui::dialog::ChoicePopup;
 use crate::ui::dialog::DescribePopup;
 use crate::ui::dialog::LoaderPopup;
 use crate::ui::dialog::MessagePopup;
@@ -47,7 +49,6 @@ use crate::ui::panel::route_mouse;
 use crate::ui::utils::PaneDivider;
 use crate::ui::utils::centered_rect_line_height;
 
-const NEW_POPUP_ID: u16 = 1;
 const EDIT_POPUP_ID: u16 = 2;
 const ABANDON_POPUP_ID: u16 = 3;
 const SQUASH_POPUP_ID: u16 = 4;
@@ -77,6 +78,9 @@ pub struct LogTab<'a> {
 
     goto_parent_tx: std::sync::mpsc::Sender<Head>,
     goto_parent_rx: std::sync::mpsc::Receiver<Head>,
+
+    new_insert_tx: std::sync::mpsc::Sender<NewInsertMode>,
+    new_insert_rx: std::sync::mpsc::Receiver<NewInsertMode>,
 
     describe_after_new: bool,
 
@@ -117,6 +121,7 @@ impl<'a> LogTab<'a> {
     pub fn new(background_tasks: BackgroundTasks, head: Head) -> Self {
         let (popup_tx, popup_rx) = std::sync::mpsc::channel();
         let (goto_parent_tx, goto_parent_rx) = std::sync::mpsc::channel();
+        let (new_insert_tx, new_insert_rx) = std::sync::mpsc::channel();
 
         let mut keybinds = LogTabKeybinds::default();
         let mut details_keybinds = DetailsPanelKeybinds::default();
@@ -146,9 +151,11 @@ impl<'a> LogTab<'a> {
             popup: ConfirmDialogState::default(),
             popup_tx,
             popup_rx,
-
             goto_parent_tx,
             goto_parent_rx,
+
+            new_insert_tx,
+            new_insert_rx,
 
             describe_after_new: false,
 
@@ -218,41 +225,52 @@ each other in code:
 impl<'a> LogTab<'a> {
     fn handle_new(&mut self, describe: bool) -> Result<ComponentInputResult> {
         let mark_count = self.log_panel.marked_heads.len();
-        let text = if mark_count > 0 {
-            Text::from(vec![Line::from(format!(
-                "Are you sure you want to create a new change with {mark_count} marked parents?"
-            ))])
-            .fg(Color::default())
+        let target: String = if mark_count > 0 {
+            format!("the {mark_count} marked changes")
         } else {
-            Text::from(vec![
-                Line::from("Are you sure you want to create a new change?"),
-                Line::from(format!("New parent: {}", self.head.change_id.as_str())),
-            ])
-            .fg(Color::default())
+            self.head.change_id.as_str().chars().take(8).collect()
         };
-        self.popup = ConfirmDialogState::new(
-            NEW_POPUP_ID,
-            Span::styled(" New ", Style::new().bold().cyan()),
-            text,
-        );
-        self.popup
-            .with_yes_button(ButtonLabel::YES.clone())
-            .with_no_button(ButtonLabel::NO.clone())
-            .with_listener(Some(self.popup_tx.clone()))
-            .open();
+        let items = vec![
+            (
+                Line::raw(format!("New child of {target}")),
+                NewInsertMode::Child,
+            ),
+            (
+                Line::raw(format!("Insert after {target}")),
+                NewInsertMode::After,
+            ),
+            (
+                Line::raw(format!("Insert before {target}")),
+                NewInsertMode::Before,
+            ),
+        ];
         self.describe_after_new = describe;
-        Ok(ComponentInputResult::Handled)
+        Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
+            Box::new(ChoicePopup::new(
+                self.config.clone(),
+                self.new_insert_tx.clone(),
+                "New",
+                items,
+            )),
+        )))
     }
 
-    // Execute new command, after self.popup returned
-    fn execute_new(&mut self) -> Result<Option<AppAction>> {
-        let commit_ids = self.log_panel.extract_and_clear_head_marks();
+    // Execute new command, after the insertion point has been picked
+    fn execute_new(&mut self, insert: NewInsertMode) -> Result<Option<AppAction>> {
+        let describe = std::mem::take(&mut self.describe_after_new);
+        let commit_ids: Vec<_> = self.log_panel.marked_heads.iter().cloned().collect();
         let revset =
             Revset::union(&commit_ids).unwrap_or_else(|| Revset::from(&self.head.commit_id));
-        new_commander().run_new(revset)?;
+        // Inserting can hit immutable changes, so report the refusal and
+        // keep the marks for another attempt.
+        if let Err(err) = new_commander().run_new_with_insert(revset, insert) {
+            return Ok(Some(AppAction::SetPopup(Box::new(
+                MessagePopup::new("New", format!("{err:#}")).text_align(Alignment::Left),
+            ))));
+        }
+        self.log_panel.marked_heads.clear();
         self.set_head(new_commander().get_current_head()?);
-        if self.describe_after_new {
-            self.describe_after_new = false;
+        if describe {
             return Ok(Some(AppAction::Multiple(vec![
                 AppAction::ChangeHead(self.head.clone()),
                 AppAction::SetPopup(Box::new(DescribePopup::new(self.head.clone(), vec![]))),
@@ -653,9 +671,6 @@ impl Component for LogTab<'_> {
             && res.1.unwrap_or(false)
         {
             match res.0 {
-                NEW_POPUP_ID => {
-                    return self.execute_new();
-                }
                 EDIT_POPUP_ID => {
                     new_commander().run_edit(&self.head.commit_id, self.edit_ignore_immutable)?;
                     return Ok(Some(AppAction::Multiple(vec![
@@ -687,6 +702,10 @@ impl Component for LogTab<'_> {
         // ask for a refresh.
         if let Ok(head) = self.goto_parent_rx.try_recv() {
             return Ok(Some(AppAction::ViewLog(head)));
+        }
+
+        if let Ok(insert) = self.new_insert_rx.try_recv() {
+            return self.execute_new(insert);
         }
 
         Ok(None)


### PR DESCRIPTION
Building a change into the middle of a chain means dropping to the shell for `jj new --insert-after`/`--insert-before`, as all we offer is a child of the selected change. Where the change goes is a parameter of the operation rather than an operation of its own, and `n` already puts up a dialog that has nothing to ask but "are you sure", so let it ask that instead. The three positions go into a choice popup, with the child first so that `n` followed by Enter still does what it did. Inserting rewrites existing changes, so unlike a plain child it can be refused, most obviously when they are immutable. We put jj's complaint up in a popup and keep the marks so that the operation can be tried again.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
