### PR TITLE
commander: Pass revsets as Revset rather than as strings

### DIFF
--- a/src/app/command.rs
+++ b/src/app/command.rs
@@ -122,7 +122,7 @@ impl Command {
                 let _ = execute!(std::io::stdout(), CopyToClipboard::to_clipboard_from(text));
                 Ok(None)
             }
-            Command::Duplicate(revset) => match new_commander().run_duplicate(revset.as_str()) {
+            Command::Duplicate(revset) => match new_commander().run_duplicate(revset) {
                 Ok(()) => Ok(Some(AppAction::MarkTabsStale)),
                 Err(err) => Ok(Some(refused("Duplicate", err))),
             },
@@ -159,7 +159,7 @@ impl Command {
             Command::Squash {
                 target,
                 ignore_immutable,
-            } => match new_commander().run_squash(target.commit_id.as_str(), ignore_immutable) {
+            } => match new_commander().run_squash(&target.commit_id, ignore_immutable) {
                 Ok(()) => Ok(Some(show_change(new_commander().get_current_head()?))),
                 Err(err) => Ok(Some(refused("Squash", err))),
             },

--- a/src/commander/jj.rs
+++ b/src/commander/jj.rs
@@ -77,9 +77,9 @@ impl Commander {
         self.jj(args).run_void().context("Failed executing jj new")
     }
 
-    /// Duplicate a change. Maps to `jj duplicate`
-    pub fn run_duplicate(&self, revision: &str) -> Result<()> {
-        self.jj(["duplicate", revision])
+    /// Duplicate a change. Maps to `jj duplicate <revset>`.
+    pub fn run_duplicate(&self, revset: impl Into<Revset>) -> Result<()> {
+        self.jj(["duplicate", revset.into().as_str()])
             .run_void()
             .context("Failed executing jj duplicate")
     }
@@ -167,10 +167,14 @@ impl Commander {
             .run_void()?)
     }
 
-    /// Squash changes. Maps to `jj squash -u --into <revision>`
-    #[instrument(level = "trace", skip(self))]
-    pub fn run_squash(&self, revision: &str, ignore_immutable: bool) -> Result<()> {
-        let mut args = vec!["squash", "-u", "--into", revision];
+    /// Squash changes. Maps to `jj squash -u --into <revset>`
+    pub fn run_squash(&self, revset: impl Into<Revset>, ignore_immutable: bool) -> Result<()> {
+        self.run_squash_inner(revset.into().as_str(), ignore_immutable)
+    }
+
+    #[instrument(level = "trace", name = "run_squash", skip(self))]
+    fn run_squash_inner(&self, revset: &str, ignore_immutable: bool) -> Result<()> {
+        let mut args = vec!["squash", "-u", "--into", revset];
         if ignore_immutable {
             args.push("--ignore-immutable");
         }

--- a/src/commander/log.rs
+++ b/src/commander/log.rs
@@ -22,6 +22,7 @@ use crate::commander::JjCommand;
 use crate::commander::RemoveEndLine;
 use crate::commander::ids::ChangeId;
 use crate::commander::ids::CommitId;
+use crate::commander::revset::Revset;
 use crate::env::DiffFormat;
 
 /// A change as [head_template] describes it. The field names are the ones
@@ -148,19 +149,34 @@ fn parse_record<T: DeserializeOwned>(text: &str) -> Result<T> {
 }
 
 impl Commander {
-    fn execute_jj_log(&self, revset: &str, template: &str) -> Result<String, CommandError> {
-        self.jj(["log", "--no-graph", "--template", template, "-r", revset])
-            .run()
-    }
-
-    fn execute_jj_log_one(&self, revset: &str, template: &str) -> Result<String, CommandError> {
+    fn execute_jj_log(
+        &self,
+        revset: impl Into<Revset>,
+        template: &str,
+    ) -> Result<String, CommandError> {
         self.jj([
             "log",
             "--no-graph",
             "--template",
             template,
             "-r",
-            revset,
+            revset.into().as_str(),
+        ])
+        .run()
+    }
+
+    fn execute_jj_log_one(
+        &self,
+        revset: impl Into<Revset>,
+        template: &str,
+    ) -> Result<String, CommandError> {
+        self.jj([
+            "log",
+            "--no-graph",
+            "--template",
+            template,
+            "-r",
+            revset.into().as_str(),
             "--limit",
             "1",
         ])
@@ -296,7 +312,7 @@ impl Commander {
     pub fn get_current_head(&self) -> Result<Head> {
         parse_record(
             &self
-                .execute_jj_log_one("@", &head_template_nl())
+                .execute_jj_log_one(Revset::working_copy(), &head_template_nl())
                 .context("Failed getting current head")?
                 .remove_end_line(),
         )
@@ -306,10 +322,8 @@ impl Commander {
     #[instrument(level = "trace", skip(self))]
     pub fn get_head_latest(&self, head: &Head) -> Result<Head> {
         // Get all heads which point to the same change ID
-        let latest_heads_res = self.execute_jj_log(
-            &format!(r#"change_id({})"#, head.change_id.as_str()),
-            &head_template_nl(),
-        );
+        let latest_heads_res =
+            self.execute_jj_log(Revset::change(&head.change_id), &head_template_nl());
         let Ok(latest_heads_res) = latest_heads_res else {
             return self.get_head_latest(&self.get_current_head()?);
         };
@@ -365,7 +379,7 @@ impl Commander {
     /// Maps to `jj log -r <revision> -T 'self.parents()...'`
     #[instrument(level = "trace", skip(self))]
     pub fn get_commit_parents(&self, commit_id: &CommitId) -> Result<Vec<Parent>> {
-        self.execute_jj_log_one(commit_id.as_str(), &parents_template())
+        self.execute_jj_log_one(commit_id, &parents_template())
             .with_context(|| format!("Failed getting commit parents: {commit_id}"))?
             .lines()
             .map(parse_record)
@@ -387,7 +401,7 @@ impl Commander {
     #[instrument(level = "trace", skip(self))]
     pub fn get_commit_description(&self, commit_id: &CommitId) -> Result<String> {
         Ok(self
-            .execute_jj_log_one(commit_id.as_str(), "description")
+            .execute_jj_log_one(commit_id, "description")
             .with_context(|| format!("Failed getting commit description: {commit_id}"))?
             .remove_end_line())
     }

--- a/src/commander/revset.rs
+++ b/src/commander/revset.rs
@@ -18,6 +18,17 @@ impl Revset {
         Self(expression.into())
     }
 
+    /// The working copy commit.
+    pub fn working_copy() -> Self {
+        Self("@".to_owned())
+    }
+
+    /// Every commit a change id names, which is more than one where the
+    /// change is divergent.
+    pub fn change(id: &ChangeId) -> Self {
+        Self(format!("change_id({id})"))
+    }
+
     /// The union of the given revsets, or [None] if there are none.
     pub fn union(revsets: impl IntoIterator<Item = impl Into<Revset>>) -> Option<Self> {
         let expressions: Vec<_> = revsets.into_iter().map(|revset| revset.into().0).collect();


### PR DESCRIPTION
Duplicate, squash and the log queries still take their revision argument as a plain string, so callers holding a Revset or an id have to unwrap it, and the change_id() expression behind get_head_latest() is built with a format! at the call site. We give them the same `impl Into<Revset>` the other commands take, along with constructors for the working copy and for the commits a change id names, the two revsets that have no id to build them from.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
