### PR TITLE
bookmarks: Ask where a new change from a bookmark goes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mouse as well: the wheel scrolls it, a click picks a parent, and a click
   outside dismisses it
 - The new-change dialog now asks where to put the change, so it can also be
-  inserted before or after the selected one rather than only as its child
+  inserted before or after the selected one rather than only as its child; the
+  bookmarks tab asks the same instead of only confirming
 - Work done outside the app, such as a jj command run in another terminal, is
   picked up on its own while the terminal window has no focus
 - `blazingjj.poll-interval` to set how often the app checks for it, or `0` to

--- a/src/commander/jj.rs
+++ b/src/commander/jj.rs
@@ -26,7 +26,9 @@ pub enum NewInsertMode {
 }
 
 impl Commander {
-    /// Create a new change. Maps to `jj new <revset>`.
+    /// Create a new change. Maps to `jj new <revset>`. Only the tests
+    /// create one without saying where it goes.
+    #[cfg(test)]
     pub fn run_new(&self, revset: impl Into<Revset>) -> Result<()> {
         self.run_new_with_insert(revset, NewInsertMode::Child)
     }

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -19,6 +19,7 @@ use crate::background_tasks::TaskResult;
 use crate::background_tasks::TaskSlot;
 use crate::commander::CommandError;
 use crate::commander::bookmarks::BookmarkLine;
+use crate::commander::jj::NewInsertMode;
 use crate::commander::new_commander;
 use crate::commander::revset::Revset;
 use crate::env::JjConfig;
@@ -35,6 +36,7 @@ use crate::ui::Tab;
 use crate::ui::dialog::BookmarkNamePopup;
 use crate::ui::dialog::DescribePopup;
 use crate::ui::dialog::MessagePopup;
+use crate::ui::dialog::new_insert;
 use crate::ui::panel::CommitShowPanel;
 use crate::ui::panel::ListPane;
 use crate::ui::panel::MouseInput;
@@ -51,7 +53,6 @@ struct ForgetBookmark {
 
 const DELETE_BRANCH_POPUP_ID: u16 = 1;
 const FORGET_BRANCH_POPUP_ID: u16 = 2;
-const NEW_POPUP_ID: u16 = 3;
 const EDIT_POPUP_ID: u16 = 4;
 
 /// Bookmarks tab. Shows bookmarks in main panel and selected bookmark current change in details panel.
@@ -79,6 +80,9 @@ pub struct BookmarksTab {
 
     bookmark_name_popup_tx: std::sync::mpsc::Sender<String>,
     bookmark_name_popup_rx: std::sync::mpsc::Receiver<String>,
+
+    new_insert_tx: std::sync::mpsc::Sender<NewInsertMode>,
+    new_insert_rx: std::sync::mpsc::Receiver<NewInsertMode>,
 
     config: JjConfig,
     keybinds: BookmarksTabKeybinds,
@@ -124,6 +128,7 @@ impl BookmarksTab {
     pub fn new(background_tasks: BackgroundTasks) -> Self {
         let (popup_tx, popup_rx) = std::sync::mpsc::channel();
         let (bookmark_name_popup_tx, bookmark_name_popup_rx) = std::sync::mpsc::channel();
+        let (new_insert_tx, new_insert_rx) = std::sync::mpsc::channel();
 
         let config = get_env().jj_config.clone();
         let pane_divider = PaneDivider::new(config.layout_percent());
@@ -153,6 +158,9 @@ impl BookmarksTab {
 
             bookmark_name_popup_tx,
             bookmark_name_popup_rx,
+
+            new_insert_tx,
+            new_insert_rx,
 
             config,
             keybinds,
@@ -228,6 +236,32 @@ impl BookmarksTab {
             self.show_bookmark();
         }
     }
+
+    /// Create the new change, once the insertion point has been picked.
+    fn execute_new(&mut self, insert: NewInsertMode) -> Result<Option<AppAction>> {
+        let describe = std::mem::take(&mut self.describe_after_new);
+        let Some(BookmarkLine::Parsed { bookmark, .. }) = self.bookmark.as_ref() else {
+            return Ok(None);
+        };
+
+        // Inserting can hit immutable changes, so report the refusal
+        // rather than moving on.
+        let revset = Revset::expression(bookmark.to_string());
+        if let Err(err) = new_commander().run_new_with_insert(revset, insert) {
+            return Ok(Some(AppAction::SetPopup(Box::new(
+                MessagePopup::new("New", format!("{err:#}")).text_align(Alignment::Left),
+            ))));
+        }
+
+        let head = new_commander().get_current_head()?;
+        if describe {
+            return Ok(Some(AppAction::SetPopup(Box::new(DescribePopup::new(
+                head,
+                vec![],
+            )))));
+        }
+        Ok(Some(AppAction::ViewLog(head)))
+    }
 }
 
 impl Tab for BookmarksTab {
@@ -274,6 +308,10 @@ impl Component for BookmarksTab {
     fn update(&mut self) -> Result<Option<AppAction>> {
         self.bookmark_panel.update();
 
+        if let Ok(insert) = self.new_insert_rx.try_recv() {
+            return self.execute_new(insert);
+        }
+
         // Check for popup action
         if let Ok(res) = self.popup_rx.try_recv()
             && res.1.unwrap_or(false)
@@ -302,21 +340,6 @@ impl Component for BookmarksTab {
                                     err.to_string(),
                                 )))));
                             }
-                        }
-                    }
-                }
-                NEW_POPUP_ID => {
-                    if let Some(BookmarkLine::Parsed { bookmark, .. }) = self.bookmark.as_ref() {
-                        new_commander().run_new(Revset::expression(bookmark.to_string()))?;
-                        let head = new_commander().get_current_head()?;
-                        if self.describe_after_new {
-                            self.describe_after_new = false;
-                            return Ok(Some(AppAction::SetPopup(Box::new(DescribePopup::new(
-                                head,
-                                vec![],
-                            )))));
-                        } else {
-                            return Ok(Some(AppAction::ViewLog(head)));
                         }
                     }
                 }
