### PR TITLE
app: Pick up work done outside the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   outside dismisses it
 - The new-change dialog now asks where to put the change, so it can also be
   inserted before or after the selected one rather than only as its child
+- Work done outside the app, such as a jj command run in another terminal, is
+  picked up on its own while the terminal window has no focus
+- `blazingjj.poll-interval` to set how often the app checks for it, or `0` to
+  have it only check when asked
+- The header's `R: refresh` hint turns red when the current tab has gone
+  stale and the app is not going to catch it up on its own
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ You can optionally configure the following options through your jj config:
   - If `blazingjj.bookmark-template` is not set but `templates.git_push_bookmark` is, the latter will be used
 - `blazingjj.layout`: Changes the layout of the main and details panel. Can be `horizontal` (default) or `vertical`
 - `blazingjj.layout-percent`: Changes the layout split of the main page. Should be number between 0 and 100. Defaults to `50`
+- `blazingjj.poll-interval`: Seconds between checks for work done outside the app. Set to `0` to only check when asked. Defaults to `1`
+  - What is found is picked up while the terminal window has no focus; while it has focus, the header's `R: refresh` hint turns red instead, as refreshing what is being read moves it
+  - A terminal that does not report focus changes counts as always focused, so there the hint is all you get
 
 Example: `jj config set --user blazingjj.diff-format "color-words"` (for storing in [user config file](https://martinvonz.github.io/jj/latest/config/#user-config-file), repo config is also supported)
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,3 +1,5 @@
+mod repo_watch;
+
 use core::fmt;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -22,7 +24,11 @@ use tracing::instrument;
 use tracing::trace;
 use tracing::warn;
 
+use crate::app::repo_watch::Check;
+use crate::app::repo_watch::Moment;
+use crate::app::repo_watch::RepoWatch;
 use crate::background_tasks::BackgroundTasks;
+use crate::background_tasks::TaskOutput;
 use crate::background_tasks::TaskResult;
 use crate::background_tasks::TaskSlot;
 use crate::commander::ids::OperationId;
@@ -71,8 +77,15 @@ pub struct Stats {
     pub start_time: Instant,
 }
 
-/// How long after a check of what the repo is at the next one is due.
-const OP_ID_CHECK_INTERVAL: Duration = Duration::from_secs(1);
+/// What handling an event leaves for the main loop to do.
+pub enum Handled {
+    /// Nothing the app shows can have changed.
+    Nothing,
+    /// What the app shows may have changed.
+    Redraw,
+    /// The app was asked to stop.
+    Stop,
+}
 
 pub struct App<'a> {
     // user interface
@@ -85,12 +98,7 @@ pub struct App<'a> {
     pub stats: Stats,
     global_keybinds: GlobalKeybinds,
 
-    repo_op_id: Option<OperationId>,
-    next_op_id_check: Instant,
-
-    /// Whether the next check may leave the working copy alone rather
-    /// than snapshotting it.
-    ignore_working_copy: bool,
+    repo_watch: RepoWatch,
 
     // event handling
     running: Arc<AtomicBool>,
@@ -121,9 +129,7 @@ impl<'a> App<'a> {
             },
             global_keybinds,
 
-            repo_op_id: None,
-            next_op_id_check: Instant::now(),
-            ignore_working_copy: false,
+            repo_watch: RepoWatch::new(Instant::now()),
 
             running,
             event_source,
@@ -163,15 +169,17 @@ impl<'a> App<'a> {
         self.current_tab = tab;
     }
 
-    /// Mark every tab stale if the repo has moved since the last check,
-    /// then read the current tab if it is stale. Returns whether
-    /// anything on screen changed.
+    /// Start a check of what the repo is at if one is called for, and
+    /// read the current tab if it is stale. Returns whether anything on
+    /// screen changed.
     pub fn refresh_view(&mut self) -> Result<bool> {
-        if self.check_repo_moved() {
-            trace!("The repo has moved, so every tab is stale");
-            for tab in TabId::VALUES {
-                self.get_tab(tab).mark_stale();
-            }
+        let moment = Moment {
+            at: Instant::now(),
+            checking: self.background_tasks.is_running(&TaskSlot::RepoOpId),
+            room: self.background_tasks.has_room(),
+        };
+        if let Some(check) = self.repo_watch.check_to_start(moment) {
+            self.submit_repo_check(check);
         }
 
         if !self.get_current_tab().is_stale() {
@@ -183,43 +191,36 @@ impl<'a> App<'a> {
         Ok(true)
     }
 
-    /// Ask for the next check to read the repo without waiting out
-    /// [OP_ID_CHECK_INTERVAL], and snapshot the working copy while at it.
-    fn request_check_with_snapshot(&mut self) {
-        self.next_op_id_check = Instant::now();
-        self.ignore_working_copy = false;
+    /// Read what operation the repo is at, keeping the slot until the
+    /// check is done rather than letting newer work kill it.
+    fn submit_repo_check(&mut self, check: Check) {
+        self.background_tasks
+            .submit_uninterruptible(TaskSlot::RepoOpId, move || {
+                let mut commander = new_commander();
+                if !check.snapshot {
+                    commander.ignore_working_copy();
+                }
+                Ok(commander.get_operation_id()?.0)
+            });
     }
 
-    /// Read what operation the repo is at once the last check is an
-    /// [OP_ID_CHECK_INTERVAL] old, or as soon as one was asked for, and
-    /// remember it. Reports whether it differs from what was remembered
-    /// before; a check that is not due yet or that fails reports no
-    /// movement.
-    fn check_repo_moved(&mut self) -> bool {
-        if Instant::now() < self.next_op_id_check {
-            return false;
-        }
-
-        let mut commander = new_commander();
-        if self.ignore_working_copy {
-            commander.ignore_working_copy();
-        }
-
-        let result = commander.get_operation_id();
-        self.next_op_id_check = Instant::now() + OP_ID_CHECK_INTERVAL;
-
-        let operation_id = match result {
-            Ok(operation_id) => operation_id,
+    /// Take what a check found and mark every tab stale if the repo has
+    /// moved since the last one.
+    fn repo_checked(&mut self, output: TaskOutput) {
+        let op_id = match output {
+            Ok(op_id) => Some(OperationId(op_id)),
             Err(err) => {
                 warn!("Could not read what the repo is at: {err}");
-                return false;
+                None
             }
         };
-        self.ignore_working_copy = true;
 
-        let moved = self.repo_op_id.as_ref() != Some(&operation_id);
-        self.repo_op_id = Some(operation_id);
-        moved
+        if self.repo_watch.checked(Instant::now(), op_id) {
+            trace!("The repo has moved, so every tab is stale");
+            for tab in TabId::VALUES {
+                self.get_tab(tab).mark_stale();
+            }
+        }
     }
 
     pub fn get_tab(&mut self, tab: TabId) -> &mut dyn Tab {
@@ -272,9 +273,10 @@ impl<'a> App<'a> {
             }
             AppAction::RefreshTab => {
                 self.get_current_tab().mark_stale();
-                // Whatever asks for this has likely moved the repo, so
-                // the other tabs want checking without delay.
-                self.next_op_id_check = Instant::now();
+                // Whatever asks for this has likely moved the repo, and
+                // snapshotted while at it, so the other tabs want
+                // checking without delay but not another snapshot.
+                self.repo_watch.ask_check(Check::default());
             }
         }
 
@@ -387,10 +389,16 @@ impl<'a> App<'a> {
     }
 
     /// Hand the output of a finished task to whoever asked for it
-    fn handle_task_result(&mut self, result: TaskResult) -> Result<()> {
+    fn handle_task_result(&mut self, result: TaskResult) -> Result<Handled> {
         self.background_tasks.finish(&result);
 
         let consumer: Option<&mut dyn Component> = match result.slot {
+            // The check is the app's own, and puts nothing on screen
+            // itself.
+            TaskSlot::RepoOpId => {
+                self.repo_checked(result.output);
+                return Ok(Handled::Nothing);
+            }
             TaskSlot::CommitShow(tab, _)
             | TaskSlot::FileDiff(tab, _)
             | TaskSlot::EvologShow(tab, _) => Some(self.get_tab(tab)),
@@ -403,24 +411,23 @@ impl<'a> App<'a> {
         };
         let Some(consumer) = consumer else {
             trace!("Dropping task result, its consumer is gone");
-            return Ok(());
+            return Ok(Handled::Nothing);
         };
 
         if let Some(app_action) = consumer.task_done(result)? {
             self.handle_action(app_action)?;
         }
-        Ok(())
+        Ok(Handled::Redraw)
     }
 
     /// Process an AppEvent
     #[instrument(level = "trace", skip(self))]
-    pub fn input(&mut self, event: AppEvent) -> Result<bool> {
+    pub fn input(&mut self, event: AppEvent) -> Result<Handled> {
         let event = match event {
             AppEvent::UserInput(event) => event,
             AppEvent::TaskDone(result) => {
                 trace!("Processing task result");
-                self.handle_task_result(result)?;
-                return Ok(false); // do not terminate the app
+                return self.handle_task_result(result);
             }
         };
         trace!("Processing user input");
@@ -428,8 +435,8 @@ impl<'a> App<'a> {
         // Coming back to the window is worth a check, as the repo may
         // well have moved while we were not being watched.
         if event == event::Event::FocusGained {
-            self.request_check_with_snapshot();
-            return Ok(false);
+            self.repo_watch.ask_check(Check { snapshot: true });
+            return Ok(Handled::Nothing);
         }
 
         if let Some(popup) = self.popup.as_mut() {
@@ -486,7 +493,7 @@ impl<'a> App<'a> {
                                 self.get_current_tab().focus_current()?;
                             }
                             GlobalEvent::Refresh => {
-                                self.request_check_with_snapshot();
+                                self.repo_watch.ask_check(Check { snapshot: true });
                                 self.get_current_tab().drop_caches();
                                 self.handle_action(AppAction::RefreshTab)?;
                             }
@@ -502,7 +509,7 @@ impl<'a> App<'a> {
                             GlobalEvent::OpenHelp => self.open_help()?,
                             GlobalEvent::Quit => {
                                 self.running.store(false, Ordering::Relaxed);
-                                return Ok(true);
+                                return Ok(Handled::Stop);
                             }
                             GlobalEvent::Unbound => {}
                         }
@@ -511,6 +518,6 @@ impl<'a> App<'a> {
             };
         }
 
-        Ok(false)
+        Ok(Handled::Redraw)
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -129,7 +129,7 @@ impl<'a> App<'a> {
             },
             global_keybinds,
 
-            repo_watch: RepoWatch::new(Instant::now()),
+            repo_watch: RepoWatch::new(get_env().jj_config.poll_interval(), Instant::now()),
 
             running,
             event_source,
@@ -165,25 +165,51 @@ impl<'a> App<'a> {
     }
 
     pub fn set_tab(&mut self, tab: TabId) {
+        // Asking for the tab already on screen is not asking for it to
+        // move.
+        if tab == self.current_tab {
+            return;
+        }
+
         info!("Setting tab to {}", tab);
         self.current_tab = tab;
+        // The user is not reading the tab they are switching to yet, so
+        // nothing moves under them if we bring it up to date.
+        self.repo_watch.catching_up();
     }
 
-    /// Start a check of what the repo is at if one is called for, and
-    /// read the current tab if it is stale. Returns whether anything on
-    /// screen changed.
-    pub fn refresh_view(&mut self) -> Result<bool> {
-        let moment = Moment {
+    /// How long until the app next checks for work done outside it, or
+    /// None if there is nothing to wake up for.
+    pub fn time_until_poll(&self) -> Option<Duration> {
+        self.repo_watch.time_until_poll(self.moment())
+    }
+
+    fn moment(&self) -> Moment {
+        Moment {
             at: Instant::now(),
             checking: self.background_tasks.is_running(&TaskSlot::RepoOpId),
             room: self.background_tasks.has_room(),
-        };
-        if let Some(check) = self.repo_watch.check_to_start(moment) {
+        }
+    }
+
+    /// Start a check of what the repo is at if one is called for, and
+    /// catch the current tab up unless refreshing it now would move what
+    /// the user is reading. Returns whether anything on screen changed.
+    pub fn refresh_view(&mut self) -> Result<bool> {
+        // A popup covers the tab a check would read for, and keeps the
+        // loop running for its own sake.
+        if self.popup.is_some() {
+            return Ok(false);
+        }
+
+        if let Some(check) = self.repo_watch.check_to_start(self.moment()) {
             self.submit_repo_check(check);
         }
 
-        if !self.get_current_tab().is_stale() {
-            return Ok(false);
+        let stale = self.get_current_tab().is_stale();
+        let hint_changed = self.repo_watch.leave_stale(stale);
+        if self.repo_watch.waiting_for_refresh() || !stale {
+            return Ok(hint_changed);
         }
 
         self.get_current_tab().refresh()?;
@@ -276,7 +302,10 @@ impl<'a> App<'a> {
                 // Whatever asks for this has likely moved the repo, and
                 // snapshotted while at it, so the other tabs want
                 // checking without delay but not another snapshot.
-                self.repo_watch.ask_check(Check::default());
+                self.repo_watch.ask_check(Check {
+                    snapshot: false,
+                    ours: true,
+                });
             }
         }
 
@@ -338,16 +367,28 @@ impl<'a> App<'a> {
             f.render_widget(tabs, header_chunks[0]);
         }
         {
-            let tabs = Paragraph::new("q: quit | ?: help | R: refresh | 1-4: change tab")
-                .fg(Color::DarkGray)
-                .block(
-                    Block::bordered()
-                        .title(" blazingjj ")
-                        .border_type(BorderType::Rounded)
-                        .fg(Color::default()),
-                );
+            // The app is not going to pick it up, so light up the key
+            // that does.
+            let refresh_style = if self.repo_watch.waiting_for_refresh() {
+                Style::default().fg(Color::Red)
+            } else {
+                Style::default()
+            };
 
-            f.render_widget(tabs, header_chunks[1]);
+            let hints = Paragraph::new(Line::from(vec![
+                Span::raw("q: quit | ?: help | "),
+                Span::styled("R: refresh", refresh_style),
+                Span::raw(" | 1-4: change tab"),
+            ]))
+            .fg(Color::DarkGray)
+            .block(
+                Block::bordered()
+                    .title(" blazingjj ")
+                    .border_type(BorderType::Rounded)
+                    .fg(Color::default()),
+            );
+
+            f.render_widget(hints, header_chunks[1]);
         }
 
         self.get_current_tab().draw(f, chunks[1])?;
@@ -432,11 +473,22 @@ impl<'a> App<'a> {
         };
         trace!("Processing user input");
 
-        // Coming back to the window is worth a check, as the repo may
-        // well have moved while we were not being watched.
-        if event == event::Event::FocusGained {
-            self.repo_watch.ask_check(Check { snapshot: true });
-            return Ok(Handled::Nothing);
+        match event {
+            // Coming back to the window is worth a check, as the repo
+            // may well have moved while we were not being watched.
+            event::Event::FocusGained => {
+                self.repo_watch.set_focus(true);
+                self.repo_watch.ask_check(Check {
+                    snapshot: true,
+                    ours: false,
+                });
+                return Ok(Handled::Nothing);
+            }
+            event::Event::FocusLost => {
+                self.repo_watch.set_focus(false);
+                return Ok(Handled::Nothing);
+            }
+            _ => {}
         }
 
         if let Some(popup) = self.popup.as_mut() {
@@ -493,7 +545,10 @@ impl<'a> App<'a> {
                                 self.get_current_tab().focus_current()?;
                             }
                             GlobalEvent::Refresh => {
-                                self.repo_watch.ask_check(Check { snapshot: true });
+                                self.repo_watch.ask_check(Check {
+                                    snapshot: true,
+                                    ours: true,
+                                });
                                 self.get_current_tab().drop_caches();
                                 self.handle_action(AppAction::RefreshTab)?;
                             }

--- a/src/app/repo_watch.rs
+++ b/src/app/repo_watch.rs
@@ -1,0 +1,259 @@
+/*! When the app looks at what the repo is at.
+
+Reading it is a jj invocation, so a check runs as a background task and
+its answer arrives later. A [RepoWatch] decides when to start one, what
+it is to do, and whether its answer means what the app shows is out of
+date.
+*/
+
+use std::mem;
+use std::time::Duration;
+use std::time::Instant;
+
+use crate::commander::ids::OperationId;
+
+/// How long after a check of what the repo is at the next one is due.
+const CHECK_INTERVAL: Duration = Duration::from_secs(1);
+
+/// What a check of what the repo is at is to do.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct Check {
+    /// Whether to snapshot the working copy while reading, which records
+    /// an operation of its own if the working copy has moved on.
+    pub snapshot: bool,
+}
+
+/// What the app can say about the moment it is asking about.
+#[derive(Clone, Copy, Debug)]
+pub struct Moment {
+    pub at: Instant,
+    /// Whether a check is still running.
+    pub checking: bool,
+    /// Whether a check can start without killing work already running.
+    pub room: bool,
+}
+
+/// What the app knows about where the repo is.
+pub struct RepoWatch {
+    /// The operation the last check that answered found.
+    op_id: Option<OperationId>,
+
+    /// When a check last started or answered.
+    last_check: Instant,
+
+    /// What the next check is to do.
+    next: Check,
+
+    /// Whether the next check is not to wait out [CHECK_INTERVAL].
+    asked: bool,
+
+    /// What the check the app started last is doing.
+    running: Check,
+}
+
+impl RepoWatch {
+    /// Starts out asking to be shown what the repo is at.
+    pub fn new(now: Instant) -> Self {
+        Self {
+            op_id: None,
+            last_check: now,
+            next: Check { snapshot: true },
+            asked: true,
+            running: Check::default(),
+        }
+    }
+
+    /// Ask for a check that does not wait out the interval.
+    pub fn ask_check(&mut self, check: Check) {
+        self.asked = true;
+        self.want(check);
+    }
+
+    /// Which check to start now, if any. Never more than one at a time.
+    pub fn check_to_start(&mut self, moment: Moment) -> Option<Check> {
+        if moment.checking || !moment.room {
+            return None;
+        }
+        if !self.asked && !self.is_due(moment.at) {
+            return None;
+        }
+
+        self.asked = false;
+        // Starting one counts as a check, so that a check still running
+        // does not make the next one due.
+        self.last_check = moment.at;
+        self.running = mem::take(&mut self.next);
+
+        Some(self.running)
+    }
+
+    /// Take what a check found, or None if it could not read the repo,
+    /// and report whether the repo has moved since the last answer.
+    pub fn checked(&mut self, at: Instant, op_id: Option<OperationId>) -> bool {
+        // Timed from when the check is done, so that a slow one does not
+        // leave the app checking back to back.
+        self.last_check = at;
+
+        let Some(op_id) = op_id else {
+            self.want(self.running);
+            return false;
+        };
+
+        // The first answer has nothing to have moved from.
+        let moved = self.op_id.as_ref().is_some_and(|known| known != &op_id);
+        self.op_id = Some(op_id);
+
+        moved
+    }
+
+    /// Roll `check` into what the next check is to do.
+    fn want(&mut self, check: Check) {
+        self.next.snapshot |= check.snapshot;
+    }
+
+    fn is_due(&self, at: Instant) -> bool {
+        at.saturating_duration_since(self.last_check) >= CHECK_INTERVAL
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A moment with room for a check and none running.
+    fn moment(at: Instant) -> Moment {
+        Moment {
+            at,
+            checking: false,
+            room: true,
+        }
+    }
+
+    fn op_id(id: &str) -> Option<OperationId> {
+        Some(OperationId(id.to_owned()))
+    }
+
+    #[test]
+    fn opens_by_asking_for_a_snapshotting_check() {
+        let now = Instant::now();
+        let mut watch = RepoWatch::new(now);
+
+        assert_eq!(
+            watch.check_to_start(moment(now)),
+            Some(Check { snapshot: true })
+        );
+        assert_eq!(watch.check_to_start(moment(now)), None);
+    }
+
+    #[test]
+    fn polls_once_the_interval_has_passed() {
+        let now = Instant::now();
+        let mut watch = RepoWatch::new(now);
+        watch.check_to_start(moment(now));
+        watch.checked(now, op_id("a"));
+
+        assert_eq!(watch.check_to_start(moment(now + CHECK_INTERVAL / 2)), None);
+        assert_eq!(
+            watch.check_to_start(moment(now + CHECK_INTERVAL)),
+            Some(Check::default())
+        );
+    }
+
+    #[test]
+    fn holds_off_polling_while_a_check_is_running() {
+        let now = Instant::now();
+        let mut watch = RepoWatch::new(now);
+        watch.check_to_start(moment(now));
+
+        let due = now + CHECK_INTERVAL;
+        assert_eq!(
+            watch.check_to_start(Moment {
+                checking: true,
+                ..moment(due)
+            }),
+            None
+        );
+        assert_eq!(watch.check_to_start(moment(due)), Some(Check::default()));
+    }
+
+    #[test]
+    fn holds_off_polling_while_the_task_pool_is_full() {
+        let now = Instant::now();
+        let mut watch = RepoWatch::new(now);
+        watch.check_to_start(moment(now));
+
+        let due = now + CHECK_INTERVAL;
+        assert_eq!(
+            watch.check_to_start(Moment {
+                room: false,
+                ..moment(due)
+            }),
+            None
+        );
+        assert_eq!(watch.check_to_start(moment(due)), Some(Check::default()));
+    }
+
+    #[test]
+    fn starts_an_asked_check_without_waiting_out_the_interval() {
+        let now = Instant::now();
+        let mut watch = RepoWatch::new(now);
+        watch.check_to_start(moment(now));
+        watch.checked(now, op_id("a"));
+
+        watch.ask_check(Check { snapshot: true });
+        assert_eq!(
+            watch.check_to_start(moment(now)),
+            Some(Check { snapshot: true })
+        );
+    }
+
+    #[test]
+    fn keeps_asking_for_a_snapshot_until_one_is_taken() {
+        let now = Instant::now();
+        let mut watch = RepoWatch::new(now);
+        watch.check_to_start(moment(now));
+
+        // A request made while the check runs waits for it rather than
+        // taking its answer, which predates the request.
+        watch.ask_check(Check { snapshot: true });
+        assert_eq!(
+            watch.check_to_start(Moment {
+                checking: true,
+                ..moment(now)
+            }),
+            None
+        );
+
+        watch.checked(now, op_id("a"));
+        assert_eq!(
+            watch.check_to_start(moment(now)),
+            Some(Check { snapshot: true })
+        );
+    }
+
+    #[test]
+    fn leaves_a_failed_check_to_the_next_one() {
+        let now = Instant::now();
+        let mut watch = RepoWatch::new(now);
+        watch.check_to_start(moment(now));
+
+        // A failure says nothing about the repo, and the snapshot the
+        // check was to take is still owed.
+        assert!(!watch.checked(now, None));
+        assert_eq!(watch.check_to_start(moment(now)), None);
+        assert_eq!(
+            watch.check_to_start(moment(now + CHECK_INTERVAL)),
+            Some(Check { snapshot: true })
+        );
+    }
+
+    #[test]
+    fn reports_the_repo_moving_but_not_the_first_answer() {
+        let now = Instant::now();
+        let mut watch = RepoWatch::new(now);
+
+        assert!(!watch.checked(now, op_id("a")));
+        assert!(!watch.checked(now, op_id("a")));
+        assert!(watch.checked(now, op_id("b")));
+    }
+}

--- a/src/app/repo_watch.rs
+++ b/src/app/repo_watch.rs
@@ -3,7 +3,7 @@
 Reading it is a jj invocation, so a check runs as a background task and
 its answer arrives later. A [RepoWatch] decides when to start one, what
 it is to do, and whether its answer means what the app shows is out of
-date.
+date and may be caught up without the user asking.
 */
 
 use std::mem;
@@ -12,15 +12,15 @@ use std::time::Instant;
 
 use crate::commander::ids::OperationId;
 
-/// How long after a check of what the repo is at the next one is due.
-const CHECK_INTERVAL: Duration = Duration::from_secs(1);
-
-/// What a check of what the repo is at is to do.
+/// What a check of what the repo is at is to do, and what its answer is
+/// to mean.
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct Check {
     /// Whether to snapshot the working copy while reading, which records
     /// an operation of its own if the working copy has moved on.
     pub snapshot: bool,
+    /// Whether a move this check finds is one the app has just made.
+    pub ours: bool,
 }
 
 /// What the app can say about the moment it is asking about.
@@ -35,6 +35,9 @@ pub struct Moment {
 
 /// What the app knows about where the repo is.
 pub struct RepoWatch {
+    /// How long between polls, or None to only check when asked.
+    interval: Option<Duration>,
+
     /// The operation the last check that answered found.
     op_id: Option<OperationId>,
 
@@ -44,22 +47,43 @@ pub struct RepoWatch {
     /// What the next check is to do.
     next: Check,
 
-    /// Whether the next check is not to wait out [CHECK_INTERVAL].
+    /// Whether the next check is not to wait out the interval.
     asked: bool,
 
     /// What the check the app started last is doing.
     running: Check,
+
+    /// Whether the app itself put the view out of date.
+    stale_is_ours: bool,
+
+    /// Whether the terminal window has focus. True to start with, as the
+    /// terminal says nothing about focus until it changes.
+    has_focus: bool,
+
+    /// Whether the app has left the view out of date for the user to
+    /// refresh.
+    left_stale: bool,
 }
 
 impl RepoWatch {
+    /// Polls every `interval`, or only checks when asked if that is None.
     /// Starts out asking to be shown what the repo is at.
-    pub fn new(now: Instant) -> Self {
+    pub fn new(interval: Option<Duration>, now: Instant) -> Self {
         Self {
+            interval,
             op_id: None,
             last_check: now,
-            next: Check { snapshot: true },
+            next: Check {
+                snapshot: true,
+                ours: false,
+            },
             asked: true,
             running: Check::default(),
+            // Nothing has been read yet, and reading it is what the user
+            // opened the app for.
+            stale_is_ours: true,
+            has_focus: true,
+            left_stale: false,
         }
     }
 
@@ -69,12 +93,54 @@ impl RepoWatch {
         self.want(check);
     }
 
+    /// Note that the app is putting the view out of date itself, without
+    /// a check to find it.
+    pub fn catching_up(&mut self) {
+        self.stale_is_ours = true;
+        // A check already on its way was started before we knew that,
+        // so what it comes back with says nothing about who moved the
+        // repo.
+        self.running.ours = true;
+    }
+
+    pub fn set_focus(&mut self, has_focus: bool) {
+        self.has_focus = has_focus;
+    }
+
+    /// Whether the view is out of date and the app is waiting to be
+    /// asked before catching it up.
+    pub fn waiting_for_refresh(&self) -> bool {
+        self.left_stale
+    }
+
+    /// How long until a poll is due, or None if none is coming and there
+    /// is nothing to wait for it on.
+    pub fn time_until_poll(&self, moment: Moment) -> Option<Duration> {
+        // Having left the view stale, there is nothing more to learn
+        // until the user acts on it.
+        if self.left_stale || moment.checking || !moment.room {
+            return None;
+        }
+
+        self.interval.map(|interval| {
+            interval.saturating_sub(moment.at.saturating_duration_since(self.last_check))
+        })
+    }
+
+    /// Decide whether to leave the view out of date rather than catch it
+    /// up, and report whether that has changed since the last pass.
+    pub fn leave_stale(&mut self, stale: bool) -> bool {
+        let left_stale = stale && self.has_focus && !self.stale_is_ours;
+        mem::replace(&mut self.left_stale, left_stale) != left_stale
+    }
+
     /// Which check to start now, if any. Never more than one at a time.
     pub fn check_to_start(&mut self, moment: Moment) -> Option<Check> {
+        // Even one that was asked for waits its turn.
         if moment.checking || !moment.room {
             return None;
         }
-        if !self.asked && !self.is_due(moment.at) {
+        if !self.asked && !self.is_due(moment) {
             return None;
         }
 
@@ -103,22 +169,38 @@ impl RepoWatch {
         let moved = self.op_id.as_ref().is_some_and(|known| known != &op_id);
         self.op_id = Some(op_id);
 
+        if moved && !self.running.ours {
+            self.stale_is_ours = false;
+        }
+
         moved
     }
 
-    /// Roll `check` into what the next check is to do.
+    /// Roll `check` into what the next check is to do, and take a move
+    /// it claims as the app's own as one already made.
     fn want(&mut self, check: Check) {
         self.next.snapshot |= check.snapshot;
+        self.next.ours |= check.ours;
+        if check.ours {
+            self.catching_up();
+        }
     }
 
-    fn is_due(&self, at: Instant) -> bool {
-        at.saturating_duration_since(self.last_check) >= CHECK_INTERVAL
+    fn is_due(&self, moment: Moment) -> bool {
+        self.time_until_poll(moment)
+            .is_some_and(|until| until.is_zero())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const INTERVAL: Duration = Duration::from_secs(1);
+
+    fn watch(now: Instant) -> RepoWatch {
+        RepoWatch::new(Some(INTERVAL), now)
+    }
 
     /// A moment with room for a check and none running.
     fn moment(at: Instant) -> Moment {
@@ -129,6 +211,13 @@ mod tests {
         }
     }
 
+    fn snapshotting() -> Check {
+        Check {
+            snapshot: true,
+            ours: false,
+        }
+    }
+
     fn op_id(id: &str) -> Option<OperationId> {
         Some(OperationId(id.to_owned()))
     }
@@ -136,25 +225,22 @@ mod tests {
     #[test]
     fn opens_by_asking_for_a_snapshotting_check() {
         let now = Instant::now();
-        let mut watch = RepoWatch::new(now);
+        let mut watch = watch(now);
 
-        assert_eq!(
-            watch.check_to_start(moment(now)),
-            Some(Check { snapshot: true })
-        );
+        assert_eq!(watch.check_to_start(moment(now)), Some(snapshotting()));
         assert_eq!(watch.check_to_start(moment(now)), None);
     }
 
     #[test]
     fn polls_once_the_interval_has_passed() {
         let now = Instant::now();
-        let mut watch = RepoWatch::new(now);
+        let mut watch = watch(now);
         watch.check_to_start(moment(now));
         watch.checked(now, op_id("a"));
 
-        assert_eq!(watch.check_to_start(moment(now + CHECK_INTERVAL / 2)), None);
+        assert_eq!(watch.check_to_start(moment(now + INTERVAL / 2)), None);
         assert_eq!(
-            watch.check_to_start(moment(now + CHECK_INTERVAL)),
+            watch.check_to_start(moment(now + INTERVAL)),
             Some(Check::default())
         );
     }
@@ -162,10 +248,10 @@ mod tests {
     #[test]
     fn holds_off_polling_while_a_check_is_running() {
         let now = Instant::now();
-        let mut watch = RepoWatch::new(now);
+        let mut watch = watch(now);
         watch.check_to_start(moment(now));
 
-        let due = now + CHECK_INTERVAL;
+        let due = now + INTERVAL;
         assert_eq!(
             watch.check_to_start(Moment {
                 checking: true,
@@ -179,10 +265,10 @@ mod tests {
     #[test]
     fn holds_off_polling_while_the_task_pool_is_full() {
         let now = Instant::now();
-        let mut watch = RepoWatch::new(now);
+        let mut watch = watch(now);
         watch.check_to_start(moment(now));
 
-        let due = now + CHECK_INTERVAL;
+        let due = now + INTERVAL;
         assert_eq!(
             watch.check_to_start(Moment {
                 room: false,
@@ -196,26 +282,23 @@ mod tests {
     #[test]
     fn starts_an_asked_check_without_waiting_out_the_interval() {
         let now = Instant::now();
-        let mut watch = RepoWatch::new(now);
+        let mut watch = watch(now);
         watch.check_to_start(moment(now));
         watch.checked(now, op_id("a"));
 
-        watch.ask_check(Check { snapshot: true });
-        assert_eq!(
-            watch.check_to_start(moment(now)),
-            Some(Check { snapshot: true })
-        );
+        watch.ask_check(snapshotting());
+        assert_eq!(watch.check_to_start(moment(now)), Some(snapshotting()));
     }
 
     #[test]
     fn keeps_asking_for_a_snapshot_until_one_is_taken() {
         let now = Instant::now();
-        let mut watch = RepoWatch::new(now);
+        let mut watch = watch(now);
         watch.check_to_start(moment(now));
 
         // A request made while the check runs waits for it rather than
         // taking its answer, which predates the request.
-        watch.ask_check(Check { snapshot: true });
+        watch.ask_check(snapshotting());
         assert_eq!(
             watch.check_to_start(Moment {
                 checking: true,
@@ -225,16 +308,13 @@ mod tests {
         );
 
         watch.checked(now, op_id("a"));
-        assert_eq!(
-            watch.check_to_start(moment(now)),
-            Some(Check { snapshot: true })
-        );
+        assert_eq!(watch.check_to_start(moment(now)), Some(snapshotting()));
     }
 
     #[test]
     fn leaves_a_failed_check_to_the_next_one() {
         let now = Instant::now();
-        let mut watch = RepoWatch::new(now);
+        let mut watch = watch(now);
         watch.check_to_start(moment(now));
 
         // A failure says nothing about the repo, and the snapshot the
@@ -242,18 +322,179 @@ mod tests {
         assert!(!watch.checked(now, None));
         assert_eq!(watch.check_to_start(moment(now)), None);
         assert_eq!(
-            watch.check_to_start(moment(now + CHECK_INTERVAL)),
-            Some(Check { snapshot: true })
+            watch.check_to_start(moment(now + INTERVAL)),
+            Some(snapshotting())
         );
     }
 
     #[test]
     fn reports_the_repo_moving_but_not_the_first_answer() {
         let now = Instant::now();
-        let mut watch = RepoWatch::new(now);
+        let mut watch = watch(now);
 
         assert!(!watch.checked(now, op_id("a")));
         assert!(!watch.checked(now, op_id("a")));
         assert!(watch.checked(now, op_id("b")));
+    }
+
+    #[test]
+    fn only_checks_when_asked_without_an_interval() {
+        let now = Instant::now();
+        let mut watch = RepoWatch::new(None, now);
+        watch.check_to_start(moment(now));
+        watch.checked(now, op_id("a"));
+
+        assert_eq!(watch.time_until_poll(moment(now)), None);
+        assert_eq!(watch.check_to_start(moment(now + INTERVAL * 60)), None);
+
+        watch.ask_check(Check::default());
+        assert_eq!(watch.check_to_start(moment(now)), Some(Check::default()));
+    }
+
+    #[test]
+    fn reads_the_view_it_opens_with() {
+        let now = Instant::now();
+        let mut watch = watch(now);
+
+        // No tab has been read yet, and showing them is what the app was
+        // opened for, so none of them is left for the user to ask about.
+        assert!(!watch.leave_stale(true));
+        assert!(!watch.waiting_for_refresh());
+        assert_eq!(watch.time_until_poll(moment(now)), Some(INTERVAL));
+    }
+
+    #[test]
+    fn has_nothing_to_wake_up_for_while_a_check_cannot_start() {
+        let now = Instant::now();
+        let mut watch = watch(now);
+        watch.check_to_start(moment(now));
+
+        // The answer wakes the loop, so waiting on the clock as well
+        // would only spin until it arrives.
+        let overdue = now + INTERVAL * 2;
+        assert_eq!(
+            watch.time_until_poll(Moment {
+                checking: true,
+                ..moment(overdue)
+            }),
+            None
+        );
+        assert_eq!(
+            watch.time_until_poll(Moment {
+                room: false,
+                ..moment(overdue)
+            }),
+            None
+        );
+
+        watch.checked(now, op_id("a"));
+        assert_eq!(watch.time_until_poll(moment(now)), Some(INTERVAL));
+    }
+
+    #[test]
+    fn leaves_a_move_it_found_itself_stale_while_the_window_has_focus() {
+        let now = Instant::now();
+        let mut watch = watch(now);
+        watch.check_to_start(moment(now));
+        watch.checked(now, op_id("a"));
+        watch.check_to_start(moment(now + INTERVAL));
+        assert!(watch.checked(now, op_id("b")));
+
+        assert!(watch.leave_stale(true));
+        assert!(watch.waiting_for_refresh());
+        // Nothing more to learn until the user asks.
+        assert_eq!(watch.time_until_poll(moment(now)), None);
+
+        // The hint goes as soon as the tab catches up by any route.
+        assert!(watch.leave_stale(false));
+        assert!(!watch.waiting_for_refresh());
+    }
+
+    #[test]
+    fn asks_before_catching_up_with_what_changed_while_away() {
+        let now = Instant::now();
+        let mut watch = watch(now);
+        watch.check_to_start(moment(now));
+        watch.checked(now, op_id("a"));
+
+        // Back at the window, the check that comes with regaining focus
+        // reads for a user who is looking at the view again, so what it
+        // turns up is theirs to ask for rather than ours to show.
+        watch.set_focus(false);
+        watch.set_focus(true);
+        watch.ask_check(snapshotting());
+        watch.check_to_start(moment(now));
+        assert!(watch.checked(now, op_id("b")));
+
+        assert!(watch.leave_stale(true));
+        assert!(watch.waiting_for_refresh());
+    }
+
+    #[test]
+    fn catches_up_with_a_move_it_found_itself_while_focus_is_elsewhere() {
+        let now = Instant::now();
+        let mut watch = watch(now);
+        watch.check_to_start(moment(now));
+        watch.checked(now, op_id("a"));
+        watch.set_focus(false);
+        watch.check_to_start(moment(now + INTERVAL));
+        assert!(watch.checked(now, op_id("b")));
+
+        assert!(!watch.leave_stale(true));
+        assert!(!watch.waiting_for_refresh());
+    }
+
+    #[test]
+    fn catches_up_with_a_move_the_app_made_even_with_focus() {
+        let now = Instant::now();
+        let mut watch = watch(now);
+        watch.check_to_start(moment(now));
+        watch.checked(now, op_id("a"));
+
+        // A command the app ran moved the repo, and the check that finds
+        // it answers only after the tab has been read again.
+        watch.ask_check(Check {
+            snapshot: false,
+            ours: true,
+        });
+        watch.check_to_start(moment(now));
+        assert!(!watch.leave_stale(false));
+
+        assert!(watch.checked(now, op_id("b")));
+        assert!(!watch.leave_stale(true));
+        assert!(!watch.waiting_for_refresh());
+    }
+
+    #[test]
+    fn stops_treating_staleness_as_its_own_once_a_poll_finds_a_move() {
+        let now = Instant::now();
+        let mut watch = watch(now);
+        watch.check_to_start(moment(now));
+        watch.checked(now, op_id("a"));
+
+        // Switching tabs is reason enough to catch the view up, but says
+        // nothing about the move a later poll turns up.
+        watch.catching_up();
+        watch.check_to_start(moment(now + INTERVAL));
+        assert!(watch.checked(now, op_id("b")));
+
+        assert!(watch.leave_stale(true));
+    }
+
+    #[test]
+    fn catches_up_with_a_move_a_check_already_running_comes_back_with() {
+        let now = Instant::now();
+        let mut watch = watch(now);
+        watch.check_to_start(moment(now));
+        watch.checked(now, op_id("a"));
+
+        // The poll is on its way when the app puts the view behind
+        // itself, so it is the one that comes back with the move.
+        watch.check_to_start(moment(now + INTERVAL));
+        watch.catching_up();
+        assert!(watch.checked(now, op_id("b")));
+
+        assert!(!watch.leave_stale(true));
+        assert!(!watch.waiting_for_refresh());
     }
 }

--- a/src/background_tasks.rs
+++ b/src/background_tasks.rs
@@ -70,6 +70,8 @@ pub enum TaskSlot {
     EvologShow(TabId, OutputRequest<EvologShowKey>),
     GitPush,
     GitFetch,
+    /// A read of what operation the repo is at.
+    RepoOpId,
 }
 
 /// Which run of a slot a task is. Unique for the lifetime of the app,
@@ -244,14 +246,20 @@ impl BackgroundTasks {
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
-    #[cfg(test)]
-    fn running_count(&self) -> usize {
-        self.lock().tasks.len()
+    /// Whether the task in `slot` has yet to deliver its result.
+    pub fn is_running(&self, slot: &TaskSlot) -> bool {
+        self.lock().tasks.iter().any(|task| &task.slot == slot)
+    }
+
+    /// Whether a submission would find a free slot rather than have to
+    /// make room.
+    pub fn has_room(&self) -> bool {
+        self.lock().tasks.len() < MAX_RUNNING
     }
 
     #[cfg(test)]
-    fn contains(&self, slot: &TaskSlot) -> bool {
-        self.lock().tasks.iter().any(|task| &task.slot == slot)
+    fn running_count(&self) -> usize {
+        self.lock().tasks.len()
     }
 }
 
@@ -410,8 +418,11 @@ mod tests {
         gates.push(gate);
         tasks.submit(slot(MAX_RUNNING), move |_cancel| task());
 
-        assert!(!tasks.contains(&slot(0)), "oldest task should be evicted");
-        assert!(tasks.contains(&slot(1)), "younger tasks should be left be");
+        assert!(!tasks.is_running(&slot(0)), "oldest task should be evicted");
+        assert!(
+            tasks.is_running(&slot(1)),
+            "younger tasks should be left be"
+        );
         assert_eq!(tasks.running_count(), MAX_RUNNING);
     }
 
@@ -431,7 +442,7 @@ mod tests {
         tasks.submit(slot(MAX_RUNNING), move |_cancel| task());
 
         assert_eq!(tasks.running_count(), MAX_RUNNING + 1);
-        assert!(tasks.contains(&slot(0)));
+        assert!(tasks.is_running(&slot(0)));
     }
 
     #[test]
@@ -454,8 +465,11 @@ mod tests {
         gates.push(gate);
         tasks.submit(slot(MAX_RUNNING), move |_cancel| task());
 
-        assert!(tasks.contains(&TaskSlot::GitPush), "a push is never killed");
-        assert!(!tasks.contains(&slot(1)), "oldest task should be evicted");
+        assert!(
+            tasks.is_running(&TaskSlot::GitPush),
+            "a push is never killed"
+        );
+        assert!(!tasks.is_running(&slot(1)), "oldest task should be evicted");
         assert_eq!(tasks.running_count(), MAX_RUNNING);
     }
 
@@ -465,7 +479,7 @@ mod tests {
         let gates = fill_with_gated_tasks(&tasks);
 
         tasks.submit(slot(MAX_RUNNING), |_cancel| Ok("newest".to_owned()));
-        assert!(!tasks.contains(&slot(0)), "oldest task should be evicted");
+        assert!(!tasks.is_running(&slot(0)), "oldest task should be evicted");
 
         // The evicted task runs to completion here, since a plain closure
         // has nothing we could kill. Its result is dropped anyway.
@@ -481,7 +495,7 @@ mod tests {
         tasks.submit(slot(0), move |_cancel| task());
 
         tasks.cancel(&slot(0));
-        assert!(!tasks.contains(&slot(0)));
+        assert!(!tasks.is_running(&slot(0)));
         assert_eq!(tasks.running_count(), 0);
 
         drop(gate);
@@ -495,7 +509,7 @@ mod tests {
         tasks.submit(slot(0), move |_cancel| task());
 
         tasks.cancel(&slot(1));
-        assert!(tasks.contains(&slot(0)));
+        assert!(tasks.is_running(&slot(0)));
     }
 
     #[test]
@@ -541,7 +555,10 @@ mod tests {
             })
             .collect();
         tasks.submit(slot(MAX_RUNNING), |_cancel| Ok("newest".to_owned()));
-        assert!(!tasks.contains(&slot(0)), "the oldest entry should be gone");
+        assert!(
+            !tasks.is_running(&slot(0)),
+            "the oldest entry should be gone"
+        );
 
         // With no entry left, the slot takes a second run -- which the
         // first run's result must not release.
@@ -550,7 +567,7 @@ mod tests {
         tasks.finish(&first);
 
         assert!(
-            tasks.contains(&slot(0)),
+            tasks.is_running(&slot(0)),
             "the second run should still hold the slot"
         );
     }
@@ -569,6 +586,6 @@ mod tests {
         }
 
         assert_eq!(tasks.running_count(), MAX_RUNNING);
-        assert!(tasks.contains(&slot(MAX_RUNNING * 2 - 1)));
+        assert!(tasks.is_running(&slot(MAX_RUNNING * 2 - 1)));
     }
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -8,12 +8,15 @@ It is a combination of
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::OnceLock;
+use std::time::Duration;
 
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::bail;
 use ratatui::style::Color;
 use serde::Deserialize;
+use serde::Deserializer;
+use serde::de;
 
 use crate::commander::MIN_SETTABLE_WIDTH;
 use crate::commander::RemoveEndLine;
@@ -51,6 +54,10 @@ pub struct JjConfigBlazingjj {
     layout: JJLayout,
     layout_percent: u16,
     keybinds: Option<KeybindsConfig>,
+    /// How long to wait between checks for work done outside the app, or
+    /// None to only check when one is asked for.
+    #[serde(deserialize_with = "deserialize_poll_interval")]
+    poll_interval: Option<Duration>,
 }
 
 impl Default for JjConfigBlazingjj {
@@ -58,6 +65,7 @@ impl Default for JjConfigBlazingjj {
         Self {
             highlight_color: Color::Rgb(50, 50, 150),
             layout_percent: 50,
+            poll_interval: Some(Duration::from_secs(1)),
             // Standard defaults for the rest
             diff_format: None,
             diff_tool: None,
@@ -66,6 +74,16 @@ impl Default for JjConfigBlazingjj {
             keybinds: None,
         }
     }
+}
+
+/// Reads a number of seconds, of which zero means never checking.
+fn deserialize_poll_interval<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Option<Duration>, D::Error> {
+    let seconds = f64::deserialize(deserializer)?;
+    let interval = Duration::try_from_secs_f64(seconds).map_err(de::Error::custom)?;
+
+    Ok(Some(interval).filter(|interval| !interval.is_zero()))
 }
 
 #[derive(Deserialize, Debug, Clone, Default)]
@@ -126,6 +144,10 @@ impl JjConfig {
 
     pub fn keybinds(&self) -> Option<&KeybindsConfig> {
         self.blazingjj.keybinds.as_ref()
+    }
+
+    pub fn poll_interval(&self) -> Option<Duration> {
+        self.blazingjj.poll_interval
     }
 }
 
@@ -264,5 +286,28 @@ mod tests {
         );
         assert_eq!(diff_tool.render_width(MIN_SETTABLE_WIDTH - 1), 0);
         assert_eq!(diff_tool.render_width(0), 0);
+    }
+
+    #[test]
+    fn poll_interval() {
+        assert_eq!(
+            JjConfig::default().poll_interval(),
+            Some(Duration::from_secs(1))
+        );
+
+        // As `jj config list` prints it: a dotted key.
+        let config: JjConfig = toml::from_str("blazingjj.poll-interval = 0.5\n").unwrap();
+        assert_eq!(config.poll_interval(), Some(Duration::from_millis(500)));
+
+        let config: JjConfig = toml::from_str("blazingjj.poll-interval = 0\n").unwrap();
+        assert_eq!(config.poll_interval(), None);
+
+        // Anything that is not a length of time is a config error, as a
+        // bad value is for every other setting.
+        for interval in ["-1", "nan", "inf", "1e30", "\"1s\"", "true"] {
+            let config =
+                toml::from_str::<JjConfig>(&format!("blazingjj.poll-interval = {interval}\n"));
+            assert!(config.is_err(), "{interval}");
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,7 @@ mod event;
 mod keybinds;
 mod ui;
 use crate::app::App;
+use crate::app::Handled;
 use crate::commander::Commander;
 use crate::env::Env;
 use crate::env::set_env;
@@ -163,7 +164,7 @@ fn init_env() -> Result<Env> {
 
 fn run_app(terminal: &mut DefaultTerminal, app: &mut App) -> Result<()> {
     app.launch_input_channel();
-    let mut idle = false;
+    let mut quiet = false;
     loop {
         let mut changed = app.update()?;
 
@@ -171,32 +172,22 @@ fn run_app(terminal: &mut DefaultTerminal, app: &mut App) -> Result<()> {
 
         // Waking up to find that nothing has happened must not cost a
         // frame, or the app would rebuild the whole display for it.
-        if changed || !idle {
+        if changed || !quiet {
             terminal.draw(|f| {
                 let _ = app.draw(f, f.area());
             })?;
         }
 
         match input_to_app(app)? {
-            Input::Stop => return Ok(()),
-            Input::Handled => idle = false,
-            Input::Idle => idle = true,
+            Handled::Stop => return Ok(()),
+            Handled::Redraw => quiet = false,
+            Handled::Nothing => quiet = true,
         }
     }
 }
 
-/// What waiting for input produced.
-enum Input {
-    /// The app was asked to stop.
-    Stop,
-    /// Events were handled, so what the app shows may have changed.
-    Handled,
-    /// Nothing arrived before the wait ran out.
-    Idle,
-}
-
 /// Let app process all input events in queue before returning.
-fn input_to_app(app: &mut App) -> Result<Input> {
+fn input_to_app(app: &mut App) -> Result<Handled> {
     // Duration::MAX overflows the timespec struct used by kevent/kqueue on macOS,
     // causing EINVAL (os error 22). Use a safe large value instead.
     const FOREVER: Duration = Duration::from_secs(24 * 3600);
@@ -214,17 +205,20 @@ fn input_to_app(app: &mut App) -> Result<Input> {
     // Stop if an event requested the app to stop.
     let mut event = app.try_recv_app_event(wait_duration);
     app.stats.start_time = Instant::now();
-    let handled = event.is_some();
-    let mut should_stop: bool = false;
-    while event.is_some() && !should_stop {
-        should_stop = app.input(event.unwrap())?;
+    let mut changed = false;
+    while let Some(next) = event.take() {
+        match app.input(next)? {
+            Handled::Stop => return Ok(Handled::Stop),
+            Handled::Redraw => changed = true,
+            Handled::Nothing => {}
+        }
         event = app.try_recv_app_event(Duration::ZERO);
     }
 
-    Ok(match (should_stop, handled) {
-        (true, _) => Input::Stop,
-        (false, true) => Input::Handled,
-        (false, false) => Input::Idle,
+    Ok(if changed {
+        Handled::Redraw
+    } else {
+        Handled::Nothing
     })
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,8 +170,9 @@ fn run_app(terminal: &mut DefaultTerminal, app: &mut App) -> Result<()> {
 
         changed |= app.refresh_view()?;
 
-        // Waking up to find that nothing has happened must not cost a
-        // frame, or the app would rebuild the whole display for it.
+        // Waking up on a timer to find nothing has happened must not
+        // cost a frame, or an app nobody is touching would rebuild the
+        // whole display every poll interval.
         if changed || !quiet {
             terminal.draw(|f| {
                 let _ = app.draw(f, f.area());
@@ -193,12 +194,14 @@ fn input_to_app(app: &mut App) -> Result<Handled> {
     const FOREVER: Duration = Duration::from_secs(24 * 3600);
 
     // Something that counts up on its own needs a frame every 100ms.
-    // Everything else is delivered on the event channel, so there is
-    // nothing to wake up for.
+    // Otherwise the app may be due to check for work done outside it.
+    // With neither, everything is delivered on the event channel, so
+    // there is nothing to wake up for.
     let wait_duration = if app.needs_periodic_redraw() {
         Duration::from_millis(100)
     } else {
-        FOREVER
+        app.time_until_poll()
+            .map_or(FOREVER, |until| until.min(FOREVER))
     };
 
     // Handle all pending events in the queue.


### PR DESCRIPTION
The app only looks at what the repo is at when an event wakes the main
loop, and it looks from the loop itself, so a jj command run in another
terminal goes unnoticed until you touch something, and a repo that is
slow to answer holds up input and redraws while it is read. Move the
read into a background task and poll on a timer.

An answer that arrives late is the whole difficulty: what a check is to
do has to outlive the invocation that started it, and the loop has to
know whether a check answering changed anything on screen. Refreshing
under the user's fingers would be worse than being out of date, so a
change we come across ourselves is only applied while the terminal
window has no focus; with focus, the header's `R: refresh` hint turns
red instead and the view waits to be asked. `blazingjj.poll-interval`
sets the rate, or turns polling off entirely.