### PR TITLE
Drop Escape as a keybind to quit BlazingJJ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is gone
 - A popup showing a message or the help no longer goes away on `y`, `n` or
   `o`, only on what accepts or cancels a popup
+- Escape no longer quits the app; `q` and `Ctrl+c` still do, and
+  `[blazingjj.keybinds] quit` can bind it back
 
 ### Added
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -32,7 +32,7 @@ next-tab = "l"
 prev-tab = "h"
 
 command-popup = ":"
-quit = ["q", "ctrl+c", "esc"]
+quit = ["q", "ctrl+c"]
 ```
 
 ### Popups

--- a/src/keybinds/global.rs
+++ b/src/keybinds/global.rs
@@ -64,7 +64,6 @@ impl Default for GlobalKeybinds {
             GlobalEvent::OpenHelp => "?",
             GlobalEvent::Quit => "q",
             GlobalEvent::Quit => "ctrl+c",
-            GlobalEvent::Quit => "esc",
         );
         Self { keys }
     }


### PR DESCRIPTION
Escape is used to get out of popups, dialogs, etc, all things you just want to get rid of and hit Escape as a reflex. But currently also exits the app, more often than not in an unintended way. So let's drop Escape as a binding to exit the app, `q` does that in a more deliberate way.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
