### PR TITLE
app: Stop following the selection twice when abandoning

### DIFF
--- a/src/app/command.rs
+++ b/src/app/command.rs
@@ -179,8 +179,9 @@ impl Command {
                     ),
                 };
 
-                // The selection has to come out of what is being
-                // abandoned, or it names a change that is no longer there.
+                // A tab following a change that is gone falls back to the
+                // working copy, which may be nowhere near what was being
+                // read, so take the selection to the parent instead.
                 let mut moved_to = selected.clone();
                 while abandoned.contains(&moved_to.commit_id) {
                     moved_to = new_commander().get_commit_parent(&moved_to.commit_id)?;
@@ -188,9 +189,6 @@ impl Command {
 
                 new_commander().run_abandon(revset)?;
 
-                // Abandoning may have rebased what the selection landed
-                // on.
-                let moved_to = new_commander().get_head_latest(&moved_to)?;
                 let mut actions = vec![
                     AppAction::ClearLogMarks,
                     AppAction::ViewLog(moved_to.clone()),


### PR DESCRIPTION
Abandoning reads the latest version of the change the selection lands on before handing it to the tabs, but each tab does that for itself as it reads: the log, files and evolog tabs all take their head through get_head_latest() when they refresh, and the operation marks them stale for exactly that. Drop the extra read.

What is left of the walk is where the selection lands rather than whether it stays valid: following a change that is gone falls back to the working copy on its own, which is just as likely to be somewhere else in the log, so the comment says so.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