@@ -578,21 +601,14 @@ impl Component for BookmarksTab {
                     if let Some(BookmarkLine::Parsed { bookmark, .. }) = self.bookmark.as_ref()
                         && bookmark.present
                     {
-                        self.popup = ConfirmDialogState::new(
-                            NEW_POPUP_ID,
-                            Span::styled(" New ", Style::new().bold().cyan()),
-                            Text::from(vec![
-                                Line::from("Are you sure you want to create a new change?"),
-                                Line::from(format!("Bookmark: {bookmark}")),
-                            ]),
-                        );
-                        self.popup
-                            .with_yes_button(ButtonLabel::YES.clone())
-                            .with_no_button(ButtonLabel::NO.clone())
-                            .with_listener(Some(self.popup_tx.clone()))
-                            .open();
-
                         self.describe_after_new = describe;
+                        return Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
+                            Box::new(new_insert(
+                                self.config.clone(),
+                                self.new_insert_tx.clone(),
+                                &bookmark.to_string(),
+                            )),
+                        )));
                     }
                 }
                 BookmarksTabEvent::EditChange { ignore_immutable } => {

--- a/src/ui/dialog/mod.rs
+++ b/src/ui/dialog/mod.rs
@@ -16,6 +16,7 @@ mod describe;
 mod help;
 mod loader;
 mod message;
+mod new_insert;
 mod parent_select;
 mod rebase;
 
@@ -27,5 +28,6 @@ pub use describe::DescribePopup;
 pub use help::HelpPopup;
 pub use loader::LoaderPopup;
 pub use message::MessagePopup;
+pub use new_insert::new_insert;
 pub use parent_select::parent_select;
 pub use rebase::RebasePopup;

--- a/src/ui/dialog/new_insert.rs
+++ b/src/ui/dialog/new_insert.rs
@@ -1,0 +1,37 @@
+/*! Where a new change goes relative to the one it is created from. The
+pick is sent as a [`NewInsertMode`] over a channel; whoever put the popup
+up runs the command in its own `update`.
+*/
+
+use std::sync::mpsc::Sender;
+
+use ratatui::text::Line;
+
+use crate::commander::jj::NewInsertMode;
+use crate::env::JjConfig;
+use crate::ui::dialog::ChoicePopup;
+
+/// A popup offering the insertion points around `target`, which names
+/// what the new change is created from.
+pub fn new_insert(
+    config: JjConfig,
+    tx: Sender<NewInsertMode>,
+    target: &str,
+) -> ChoicePopup<NewInsertMode> {
+    let items = vec![
+        (
+            Line::raw(format!("New child of {target}")),
+            NewInsertMode::Child,
+        ),
+        (
+            Line::raw(format!("Insert after {target}")),
+            NewInsertMode::After,
+        ),
+        (
+            Line::raw(format!("Insert before {target}")),
+            NewInsertMode::Before,
+        ),
+    ];
+
+    ChoicePopup::new(config, tx, "New", items)
+}

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -37,11 +37,11 @@ use crate::ui::ComponentInputResult;
 use crate::ui::Scroll;
 use crate::ui::Tab;
 use crate::ui::dialog::BookmarkSetPopup;
-use crate::ui::dialog::ChoicePopup;
 use crate::ui::dialog::DescribePopup;
 use crate::ui::dialog::LoaderPopup;
 use crate::ui::dialog::MessagePopup;
 use crate::ui::dialog::RebasePopup;
+use crate::ui::dialog::new_insert;
 use crate::ui::dialog::parent_select;
 use crate::ui::panel::CommitShowPanel;
 use crate::ui::panel::LogPanel;
@@ -240,27 +240,12 @@ impl<'a> LogTab<'a> {
         } else {
             self.head.change_id.as_str().chars().take(8).collect()
         };
-        let items = vec![
-            (
-                Line::raw(format!("New child of {target}")),
-                NewInsertMode::Child,
-            ),
-            (
-                Line::raw(format!("Insert after {target}")),
-                NewInsertMode::After,
-            ),
-            (
-                Line::raw(format!("Insert before {target}")),
-                NewInsertMode::Before,
-            ),
-        ];
         self.describe_after_new = describe;
         Ok(ComponentInputResult::HandledAction(AppAction::SetPopup(
-            Box::new(ChoicePopup::new(
+            Box::new(new_insert(
                 self.config.clone(),
                 self.new_insert_tx.clone(),
-                "New",
-                items,
+                &target,
             )),
         )))
     }


### PR DESCRIPTION
The log tab asks where the new change goes, but the bookmarks tab still puts up a yes/no confirmation and always creates a child, so the same operation behaves differently depending on where it is started from. Pull the insertion-point popup out of the log tab and have both use it, which also reports a refusal from jj rather than letting the error bubble up. This leaves `run_new` to the tests, as everything else names an insertion point now.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
