### PR TITLE
ui: Dismiss a popup on a right click aimed past it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   have it only check when asked
 - The header's `R: refresh` hint turns red when the current tab has gone
   stale and the app is not going to catch it up on its own
+- A right click now takes a choice popup away: one inside it cancels, one
+  outside also goes on to the tab underneath, which may act on what was hit
 
 ### Changed
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -491,12 +491,17 @@ impl<'a> App<'a> {
             _ => {}
         }
 
+        let mut to_tab = self.popup.is_none();
         if let Some(popup) = self.popup.as_mut() {
             match popup.input(event.clone())? {
                 ComponentInputResult::HandledAction(app_action) => {
                     self.handle_action(app_action)?
                 }
                 ComponentInputResult::Handled => {}
+                ComponentInputResult::Dismissed => {
+                    self.popup = None;
+                    to_tab = true;
+                }
                 ComponentInputResult::NotHandled => {
                     if let TermEvent::Key(key) = event
                         && key.kind == event::KeyEventKind::Press
@@ -516,12 +521,16 @@ impl<'a> App<'a> {
                     }
                 }
             };
-        } else {
+        }
+
+        if to_tab {
             match self.get_current_tab().input(event.clone())? {
                 ComponentInputResult::HandledAction(app_action) => {
                     self.handle_action(app_action)?
                 }
-                ComponentInputResult::Handled => {}
+                // A tab is never on top of anything, so it has nothing
+                // to dismiss itself in favour of.
+                ComponentInputResult::Handled | ComponentInputResult::Dismissed => {}
                 ComponentInputResult::NotHandled => {
                     if let TermEvent::Key(key) = event
                         && key.kind == event::KeyEventKind::Press

--- a/src/ui/dialog/choice.rs
+++ b/src/ui/dialog/choice.rs
@@ -218,6 +218,15 @@ impl<T: Clone> Component for ChoicePopup<T> {
                             return self.confirm();
                         }
                     }
+                    // A right click outside still names what it hit, so
+                    // we let it through rather than only taking it as a
+                    // dismissal.
+                    MouseEventKind::Down(MouseButton::Right) => {
+                        if self.popup_area.contains(pos) {
+                            return Self::close();
+                        }
+                        return Ok(ComponentInputResult::Dismissed);
+                    }
                     _ => {}
                 }
             }
@@ -400,6 +409,36 @@ mod tests {
         assert!(matches!(
             click(&mut popup, 0, 0),
             ComponentInputResult::HandledAction(AppAction::PopupCanceled)
+        ));
+
+        assert!(rx.try_recv().is_err());
+    }
+
+    fn right_click(popup: &mut ChoicePopup<u8>, column: u16, row: u16) -> ComponentInputResult {
+        mouse(popup, MouseEventKind::Down(MouseButton::Right), column, row)
+    }
+
+    #[test]
+    fn right_clicking_a_choice_cancels_without_sending_it() {
+        let (mut popup, rx) = popup(3, 2);
+        draw(&mut popup);
+
+        assert!(matches!(
+            right_click(&mut popup, 30, 18),
+            ComponentInputResult::HandledAction(AppAction::PopupCanceled)
+        ));
+
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn right_clicking_outside_the_popup_dismisses_it_and_leaves_the_event_to_others() {
+        let (mut popup, rx) = popup(3, 0);
+        draw(&mut popup);
+
+        assert!(matches!(
+            right_click(&mut popup, 0, 0),
+            ComponentInputResult::Dismissed
         ));
 
         assert!(rx.try_recv().is_err());

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -44,6 +44,9 @@ pub enum ComponentInputResult {
     HandledAction(AppAction),
     /// The app should ask the next component in z-order to handle the event
     NotHandled,
+    /// The app should close this popup and then ask the next component
+    /// in z-order to handle the event.
+    Dismissed,
 }
 
 /// How far to move the selection in a tab's main panel.


### PR DESCRIPTION
A right click over a popup does nothing at all, though it is how the mouse asks for a menu and the click names something underneath. Let a popup answer with the new `Dismissed`, which has the app drop it and pass the event on to the tab, and have the choice popup take a right click that way when it lands outside itself, or as a plain cancel when it lands inside.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
