### PR TITLE
bookmarks: Handle a conflicted bookmark in tab and dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A duplicate jj turns down now says so, rather than looking like it worked
 - A file that cannot be untracked now reports what jj said about it, rather
   than guessing that it needs to be ignored
+- The bookmarks tab now lists a conflicted bookmark's targets under it, the
+  way `jj bookmark list` does, rather than only saying that it is conflicted;
+  selecting one shows that change in the details panel
 - A conflicted bookmark is now offered by the set-bookmark dialog, which is
   where it would be pointed at a single change to resolve it
 - Switching tabs right after an operation no longer briefly shows what they

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A duplicate jj turns down now says so, rather than looking like it worked
 - A file that cannot be untracked now reports what jj said about it, rather
   than guessing that it needs to be ignored
+- A conflicted bookmark is now offered by the set-bookmark dialog, which is
+  where it would be pointed at a single change to resolve it
 - Switching tabs right after an operation no longer briefly shows what they
   held before it
 - Going to the current change (`@`) now shows it right away, rather than

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The set-bookmark dialog now offers the bookmarks the change is standing on
+  first, nearest first, rather than ordering them by how recently the change
+  each points at was committed
 - The files tab now reads a change's files when it comes on screen, so an
   operation no longer runs `jj` for it while another tab is up
 - The help popup is now sized to fit what it lists

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Keybinding in the bookmarks tab to point a bookmark at the change the
+  selected line stands for (`b`, as in the log tab), which settles a bookmark
+  torn between several targets on the one selected, and moves a bookmark to
+  what one of its remotes has
 - Evolog tab, listing the versions a change has had and showing what the rewrite
   that produced the selected one changed; opened for the change selected in the
   log tab with `v` (`open-evolog`), or from the tab bar with `4`. A version's

--- a/src/app/command.rs
+++ b/src/app/command.rs
@@ -458,6 +458,26 @@ pub fn ask_forget_bookmark(config: JjConfig, name: &str) -> AppAction {
     )
 }
 
+/// Asking to put `bookmark` on `head`, which for one of several targets
+/// is what settles it on that one.
+pub fn ask_set_bookmark(config: JjConfig, bookmark: &Bookmark, head: &Head) -> AppAction {
+    confirm(
+        config,
+        "Set",
+        Text::from(vec![
+            Line::from(format!(
+                "Are you sure you want to move the {} bookmark?",
+                bookmark.name
+            )),
+            Line::from(format!("Onto: {}", head.change_id.as_str())),
+        ]),
+        Command::SetBookmark {
+            name: bookmark.name.clone(),
+            commit_id: head.commit_id.clone(),
+        },
+    )
+}
+
 /// Put `question` to the user, running `command` if they say yes.
 fn confirm(
     config: JjConfig,

--- a/src/app/command.rs
+++ b/src/app/command.rs
@@ -110,8 +110,6 @@ pub enum Command {
     ForgetBookmark(String),
     TrackBookmark(Bookmark),
     UntrackBookmark(Bookmark),
-    /// Move the log onto the change a bookmark points at.
-    ShowBookmarkInLog(Bookmark),
 }
 
 impl Command {
@@ -302,12 +300,6 @@ impl Command {
                     Err(err) => Ok(Some(refused("Untrack", err))),
                 }
             }
-            Command::ShowBookmarkInLog(bookmark) => {
-                match new_commander().get_bookmark_head(&bookmark) {
-                    Ok(head) => Ok(Some(AppAction::ViewLog(head))),
-                    Err(err) => Ok(Some(refused("View in log", err))),
-                }
-            }
         }
     }
 }
@@ -374,9 +366,14 @@ pub fn ask_squash(config: JjConfig, selected: &Head, ignore_immutable: bool) -> 
     ))
 }
 
-/// Asking to edit `target`: the refusal when it is immutable, or the
-/// question that runs it.
-pub fn ask_edit(config: JjConfig, target: &Head, ignore_immutable: bool) -> AppAction {
+/// Asking to edit `target`, which the question names as `subject`: the
+/// refusal when it is immutable, or the question that runs it.
+pub fn ask_edit(
+    config: JjConfig,
+    target: &Head,
+    subject: String,
+    ignore_immutable: bool,
+) -> AppAction {
     if target.immutable && !ignore_immutable {
         return message(
             "Edit",
@@ -386,7 +383,7 @@ pub fn ask_edit(config: JjConfig, target: &Head, ignore_immutable: bool) -> AppA
 
     let mut lines = vec![
         Line::from("Are you sure you want to edit an existing change?"),
-        Line::from(format!("Change: {}", target.change_id.as_str())),
+        Line::from(subject),
     ];
     if ignore_immutable {
         lines.push(Line::from("This change is immutable."));
@@ -401,35 +398,6 @@ pub fn ask_edit(config: JjConfig, target: &Head, ignore_immutable: bool) -> AppA
             ignore_immutable,
         },
     )
-}
-
-/// Asking to edit the change a bookmark points at, which unlike a change
-/// picked out of the log has to be looked up to know whether it can be.
-pub fn ask_edit_bookmark(
-    config: JjConfig,
-    bookmark: &Bookmark,
-    ignore_immutable: bool,
-) -> Result<AppAction> {
-    let revset = Revset::expression(bookmark.to_string());
-    if new_commander().check_revision_immutable(revset.as_str())? && !ignore_immutable {
-        return Ok(message(
-            "Edit",
-            "The change cannot be edited because it is immutable.",
-        ));
-    }
-
-    Ok(confirm(
-        config,
-        "Edit",
-        Text::from(vec![
-            Line::from("Are you sure you want to edit an existing change?"),
-            Line::from(format!("Bookmark: {bookmark}")),
-        ]),
-        Command::Edit {
-            revset,
-            ignore_immutable,
-        },
-    ))
 }
 
 /// Asking to abandon the `marked` changes, or `selected` when none are
@@ -598,7 +566,12 @@ mod tests {
     #[test]
     fn an_immutable_change_is_refused_rather_than_asked_about() {
         assert!(says(
-            ask_edit(JjConfig::default(), &head("a", true), false),
+            ask_edit(
+                JjConfig::default(),
+                &head("a", true),
+                "Change: a".to_owned(),
+                false,
+            ),
             "because it is immutable"
         ));
     }
@@ -606,7 +579,12 @@ mod tests {
     #[test]
     fn an_immutable_change_is_asked_about_when_immutability_is_ignored() {
         assert!(says(
-            ask_edit(JjConfig::default(), &head("a", true), true),
+            ask_edit(
+                JjConfig::default(),
+                &head("a", true),
+                "Change: a".to_owned(),
+                true,
+            ),
             "This change is immutable"
         ));
     }

--- a/src/commander/bookmarks.rs
+++ b/src/commander/bookmarks.rs
@@ -55,31 +55,45 @@ struct BookmarkRecord {
     head: Head,
 }
 
-/// Template writing a [BookmarkRecord] as a JSON object, one per line.
+/// The [Bookmark] fields, as the members of a JSON object without the
+/// braces around them.
 ///
 /// `name` and `remote` are revset symbols, which jj only quotes when it
 /// renders them as a template -- `stringify()` alone would hand back the
 /// bare name. Concatenating is what puts them through that rendering.
+const BOOKMARK_FIELDS: &str = r#"
+    '"name":' ++ stringify(concat(name)).escape_json()
+    ++ ',"remote":' ++ if(remote, stringify(concat(remote)).escape_json(), 'null')
+    ++ ',"present":' ++ present
+"#;
+
+/// Template writing a [Bookmark] as a JSON object, one per line. Says
+/// nothing about what the bookmark points at, so a bookmark with no
+/// single target is written like any other.
+fn bookmark_only_template() -> String {
+    format!(r#"'{{' ++ {BOOKMARK_FIELDS} ++ '}}' ++ "\n""#)
+}
+
+/// Template writing a [BookmarkRecord] as a JSON object, one per line.
 ///
 /// A bookmark that has no single target has no head, and jj writes its
 /// error where one belongs. That leaves the line unparsable, which is how
-/// such a bookmark is meant to come out.
+/// such a bookmark is meant to come out of a listing that shows what each
+/// one points at.
 fn bookmark_template() -> String {
     let head = head_template("self.normal_target()");
-    format!(
-        r#"
-    '{{"name":' ++ stringify(concat(name)).escape_json()
-    ++ ',"remote":' ++ if(remote, stringify(concat(remote)).escape_json(), 'null')
-    ++ ',"present":' ++ present
-    ++ ',"head":' ++ {head}
-    ++ '}}' ++ "\n"
-"#
-    )
+    format!(r#"'{{' ++ {BOOKMARK_FIELDS} ++ ',"head":' ++ {head} ++ '}}' ++ "\n""#)
 }
 
 /// Parse the [BookmarkRecord] one line of [bookmark_template] output
 /// describes.
 fn parse_bookmark(text: &str) -> Option<BookmarkRecord> {
+    serde_json::from_str(text).ok()
+}
+
+/// Parse the [Bookmark] one line of [bookmark_only_template] output
+/// describes.
+fn parse_bookmark_only(text: &str) -> Option<Bookmark> {
     serde_json::from_str(text).ok()
 }
 
@@ -168,7 +182,7 @@ impl Commander {
             "bookmark".to_owned(),
             "list".to_owned(),
             "-T".to_owned(),
-            format!(r#"if(present, {}, "")"#, bookmark_template()),
+            format!(r#"if(present, {}, "")"#, bookmark_only_template()),
         ];
         if show_all {
             args.push("--all-remotes".to_owned());
@@ -180,8 +194,7 @@ impl Commander {
             .ignore_working_copy()
             .run()?
             .lines()
-            .filter_map(parse_bookmark)
-            .map(|record| record.bookmark)
+            .filter_map(parse_bookmark_only)
             .sorted_by_key(|bookmark| match bookmark.remote {
                 // Only local bookmarks are ranked, so one on a remote
                 // would otherwise take the rank of the local bookmark it
@@ -474,6 +487,59 @@ mod tests {
         assert_eq!(names.last(), Some(&"aside".to_owned()), "{names:?}");
         assert!(names.contains(&"both".to_owned()), "{names:?}");
         assert!(names.contains(&"here".to_owned()), "{names:?}");
+
+        Ok(())
+    }
+
+    /// A bookmark with more than one target has no single commit to
+    /// point at. Leaving it out would hide it from the one listing that
+    /// offers to set it, which is how such a bookmark is resolved.
+    #[test]
+    fn get_bookmarks_list_offers_a_conflicted_bookmark() -> Result<()> {
+        let test_repo = TestRepo::new()?;
+        let commander = &test_repo.commander;
+
+        commander.jj(["new", "root()", "-m", "one"]).run_void()?;
+        let one = commander.get_current_head()?.commit_id;
+        commander.jj(["new", "root()", "-m", "two"]).run_void()?;
+        let two = commander.get_current_head()?.commit_id;
+
+        // Two operations from the same point, each putting the bookmark
+        // somewhere else, is what leaves it with both targets.
+        let at_op = commander
+            .jj([
+                "op",
+                "log",
+                "--no-graph",
+                "--limit",
+                "1",
+                "-T",
+                "id.short()",
+            ])
+            .run()?;
+        commander
+            .jj(["bookmark", "create", "bm", "-r", one.as_str()])
+            .run_void()?;
+        commander
+            .jj([
+                "--at-op",
+                at_op.trim(),
+                "bookmark",
+                "create",
+                "bm",
+                "-r",
+                two.as_str(),
+            ])
+            .run_void()?;
+
+        let names: Vec<String> = commander
+            .get_bookmarks_list(false, &two)?
+            .into_iter()
+            .filter(|bookmark| bookmark.remote.is_none())
+            .map(|bookmark| bookmark.name)
+            .collect();
+
+        assert_eq!(names, ["bm"]);
 
         Ok(())
     }

--- a/src/commander/bookmarks.rs
+++ b/src/commander/bookmarks.rs
@@ -376,7 +376,8 @@ mod tests {
     fn get_bookmarks_reads_the_change_each_bookmark_points_at() -> Result<()> {
         let test_repo = TestRepo::new()?;
 
-        let bookmark = test_repo.commander.create_bookmark("test")?;
+        // The bookmark is created on the change the working copy is on.
+        test_repo.commander.create_bookmark("test")?;
         let bookmarks = test_repo.commander.get_bookmarks(false)?;
 
         assert_eq!(
@@ -384,7 +385,7 @@ mod tests {
                 BookmarkLine::Parsed { head, .. } => Some(head.clone()),
                 BookmarkLine::Unparsable(_) => None,
             }),
-            Some(test_repo.commander.get_bookmark_head(&bookmark)?)
+            Some(test_repo.commander.get_current_head()?)
         );
 
         Ok(())

--- a/src/commander/bookmarks.rs
+++ b/src/commander/bookmarks.rs
@@ -76,13 +76,25 @@ fn bookmark_only_template() -> String {
 
 /// Template writing a [BookmarkRecord] as a JSON object, one per line.
 ///
-/// A bookmark that has no single target has no head, and jj writes its
-/// error where one belongs. That leaves the line unparsable, which is how
-/// such a bookmark is meant to come out of a listing that shows what each
-/// one points at.
+/// A bookmark with more than one target is written the way jj lists it:
+/// a line naming the bookmark, which points at no change of its own and
+/// so holds no head, and one line per target under it.
 fn bookmark_template() -> String {
-    let head = head_template("self.normal_target()");
-    format!(r#"'{{' ++ {BOOKMARK_FIELDS} ++ ',"head":' ++ {head} ++ '}}' ++ "\n""#)
+    let record =
+        |head: &str| format!(r#"'{{' ++ {BOOKMARK_FIELDS} ++ ',"head":' ++ {head} ++ '}}'"#);
+    let single = record(&head_template("self.normal_target()"));
+    let target = record(&head_template("target"));
+
+    format!(
+        r#"
+if(self.conflict(),
+  '{{' ++ {BOOKMARK_FIELDS} ++ '}}' ++ "\n"
+  ++ self.removed_targets().map(|target| {target} ++ "\n").join("")
+  ++ self.added_targets().map(|target| {target} ++ "\n").join(""),
+  {single} ++ "\n",
+)
+"#
+    )
 }
 
 /// Parse the [BookmarkRecord] one line of [bookmark_template] output
@@ -130,22 +142,7 @@ impl Commander {
         args.push("--sort");
         args.push("committer-date-");
         let bookmarks_colored = self
-            .jj([
-                vec![
-                    "bookmark",
-                    "list",
-                    "--config",
-                    // Override format_ref_targets to not list conflicts
-                    r#"template-aliases.'format_ref_targets(ref)'='''
-                        if(ref.conflict(),
-                          " " ++ label("conflict", "(conflicted)"),
-                          ": " ++ format_commit_summary_with_refs(ref.normal_target(), ""),
-                        )
-                    '''"#,
-                ],
-                args.clone(),
-            ]
-            .concat())
+            .jj([vec!["bookmark", "list"], args.clone()].concat())
             .color()
             .ignore_working_copy()
             .run()?;
@@ -491,21 +488,36 @@ mod tests {
         Ok(())
     }
 
-    /// A bookmark with more than one target has no single commit to
-    /// point at. Leaving it out would hide it from the one listing that
-    /// offers to set it, which is how such a bookmark is resolved.
-    #[test]
-    fn get_bookmarks_list_offers_a_conflicted_bookmark() -> Result<()> {
+    /// A repo whose only bookmark is torn between three targets: two
+    /// operations from the same point, each moving it somewhere else,
+    /// leave the change it was on as the one given up and both of the
+    /// changes it was moved to as ones taken, which is jj's `-` and `+`.
+    fn conflicted_bookmark() -> Result<TestRepo> {
         let test_repo = TestRepo::new()?;
         let commander = &test_repo.commander;
 
-        commander.jj(["new", "root()", "-m", "one"]).run_void()?;
-        let one = commander.get_current_head()?.commit_id;
-        commander.jj(["new", "root()", "-m", "two"]).run_void()?;
-        let two = commander.get_current_head()?.commit_id;
+        let change = |message: &str| -> Result<CommitId> {
+            commander.jj(["new", "root()", "-m", message]).run_void()?;
 
-        // Two operations from the same point, each putting the bookmark
-        // somewhere else, is what leaves it with both targets.
+            Ok(commander.get_current_head()?.commit_id)
+        };
+        let base = change("base")?;
+        let one = change("one")?;
+        let two = change("two")?;
+
+        let set_to = |commit_id: &CommitId| {
+            vec![
+                "bookmark".to_owned(),
+                "set".to_owned(),
+                "bm".to_owned(),
+                "-r".to_owned(),
+                commit_id.as_str().to_owned(),
+                "--allow-backwards".to_owned(),
+            ]
+        };
+        commander
+            .jj(["bookmark", "create", "bm", "-r", base.as_str()])
+            .run_void()?;
         let at_op = commander
             .jj([
                 "op",
@@ -517,29 +529,89 @@ mod tests {
                 "id.short()",
             ])
             .run()?;
-        commander
-            .jj(["bookmark", "create", "bm", "-r", one.as_str()])
-            .run_void()?;
+        commander.jj(set_to(&one)).run_void()?;
         commander
             .jj([
-                "--at-op",
-                at_op.trim(),
-                "bookmark",
-                "create",
-                "bm",
-                "-r",
-                two.as_str(),
-            ])
+                vec!["--at-op".to_owned(), at_op.trim().to_owned()],
+                set_to(&two),
+            ]
+            .concat())
             .run_void()?;
 
+        Ok(test_repo)
+    }
+
+    /// A bookmark with more than one target has no single commit to
+    /// point at. Leaving it out would hide it from the one listing that
+    /// offers to set it, which is how such a bookmark is resolved.
+    #[test]
+    fn get_bookmarks_list_offers_a_conflicted_bookmark() -> Result<()> {
+        let test_repo = conflicted_bookmark()?;
+        let commander = &test_repo.commander;
+        let on = commander.get_current_head()?.commit_id;
+
         let names: Vec<String> = commander
-            .get_bookmarks_list(false, &two)?
+            .get_bookmarks_list(false, &on)?
             .into_iter()
             .filter(|bookmark| bookmark.remote.is_none())
             .map(|bookmark| bookmark.name)
             .collect();
 
         assert_eq!(names, ["bm"]);
+
+        Ok(())
+    }
+
+    /// jj lists such a bookmark as a line naming it and one per target,
+    /// and the tab shows what jj prints, so the two have to agree on how
+    /// many lines that is.
+    #[test]
+    fn get_bookmarks_lists_a_conflicted_bookmark_once_per_target() -> Result<()> {
+        let test_repo = conflicted_bookmark()?;
+        let commander = &test_repo.commander;
+
+        let listed = commander.get_bookmarks(false)?;
+        let targets: Vec<CommitId> = listed
+            .iter()
+            .filter_map(|line| match line {
+                BookmarkLine::Parsed { bookmark, head, .. } if bookmark.remote.is_none() => {
+                    Some(head.commit_id.clone())
+                }
+                _ => None,
+            })
+            .collect();
+        let naming = listed
+            .iter()
+            .filter(|line| matches!(line, BookmarkLine::Unparsable(_)))
+            .count();
+
+        // The line naming the bookmark points at nothing, and each of the
+        // three below it holds the target it stands for.
+        assert_eq!(naming, 1, "{listed:?}");
+        assert_eq!(targets.iter().unique().count(), 3, "{listed:?}");
+
+        Ok(())
+    }
+
+    /// The two listings are paired line by line, so a target has to end
+    /// up beside the line jj wrote about that same target.
+    #[test]
+    fn get_bookmarks_pairs_each_target_with_what_jj_says_about_it() -> Result<()> {
+        let test_repo = conflicted_bookmark()?;
+
+        let mismatched: Vec<BookmarkLine> = test_repo
+            .commander
+            .get_bookmarks(false)?
+            .into_iter()
+            .filter(|line| match line {
+                BookmarkLine::Parsed { text, head, .. } => {
+                    !text.contains(&head.commit_id.as_str()[..8])
+                }
+                BookmarkLine::Unparsable(_) => false,
+            })
+            .collect();
+
+        assert!(mismatched.is_empty(), "{mismatched:?}");
 
         Ok(())
     }

--- a/src/commander/bookmarks.rs
+++ b/src/commander/bookmarks.rs
@@ -6,6 +6,7 @@ other jj bookmark commands are defined in module [jj][super::jj].
 
 It is mostly used in the [bookmarks_tab][crate::ui::bookmarks_tab] module.
 */
+use std::collections::HashMap;
 use std::fmt::Display;
 
 use ansi_to_tui::IntoText;
@@ -18,6 +19,7 @@ use tracing::instrument;
 use crate::commander::CommandError;
 use crate::commander::Commander;
 use crate::commander::ids::ChangeId;
+use crate::commander::ids::CommitId;
 use crate::commander::log::Head;
 use crate::commander::log::head_template;
 
@@ -31,7 +33,6 @@ pub struct Bookmark {
     pub name: String,
     pub remote: Option<String>,
     pub present: bool,
-    pub timestamp: i64,
 }
 
 impl Display for Bookmark {
@@ -60,9 +61,9 @@ struct BookmarkRecord {
 /// renders them as a template -- `stringify()` alone would hand back the
 /// bare name. Concatenating is what puts them through that rendering.
 ///
-/// A bookmark that has no single target has neither timestamp nor head,
-/// and jj writes its error where each of them belongs. That leaves the
-/// line unparsable, which is how such a bookmark is meant to come out.
+/// A bookmark that has no single target has no head, and jj writes its
+/// error where one belongs. That leaves the line unparsable, which is how
+/// such a bookmark is meant to come out.
 fn bookmark_template() -> String {
     let head = head_template("self.normal_target()");
     format!(
@@ -70,7 +71,6 @@ fn bookmark_template() -> String {
     '{{"name":' ++ stringify(concat(name)).escape_json()
     ++ ',"remote":' ++ if(remote, stringify(concat(remote)).escape_json(), 'null')
     ++ ',"present":' ++ present
-    ++ ',"timestamp":' ++ self.normal_target().committer().timestamp().format("%s")
     ++ ',"head":' ++ {head}
     ++ '}}' ++ "\n"
 "#
@@ -155,10 +155,15 @@ impl Commander {
         Ok(bookmarks)
     }
 
-    /// Get the bookmarks that exist, newest first, leaving the working
-    /// copy alone.
+    /// The bookmarks that exist, the ones `near` already stands on first
+    /// and the nearest of those before the rest: a bookmark is usually
+    /// set on a change it is behind. Leaves the working copy alone.
     #[instrument(level = "trace", skip(self))]
-    pub fn get_bookmarks_list(&self, show_all: bool) -> Result<Vec<Bookmark>, CommandError> {
+    pub fn get_bookmarks_list(
+        &self,
+        show_all: bool,
+        near: &CommitId,
+    ) -> Result<Vec<Bookmark>, CommandError> {
         let mut args = vec![
             "bookmark".to_owned(),
             "list".to_owned(),
@@ -169,6 +174,7 @@ impl Commander {
             args.push("--all-remotes".to_owned());
         }
 
+        let ranks = self.get_bookmark_ranks(near)?;
         let bookmarks: Vec<Bookmark> = self
             .jj(args)
             .ignore_working_copy()
@@ -176,10 +182,47 @@ impl Commander {
             .lines()
             .filter_map(parse_bookmark)
             .map(|record| record.bookmark)
-            .sorted_by(|a, b| b.timestamp.cmp(&a.timestamp))
+            .sorted_by_key(|bookmark| match bookmark.remote {
+                // Only local bookmarks are ranked, so one on a remote
+                // would otherwise take the rank of the local bookmark it
+                // shares a name with.
+                Some(_) => usize::MAX,
+                None => ranks.get(&bookmark.name).copied().unwrap_or(usize::MAX),
+            })
             .collect();
 
         Ok(bookmarks)
+    }
+
+    /// Where each local bookmark on an ancestor of `commit_id` comes in
+    /// walking back from it, nearest first, by name. One with more than
+    /// one target is ranked by whichever of them is reached first.
+    ///
+    /// Ranking a bookmark on a remote by the same name would say where
+    /// the remote has it rather than where it is, so both the revset and
+    /// the template leave those out.
+    fn get_bookmark_ranks(
+        &self,
+        commit_id: &CommitId,
+    ) -> Result<HashMap<String, usize>, CommandError> {
+        let listed = self
+            .jj([
+                "log",
+                "-r",
+                &format!("bookmarks() & ::{}", commit_id.as_str()),
+                "--no-graph",
+                "-T",
+                r#"local_bookmarks.map(|bookmark| bookmark.name()).join("\n") ++ "\n""#,
+            ])
+            .ignore_working_copy()
+            .run()?;
+
+        let mut ranks = HashMap::new();
+        for (rank, name) in listed.lines().enumerate() {
+            ranks.entry(name.to_owned()).or_insert(rank);
+        }
+
+        Ok(ranks)
     }
 
     #[instrument(level = "trace", skip(self))]
@@ -229,13 +272,12 @@ mod tests {
     fn parse_bookmark_reads_a_local_bookmark() {
         assert_eq!(
             parse_bookmark_of(&bookmark_line(
-                r#""name":"main","remote":null,"present":true,"timestamp":1786973730"#
+                r#""name":"main","remote":null,"present":true"#
             )),
             Some(Bookmark {
                 name: "main".to_owned(),
                 remote: None,
                 present: true,
-                timestamp: 1786973730,
             })
         );
     }
@@ -244,13 +286,12 @@ mod tests {
     fn parse_bookmark_reads_a_remote_bookmark() {
         assert_eq!(
             parse_bookmark_of(&bookmark_line(
-                r#""name":"main","remote":"origin","present":false,"timestamp":1786973730"#
+                r#""name":"main","remote":"origin","present":false"#
             )),
             Some(Bookmark {
                 name: "main".to_owned(),
                 remote: Some("origin".to_owned()),
                 present: false,
-                timestamp: 1786973730,
             })
         );
     }
@@ -261,13 +302,12 @@ mod tests {
     fn parse_bookmark_reads_a_name_that_needed_quoting() {
         assert_eq!(
             parse_bookmark_of(&bookmark_line(
-                r#""name":"\"feature@v2\"","remote":"origin","present":true,"timestamp":1"#
+                r#""name":"\"feature@v2\"","remote":"origin","present":true"#
             )),
             Some(Bookmark {
                 name: "\"feature@v2\"".to_owned(),
                 remote: Some("origin".to_owned()),
                 present: true,
-                timestamp: 1,
             })
         );
     }
@@ -276,7 +316,7 @@ mod tests {
     fn parse_bookmark_reads_the_change_the_bookmark_points_at() {
         assert_eq!(
             parse_bookmark(&bookmark_line(
-                r#""name":"main","remote":null,"present":true,"timestamp":1"#
+                r#""name":"main","remote":null,"present":true"#
             ))
             .map(|record| record.head),
             Some(head())
@@ -284,12 +324,12 @@ mod tests {
     }
 
     /// Which is what jj leaves behind for a bookmark without a single
-    /// target, in place of the timestamp and of the head.
+    /// target, in place of the head.
     #[test]
     fn parse_bookmark_rejects_a_record_holding_an_error() {
         assert!(
             parse_bookmark(
-                r#"{"name":"main","remote":null,"present":true,"timestamp":<Error: No commit available>,"head":<Error: No commit available>}"#
+                r#"{"name":"main","remote":null,"present":true,"head":<Error: No commit available>}"#
             )
             .is_none()
         );
@@ -309,7 +349,6 @@ mod tests {
                     name: bookmark.name.clone(),
                     remote: bookmark.remote.clone(),
                     present: bookmark.present,
-                    timestamp: 0,
                 }),
                 _ => None,
             }),
@@ -317,7 +356,6 @@ mod tests {
                 name: bookmark.name.clone(),
                 remote: bookmark.remote.clone(),
                 present: bookmark.present,
-                timestamp: 0,
             })
         );
 
@@ -347,7 +385,7 @@ mod tests {
         let test_repo = TestRepo::new()?;
 
         let bookmark = test_repo.commander.create_bookmark("test")?;
-        let bookmarks = test_repo.commander.get_bookmarks_list(false)?;
+        let bookmarks = test_repo.bookmarks()?;
 
         assert_eq!(
             bookmarks
@@ -356,16 +394,86 @@ mod tests {
                     name: b.name.clone(),
                     remote: b.remote.clone(),
                     present: b.present,
-                    timestamp: 0,
                 })
                 .collect::<Vec<_>>(),
             [Bookmark {
                 name: bookmark.name,
                 remote: bookmark.remote,
                 present: bookmark.present,
-                timestamp: 0,
             }]
         );
+
+        Ok(())
+    }
+
+    /// The names the set-bookmark dialog would list, in the order it
+    /// would offer them.
+    fn listed_names(test_repo: &TestRepo) -> Result<Vec<String>> {
+        Ok(test_repo
+            .bookmarks()?
+            .into_iter()
+            .map(|bookmark| bookmark.name)
+            .collect())
+    }
+
+    /// The one the change is standing on is the one it is most likely to
+    /// be moved to.
+    #[test]
+    fn get_bookmarks_list_offers_the_nearest_bookmark_first() -> Result<()> {
+        let test_repo = TestRepo::new()?;
+        let commander = &test_repo.commander;
+
+        // near <- far, with the working copy on top of both.
+        commander.create_bookmark("far")?;
+        commander.run_new(&commander.get_current_head()?.commit_id)?;
+        commander.create_bookmark("near")?;
+        commander.run_new(&commander.get_current_head()?.commit_id)?;
+
+        assert_eq!(listed_names(&test_repo)?, ["near", "far"]);
+
+        Ok(())
+    }
+
+    /// One the change is not standing on is still worth offering, just
+    /// not before the ones it is.
+    #[test]
+    fn get_bookmarks_list_offers_a_bookmark_off_to_the_side_last() -> Result<()> {
+        let test_repo = TestRepo::new()?;
+        let commander = &test_repo.commander;
+
+        commander.create_bookmark("behind")?;
+        let behind = commander.get_current_head()?.commit_id;
+        commander.jj(["new", "root()"]).run_void()?;
+        commander.create_bookmark("aside")?;
+        commander.run_new(&behind)?;
+
+        assert_eq!(listed_names(&test_repo)?, ["behind", "aside"]);
+
+        Ok(())
+    }
+
+    /// Two bookmarks on one change are one line of the ranking each, so
+    /// neither swallows the other.
+    #[test]
+    fn get_bookmarks_list_offers_every_bookmark_on_the_same_change() -> Result<()> {
+        let test_repo = TestRepo::new()?;
+        let commander = &test_repo.commander;
+
+        // Both are ranked only if the change they share is read as two
+        // names rather than as one run-together name, which would leave
+        // them behind the bookmark off to the side.
+        commander.jj(["new", "root()"]).run_void()?;
+        commander.create_bookmark("aside")?;
+        commander.jj(["new", "root()"]).run_void()?;
+        commander.create_bookmark("both")?;
+        commander.create_bookmark("here")?;
+        commander.run_new(&commander.get_current_head()?.commit_id)?;
+
+        let names = listed_names(&test_repo)?;
+
+        assert_eq!(names.last(), Some(&"aside".to_owned()), "{names:?}");
+        assert!(names.contains(&"both".to_owned()), "{names:?}");
+        assert!(names.contains(&"here".to_owned()), "{names:?}");
 
         Ok(())
     }

--- a/src/commander/jj.rs
+++ b/src/commander/jj.rs
@@ -201,7 +201,6 @@ impl Commander {
             name: name.to_owned(),
             remote: None,
             present: true,
-            timestamp: chrono::Utc::now().timestamp(),
         })
     }
 
@@ -432,7 +431,7 @@ mod tests {
         let test_repo = TestRepo::new()?;
 
         let bookmark = test_repo.commander.create_bookmark("test")?;
-        let bookmarks = test_repo.commander.get_bookmarks_list(false)?;
+        let bookmarks = test_repo.bookmarks()?;
 
         assert_eq!(
             bookmarks,
@@ -440,7 +439,6 @@ mod tests {
                 name: bookmark.name,
                 remote: bookmark.remote,
                 present: bookmark.present,
-                timestamp: bookmarks[0].timestamp,
             }]
         );
 
@@ -532,14 +530,13 @@ mod tests {
 
         let bookmark = test_repo.commander.create_bookmark("test1")?;
 
-        let bookmarks = test_repo.commander.get_bookmarks_list(false)?;
+        let bookmarks = test_repo.bookmarks()?;
         assert_eq!(
             bookmarks,
             [Bookmark {
                 name: bookmark.name.clone(),
                 remote: bookmark.remote,
                 present: bookmark.present,
-                timestamp: bookmarks[0].timestamp,
             }]
         );
 
@@ -547,14 +544,13 @@ mod tests {
             .commander
             .rename_bookmark(&bookmark.name, "test2")?;
 
-        let bookmarks = test_repo.commander.get_bookmarks_list(false)?;
+        let bookmarks = test_repo.bookmarks()?;
         assert_eq!(
             bookmarks,
             [Bookmark {
                 name: "test2".to_owned(),
                 remote: None,
                 present: true,
-                timestamp: bookmarks[0].timestamp,
             }]
         );
 
@@ -567,20 +563,19 @@ mod tests {
 
         let bookmark = test_repo.commander.create_bookmark("test")?;
 
-        let bookmarks = test_repo.commander.get_bookmarks_list(false)?;
+        let bookmarks = test_repo.bookmarks()?;
         assert_eq!(
             bookmarks,
             [Bookmark {
                 name: bookmark.name.clone(),
                 remote: bookmark.remote,
                 present: bookmark.present,
-                timestamp: bookmarks[0].timestamp,
             }]
         );
 
         test_repo.commander.delete_bookmark(&bookmark.name)?;
 
-        let bookmarks = test_repo.commander.get_bookmarks_list(false)?;
+        let bookmarks = test_repo.bookmarks()?;
         assert_eq!(bookmarks, []);
 
         Ok(())
@@ -592,20 +587,19 @@ mod tests {
 
         let bookmark = test_repo.commander.create_bookmark("test")?;
 
-        let bookmarks = test_repo.commander.get_bookmarks_list(false)?;
+        let bookmarks = test_repo.bookmarks()?;
         assert_eq!(
             bookmarks,
             [Bookmark {
                 name: bookmark.name.clone(),
                 remote: bookmark.remote,
                 present: bookmark.present,
-                timestamp: bookmarks[0].timestamp,
             }]
         );
 
         test_repo.commander.forget_bookmark(&bookmark.name)?;
 
-        let bookmarks = test_repo.commander.get_bookmarks_list(false)?;
+        let bookmarks = test_repo.bookmarks()?;
         assert_eq!(bookmarks, []);
 
         Ok(())

--- a/src/commander/log.rs
+++ b/src/commander/log.rs
@@ -20,7 +20,6 @@ use crate::commander::CommandError;
 use crate::commander::Commander;
 use crate::commander::JjCommand;
 use crate::commander::RemoveEndLine;
-use crate::commander::bookmarks::Bookmark;
 use crate::commander::ids::ChangeId;
 use crate::commander::ids::CommitId;
 use crate::env::DiffFormat;
@@ -392,29 +391,6 @@ impl Commander {
             .with_context(|| format!("Failed getting commit description: {commit_id}"))?
             .remove_end_line())
     }
-
-    /// Check if a revision is immutable
-    /// Maps to `jj log -r <revision> -T immutable`
-    #[instrument(level = "trace", skip(self))]
-    pub fn check_revision_immutable(&self, revision: &str) -> Result<bool> {
-        Ok(self
-            .execute_jj_log_one(revision, "immutable")
-            .with_context(|| format!("Failed checking if revision is immutable: {revision}"))?
-            .remove_end_line()
-            == "true")
-    }
-
-    /// Get bookmark head
-    /// Maps to `jj log -r <bookmark>[@<remote>]`
-    #[instrument(level = "trace", skip(self))]
-    pub fn get_bookmark_head(&self, bookmark: &Bookmark) -> Result<Head> {
-        parse_record(
-            &self
-                .execute_jj_log_one(&bookmark.to_string(), &head_template_nl())
-                .context("Failed getting bookmark head")?
-                .remove_end_line(),
-        )
-    }
 }
 
 #[cfg(test)]
@@ -693,28 +669,6 @@ mod tests {
         assert_ne!(old_head, new_head);
 
         assert_eq!(new_head, test_repo.commander.get_head_latest(&old_head)?);
-
-        Ok(())
-    }
-
-    #[test]
-    fn check_revision_immutable() -> Result<()> {
-        let test_repo = TestRepo::new()?;
-
-        assert!(!(test_repo.commander.check_revision_immutable("@")?));
-
-        Ok(())
-    }
-
-    #[test]
-    fn get_bookmark_head() -> Result<()> {
-        let test_repo = TestRepo::new()?;
-
-        let head = test_repo.commander.get_current_head()?;
-        // Git doesn't support bookmark pointing to root commit, so it will advance
-        let bookmark = test_repo.commander.create_bookmark("main")?;
-
-        assert_eq!(test_repo.commander.get_bookmark_head(&bookmark)?, head);
 
         Ok(())
     }

--- a/src/commander/mod.rs
+++ b/src/commander/mod.rs
@@ -463,6 +463,7 @@ pub mod tests {
     use tempfile::TempDir;
 
     use super::*;
+    use crate::commander::bookmarks::Bookmark;
     use crate::env::Env;
     use crate::env::JjConfig;
 
@@ -509,6 +510,14 @@ pub mod tests {
                 directory,
                 commander,
             })
+        }
+
+        /// The bookmarks as the set-bookmark dialog would list them for
+        /// the change the working copy is on.
+        pub fn bookmarks(&self) -> Result<Vec<Bookmark>> {
+            let on = self.commander.get_current_head()?.commit_id;
+
+            Ok(self.commander.get_bookmarks_list(false, &on)?)
         }
     }
 

--- a/src/commander/revset.rs
+++ b/src/commander/revset.rs
@@ -11,7 +11,9 @@ use crate::commander::ids::CommitId;
 pub struct Revset(String);
 
 impl Revset {
-    /// An arbitrary revset expression, such as one entered by the user.
+    /// An arbitrary revset expression. Only the tests build one, every
+    /// caller having something more specific to hand.
+    #[cfg(test)]
     pub fn expression(expression: impl Into<String>) -> Self {
         Self(expression.into())
     }

--- a/src/keybinds/bookmarks_tab.rs
+++ b/src/keybinds/bookmarks_tab.rs
@@ -21,8 +21,15 @@ pub enum BookmarksTabEvent {
     ForgetBookmark,
     TrackBookmark,
     UntrackBookmark,
-    NewChange { describe: bool },
-    EditChange { ignore_immutable: bool },
+    /// Point the bookmark at the change the selected line stands for,
+    /// which for one of several targets is what settles it on that one.
+    SetBookmark,
+    NewChange {
+        describe: bool,
+    },
+    EditChange {
+        ignore_immutable: bool,
+    },
     ViewInLog,
 
     Unbound,
@@ -40,6 +47,7 @@ impl Default for BookmarksTabKeybinds {
             BookmarksTabEvent::ForgetBookmark => "f",
             BookmarksTabEvent::TrackBookmark => "t",
             BookmarksTabEvent::UntrackBookmark => "shift+t",
+            BookmarksTabEvent::SetBookmark => "b",
             BookmarksTabEvent::NewChange { describe: false } => "n",
             BookmarksTabEvent::NewChange { describe: true } => "shift+n",
             BookmarksTabEvent::EditChange { ignore_immutable: false } => "e",
@@ -67,6 +75,7 @@ impl BookmarksTabKeybinds {
             BookmarksTabEvent::ForgetBookmark => "forget bookmark",
             BookmarksTabEvent::TrackBookmark => "track bookmark",
             BookmarksTabEvent::UntrackBookmark => "untrack bookmark",
+            BookmarksTabEvent::SetBookmark => "set bookmark here",
             BookmarksTabEvent::ViewInLog => "view in log",
             BookmarksTabEvent::NewChange { describe: false } => "new from bookmark",
             BookmarksTabEvent::NewChange { describe: true } => "new and describe",

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -17,6 +17,7 @@ use crate::background_tasks::TaskSlot;
 use crate::commander::CommandError;
 use crate::commander::bookmarks::Bookmark;
 use crate::commander::bookmarks::BookmarkLine;
+use crate::commander::log::Head;
 use crate::commander::new_commander;
 use crate::commander::revset::Revset;
 use crate::env::JjConfig;
@@ -233,10 +234,23 @@ impl BookmarksTab {
         }
     }
 
+    /// The bookmark the operations would name and the change the line it
+    /// is on points at, if the selection is on one there to be operated
+    /// on. A bookmark with more than one target is listed once per
+    /// target, so the line says which of them an operation acts on.
+    fn selected_target(&self) -> Option<(&Bookmark, &Head)> {
+        match self.bookmark.as_ref() {
+            Some(BookmarkLine::Parsed { bookmark, head, .. }) if bookmark.present => {
+                Some((bookmark, head))
+            }
+            _ => None,
+        }
+    }
+
     /// The bookmark the operations would name, if the selection is on one
     /// that is there to be operated on.
     fn selected_bookmark(&self) -> Option<&Bookmark> {
-        self.listed_bookmark().filter(|bookmark| bookmark.present)
+        self.selected_target().map(|(bookmark, _)| bookmark)
     }
 
     /// The selected bookmark when it is one on a remote, which is the
@@ -297,10 +311,10 @@ impl BookmarksTab {
                 }
             }
             BookmarksTabEvent::NewChange { describe } => {
-                if let Some(bookmark) = self.selected_bookmark() {
+                if let Some((bookmark, head)) = self.selected_target() {
                     return Ok(Some(command::ask_new_change(
                         self.config.clone(),
-                        Revset::expression(bookmark.to_string()),
+                        Revset::from(&head.commit_id),
                         NewSource::Change,
                         &bookmark.to_string(),
                         describe,
@@ -308,19 +322,18 @@ impl BookmarksTab {
                 }
             }
             BookmarksTabEvent::EditChange { ignore_immutable } => {
-                if let Some(bookmark) = self.selected_bookmark() {
-                    return Ok(Some(command::ask_edit_bookmark(
+                if let Some((bookmark, head)) = self.selected_target() {
+                    return Ok(Some(command::ask_edit(
                         self.config.clone(),
-                        bookmark,
+                        head,
+                        format!("Bookmark: {bookmark}"),
                         ignore_immutable,
-                    )?));
+                    )));
                 }
             }
             BookmarksTabEvent::ViewInLog => {
-                if let Some(bookmark) = self.selected_bookmark() {
-                    return Ok(Some(AppAction::Run(Command::ShowBookmarkInLog(
-                        bookmark.clone(),
-                    ))));
+                if let Some((_, head)) = self.selected_target() {
+                    return Ok(Some(AppAction::ViewLog(head.clone())));
                 }
             }
             // Not an operation of its own; the key handler deals with it.

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -57,34 +57,56 @@ pub struct BookmarksTab {
     stale: bool,
 }
 
+/// Whether both lines are the same bookmark, wherever each points. A
+/// bookmark that has moved is still the same one, which is how the
+/// selection follows it.
+fn is_same_bookmark(current: &BookmarkLine, listed: &BookmarkLine) -> bool {
+    match (current, listed) {
+        (
+            BookmarkLine::Parsed {
+                bookmark: current, ..
+            },
+            BookmarkLine::Parsed { bookmark, .. },
+        ) => current.name == bookmark.name && current.remote == bookmark.remote,
+        (BookmarkLine::Unparsable(current), BookmarkLine::Unparsable(listed)) => current == listed,
+        _ => false,
+    }
+}
+
+/// Whether both lines are the same bookmark on the same change. A
+/// bookmark with more than one target is listed once per target, and
+/// only this tells those lines apart.
+fn is_same_target(current: &BookmarkLine, listed: &BookmarkLine) -> bool {
+    let (
+        BookmarkLine::Parsed {
+            head: current_head, ..
+        },
+        BookmarkLine::Parsed { head, .. },
+    ) = (current, listed)
+    else {
+        return is_same_bookmark(current, listed);
+    };
+
+    is_same_bookmark(current, listed) && current_head == head
+}
+
 fn get_current_bookmark_index(
     current_bookmark: Option<&BookmarkLine>,
     bookmarks_output: &Result<Vec<BookmarkLine>, CommandError>,
 ) -> Option<usize> {
-    match bookmarks_output {
-        Ok(bookmarks_output) => current_bookmark.as_ref().and_then(|current_bookmark| {
+    let Ok(bookmarks_output) = bookmarks_output else {
+        return None;
+    };
+    let current_bookmark = current_bookmark?;
+
+    bookmarks_output
+        .iter()
+        .position(|listed| is_same_target(current_bookmark, listed))
+        .or_else(|| {
             bookmarks_output
                 .iter()
-                .position(|bookmark| match (current_bookmark, bookmark) {
-                    (
-                        BookmarkLine::Parsed {
-                            bookmark: current_bookmark,
-                            ..
-                        },
-                        BookmarkLine::Parsed { bookmark, .. },
-                    ) => {
-                        current_bookmark.name == bookmark.name
-                            && current_bookmark.remote == bookmark.remote
-                    }
-                    (
-                        BookmarkLine::Unparsable(current_bookmark),
-                        BookmarkLine::Unparsable(bookmark),
-                    ) => current_bookmark == bookmark,
-                    _ => false,
-                })
-        }),
-        Err(_) => None,
-    }
+                .position(|listed| is_same_bookmark(current_bookmark, listed))
+        })
 }
 
 impl BookmarksTab {
@@ -506,5 +528,61 @@ impl Component for BookmarksTab {
         }
 
         Ok(ComponentInputResult::Handled)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commander::ids::ChangeId;
+    use crate::commander::ids::CommitId;
+    use crate::commander::log::Head;
+
+    /// A listed bookmark of this name pointing at this change.
+    fn line(name: &str, commit_id: &str) -> BookmarkLine {
+        BookmarkLine::Parsed {
+            text: format!("{name}: {commit_id}"),
+            bookmark: Bookmark {
+                name: name.to_owned(),
+                remote: None,
+                present: true,
+            },
+            head: Head {
+                change_id: ChangeId(commit_id.to_owned()),
+                commit_id: CommitId(commit_id.to_owned()),
+                divergent: false,
+                immutable: false,
+            },
+        }
+    }
+
+    #[test]
+    fn the_selection_stays_on_the_target_it_was_reading() {
+        let listed = Ok(vec![line("bm", "one"), line("bm", "two")]);
+
+        assert_eq!(
+            get_current_bookmark_index(Some(&line("bm", "two")), &listed),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn the_selection_follows_a_bookmark_that_has_moved() {
+        let listed = Ok(vec![line("other", "elsewhere"), line("bm", "moved")]);
+
+        assert_eq!(
+            get_current_bookmark_index(Some(&line("bm", "was")), &listed),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn a_bookmark_that_is_gone_leaves_the_selection_to_start_over() {
+        let listed = Ok(vec![line("other", "elsewhere")]);
+
+        assert_eq!(
+            get_current_bookmark_index(Some(&line("bm", "was")), &listed),
+            None
+        );
     }
 }

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -310,6 +310,15 @@ impl BookmarksTab {
                     ))));
                 }
             }
+            BookmarksTabEvent::SetBookmark => {
+                if let Some((bookmark, head)) = self.selected_target() {
+                    return Ok(Some(command::ask_set_bookmark(
+                        self.config.clone(),
+                        bookmark,
+                        head,
+                    )));
+                }
+            }
             BookmarksTabEvent::NewChange { describe } => {
                 if let Some((bookmark, head)) = self.selected_target() {
                     return Ok(Some(command::ask_new_change(

--- a/src/ui/dialog/bookmark_set.rs
+++ b/src/ui/dialog/bookmark_set.rs
@@ -53,13 +53,15 @@ pub struct BookmarkSetPopup<'a> {
     creating: Option<TextArea<'a>>,
 }
 
-fn generate_options(change_id: Option<&ChangeId>) -> Vec<BookmarkSetOption> {
-    let bookmarks = new_commander().get_bookmarks_list(false).map(|bookmarks| {
-        bookmarks
-            .into_iter()
-            .filter(|bookmark| bookmark.remote.is_none())
-            .collect::<Vec<Bookmark>>()
-    });
+fn generate_options(change_id: Option<&ChangeId>, commit_id: &CommitId) -> Vec<BookmarkSetOption> {
+    let bookmarks = new_commander()
+        .get_bookmarks_list(false, commit_id)
+        .map(|bookmarks| {
+            bookmarks
+                .into_iter()
+                .filter(|bookmark| bookmark.remote.is_none())
+                .collect::<Vec<Bookmark>>()
+        });
     let mut options = vec![BookmarkSetOption::CreateBookmark];
 
     if let Some(change_id) = change_id {
@@ -96,7 +98,7 @@ fn generate_name(change_id: &ChangeId) -> String {
 impl BookmarkSetPopup<'_> {
     pub fn new(config: JjConfig, change_id: Option<ChangeId>, commit_id: CommitId) -> Self {
         Self {
-            options: generate_options(change_id.as_ref()),
+            options: generate_options(change_id.as_ref(), &commit_id),
             change_id,
             list_state: ListState::default().with_selected(Some(0)),
             list_height: 0,
@@ -292,7 +294,8 @@ impl Component for BookmarkSetPopup<'_> {
                                 return Ok(self.set_bookmark(bookmark.name.clone()));
                             }
                             BookmarkSetOption::Error(_) => {
-                                self.options = generate_options(self.change_id.as_ref());
+                                self.options =
+                                    generate_options(self.change_id.as_ref(), &self.commit_id);
                             }
                         }
                     }

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -270,6 +270,7 @@ impl<'a> LogTab<'a> {
                 return Ok(Some(command::ask_edit(
                     self.config.clone(),
                     &self.head,
+                    format!("Change: {}", self.head.change_id.as_str()),
                     ignore_immutable,
                 )));
             }


### PR DESCRIPTION
A bookmark torn between several targets is the one kind the app cannot
help with: the tab says only "(conflicted)" and drops it from the list
it parses, and the set dialog hides it altogether, so the one listing
that offers to point a bookmark at a single change leaves out exactly
the bookmarks that would resolve one. List its targets the way `jj
bookmark list` does, act on whichever line the selection is on rather
than resolving the name, and bind `b` to setting the bookmark there.

The set dialog also stops ordering by commit date, which was only ever
a coincidence of what a bookmark is wanted for, and offers the ones the
change is standing on first.