### PR TITLE
Fix pushing bookmarks the remote does not have yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The keybindings shared by all tabs are now configured under `[blazingjj.keybinds]`:
   `focus-current`, `refresh` and `open-help` move there from
   `[blazingjj.keybinds.log-tab]`, which also loses its `scroll-*` overrides
-- jj 0.37.0 or newer is now required
+- jj 0.42.0 or newer is now required
 - The confirmation dialogs are now popups of the app and go away on `q` or
   Escape, like the other popups, rather than on the log tab's `close-popup`
   and `cancel` bindings. `[blazingjj.keybinds.log-tab] close-popup` and
@@ -149,6 +149,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   renders the change again
 - With `diff-format = "stat"`, the histogram is now scaled to the panel rather
   than to the whole terminal
+- Pushing new bookmarks works again: `ctrl+p` now names the bookmarks on the
+  selected change, which is what makes jj track them, and says so when the
+  change has none. `ctrl+shift+p` pushes all bookmarks and `shift+p` only the
+  tracked ones, as they did before
 
 ## [0.8.0] - 2026-04-19
 

--- a/README.md
+++ b/README.md
@@ -129,9 +129,10 @@ See all key mappings for the current tab with `?`.
   - Squash current changes to the selected change ignoring immutability with `S` (`jj squash --ignore-immutable`)
 - Git fetch with `f` (`jj git fetch`)
   - Git fetch all remotes with `F` (`jj git fetch --all-remotes`)
-- Git push with `p` (`jj git push`)
-  - Git push all bookmarks with `P` (`jj git push --all`)
-  - Use `Ctrl+p` or `Ctrl+P` to include pushing new bookmarks (`--allow-new`)
+- Git push the tracked bookmarks on the highlighted change with `p` (`jj git push -r`)
+  - Push its bookmarks the remote does not have yet as well with `Ctrl+p` (`jj git push --bookmark`)
+  - Push all tracked bookmarks with `P` (`jj git push --tracked`)
+  - Push all bookmarks, new ones included, with `Ctrl+P` (`jj git push --all`)
 
 ### Files tab
 

--- a/src/app/command.rs
+++ b/src/app/command.rs
@@ -22,6 +22,7 @@ use crate::commander::bookmarks::Bookmark;
 use crate::commander::files::File;
 use crate::commander::ids::CommitId;
 use crate::commander::jj::NewInsertMode;
+use crate::commander::jj::PushTarget;
 use crate::commander::jj::RebaseSource;
 use crate::commander::jj::RebaseTarget;
 use crate::commander::log::Head;
@@ -86,12 +87,7 @@ pub enum Command {
         target: Head,
         target_mode: RebaseTarget,
     },
-    /// Push the bookmarks pointing at this change, or all of them.
-    Push {
-        commit_id: CommitId,
-        all_bookmarks: bool,
-        allow_new: bool,
-    },
+    Push(PushTarget),
     Fetch {
         all_remotes: bool,
     },
@@ -225,15 +221,11 @@ impl Command {
                 Ok(()) => Ok(Some(AppAction::MarkTabsStale)),
                 Err(err) => Ok(Some(refused("Rebase", err))),
             },
-            Command::Push {
-                commit_id,
-                all_bookmarks,
-                allow_new,
-            } => Ok(Some(with_loader(
+            Command::Push(target) => Ok(Some(with_loader(
                 background_tasks,
                 "Pushing",
                 TaskSlot::GitPush,
-                move || Ok(new_commander().git_push(all_bookmarks, allow_new, &commit_id)?),
+                move || Ok(new_commander().git_push(&target)?),
             ))),
             Command::Fetch { all_remotes } => Ok(Some(with_loader(
                 background_tasks,

--- a/src/commander/bookmarks.rs
+++ b/src/commander/bookmarks.rs
@@ -22,6 +22,7 @@ use crate::commander::ids::ChangeId;
 use crate::commander::ids::CommitId;
 use crate::commander::log::Head;
 use crate::commander::log::head_template;
+use crate::commander::revset::Revset;
 
 /// A bookmark as [bookmark_template] describes it. The field names are the
 /// ones the template writes.
@@ -199,6 +200,31 @@ impl Commander {
                 Some(_) => usize::MAX,
                 None => ranks.get(&bookmark.name).copied().unwrap_or(usize::MAX),
             })
+            .collect();
+
+        Ok(bookmarks)
+    }
+
+    /// The local bookmarks pointing at `revset`, in the order jj lists
+    /// them. Leaves the working copy alone.
+    #[instrument(level = "trace", skip(self))]
+    pub fn get_local_bookmarks(&self, revset: &Revset) -> Result<Vec<Bookmark>, CommandError> {
+        let bookmarks = self
+            .jj([
+                "bookmark",
+                "list",
+                "-r",
+                revset.as_str(),
+                "-T",
+                &format!(r#"if(present, {}, "")"#, bookmark_only_template()),
+            ])
+            .ignore_working_copy()
+            .run()?
+            .lines()
+            .filter_map(parse_bookmark_only)
+            // The listing names the remotes a bookmark is out of sync
+            // with as well, which say nothing about where it is.
+            .filter(|bookmark| bookmark.remote.is_none())
             .collect();
 
         Ok(bookmarks)
@@ -485,6 +511,30 @@ mod tests {
         assert_eq!(names.last(), Some(&"aside".to_owned()), "{names:?}");
         assert!(names.contains(&"both".to_owned()), "{names:?}");
         assert!(names.contains(&"here".to_owned()), "{names:?}");
+
+        Ok(())
+    }
+
+    /// Pushing the new bookmarks of a change names them, so a bookmark
+    /// standing anywhere else must not be among them.
+    #[test]
+    fn get_local_bookmarks_holds_the_bookmarks_on_the_change() -> Result<()> {
+        let test_repo = TestRepo::new()?;
+        let commander = &test_repo.commander;
+
+        commander.create_bookmark("elsewhere")?;
+        commander.run_new(&commander.get_current_head()?.commit_id)?;
+        commander.create_bookmark("here")?;
+        commander.create_bookmark("also-here")?;
+
+        let on = commander.get_current_head()?.commit_id;
+        let names: Vec<String> = commander
+            .get_local_bookmarks(&Revset::from(&on))?
+            .into_iter()
+            .map(|bookmark| bookmark.name)
+            .collect();
+
+        assert_eq!(names, ["also-here", "here"]);
 
         Ok(())
     }

--- a/src/commander/jj.rs
+++ b/src/commander/jj.rs
@@ -47,6 +47,20 @@ pub enum RebaseTarget {
     Before,
 }
 
+/// What a push sends to the remote.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PushTarget {
+    /// `jj git push -r <rev>` — the tracked bookmarks on the change.
+    Revision(Revset),
+    /// `jj git push -b <name>` — these bookmarks, which jj starts
+    /// tracking if the remote does not have them yet.
+    Bookmarks(Vec<String>),
+    /// `jj git push --tracked` — every tracked bookmark.
+    Tracked,
+    /// `jj git push --all` — every bookmark, new ones included.
+    All,
+}
+
 impl Commander {
     /// Create a new change. Maps to `jj new <revset>`. Only the tests
     /// create one without saying where it goes.
@@ -261,21 +275,23 @@ impl Commander {
 
     /// Git push. Maps to `jj git push`
     #[instrument(level = "trace", skip(self))]
-    pub fn git_push(
-        &self,
-        all_bookmarks: bool,
-        allow_new: bool,
-        commit_id: &CommitId,
-    ) -> Result<String, CommandError> {
-        let mut args = vec!["git", "push"];
-        if allow_new {
-            args.push("--allow-new");
-        }
-        if all_bookmarks {
-            args.push("--all");
-        } else {
-            args.push("-r");
-            args.push(commit_id.as_str());
+    pub fn git_push(&self, target: &PushTarget) -> Result<String, CommandError> {
+        let mut args = vec!["git".to_owned(), "push".to_owned()];
+        match target {
+            PushTarget::Revision(revset) => {
+                args.push("-r".to_owned());
+                args.push(revset.as_str().to_owned());
+            }
+            // A bookmark name is a revset symbol, quoted where a plain
+            // name would not do, which is what `exact:` takes as well.
+            PushTarget::Bookmarks(names) => {
+                for name in names {
+                    args.push("-b".to_owned());
+                    args.push(format!("exact:{name}"));
+                }
+            }
+            PushTarget::Tracked => args.push("--tracked".to_owned()),
+            PushTarget::All => args.push("--all".to_owned()),
         }
 
         self.jj(args).color().run()

--- a/src/commander/mod.rs
+++ b/src/commander/mod.rs
@@ -61,9 +61,9 @@ use crate::env::Env;
 use crate::env::get_env;
 
 /// The oldest version of jj that is known to work with blazingjj.
-/// 0.37.0 added `status_char()` and `display_diff_path()`, which the files
-/// list is built from
-const JJ_MIN_VERSION: &str = "0.37.0";
+/// 0.42.0 dropped `jj git push --allow-new` and took `--all` to mean what
+/// it and `--allow-new` meant together, which is how we push
+const JJ_MIN_VERSION: &str = "0.42.0";
 const JJ_VERSION_IGNORE_HELP: &str = "If you want to continue anyway, use --ignore-jj-version";
 
 /// The narrowest width jj is told to limit secondary programs to. Anything

--- a/src/keybinds/log_tab.rs
+++ b/src/keybinds/log_tab.rs
@@ -25,17 +25,11 @@ pub enum LogTabEvent {
 
     GotoParent,
 
-    CreateNew {
-        describe: bool,
-    },
+    CreateNew { describe: bool },
     Duplicate,
     Rebase,
-    Squash {
-        ignore_immutable: bool,
-    },
-    EditChange {
-        ignore_immutable: bool,
-    },
+    Squash { ignore_immutable: bool },
+    EditChange { ignore_immutable: bool },
     Abandon,
     Absorb,
     Describe,
@@ -46,17 +40,25 @@ pub enum LogTabEvent {
     CopyChangeId,
     CopyRev,
 
-    Push {
-        all_bookmarks: bool,
-        allow_new: bool,
-    },
-    Fetch {
-        all_remotes: bool,
-    },
+    Push(PushScope),
+    Fetch { all_remotes: bool },
 
     OpenContextMenu,
 
     Unbound,
+}
+
+/// Which bookmarks a push is to send.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum PushScope {
+    /// Those on the selected change that are tracked.
+    Selected,
+    /// Those on the selected change, tracking the new ones.
+    SelectedWithNew,
+    /// Every tracked bookmark.
+    Tracked,
+    /// Every bookmark, new ones included.
+    All,
 }
 
 impl Default for LogTabKeybinds {
@@ -85,10 +87,10 @@ impl Default for LogTabKeybinds {
             LogTabEvent::OpenEvolog => "v",
             LogTabEvent::CopyChangeId => "y",
             LogTabEvent::CopyRev => "shift+y",
-            event_push(false, false) => "p",
-            event_push(false, true) => "ctrl+p",
-            event_push(true, false) => "shift+p",
-            event_push(true, true) => "ctrl+shift+p",
+            LogTabEvent::Push(PushScope::Selected) => "p",
+            LogTabEvent::Push(PushScope::SelectedWithNew) => "ctrl+p",
+            LogTabEvent::Push(PushScope::Tracked) => "shift+p",
+            LogTabEvent::Push(PushScope::All) => "ctrl+shift+p",
             LogTabEvent::Fetch { all_remotes: false } => "f",
             LogTabEvent::Fetch { all_remotes: true } => "shift+f",
             LogTabEvent::OpenContextMenu => "menu",
@@ -133,10 +135,10 @@ impl LogTabKeybinds {
             LogTabEvent::CopyChangeId => config.copy_change_id,
             LogTabEvent::CopyRev => config.copy_rev,
             LogTabEvent::Rebase => config.rebase,
-            event_push(false, false) => config.push,
-            event_push(false, true) => config.push_new,
-            event_push(true, false) => config.push_all,
-            event_push(true, true) => config.push_all_new,
+            LogTabEvent::Push(PushScope::Selected) => config.push,
+            LogTabEvent::Push(PushScope::SelectedWithNew) => config.push_new,
+            LogTabEvent::Push(PushScope::Tracked) => config.push_all,
+            LogTabEvent::Push(PushScope::All) => config.push_all_new,
             LogTabEvent::Fetch { all_remotes: false } => config.fetch,
             LogTabEvent::Fetch { all_remotes: true } => config.fetch_all,
             LogTabEvent::OpenContextMenu => config.open_context_menu,
@@ -165,19 +167,12 @@ impl LogTabKeybinds {
             LogTabEvent::CopyRev => "yank revision to clipboard",
             LogTabEvent::Fetch { all_remotes: false } => "git fetch",
             LogTabEvent::Fetch { all_remotes: true } => "git fetch all remotes",
-            event_push(false, false) => "git push",
-            event_push(false, true) => "git push with new bookmarks",
-            event_push(true, false) => "git push all bookmarks, except new",
-            event_push(true, true) => "git push all bookmarks",
+            LogTabEvent::Push(PushScope::Selected) => "git push",
+            LogTabEvent::Push(PushScope::SelectedWithNew) => "git push, tracking new bookmarks",
+            LogTabEvent::Push(PushScope::Tracked) => "git push all tracked bookmarks",
+            LogTabEvent::Push(PushScope::All) => "git push all bookmarks, new ones included",
             LogTabEvent::OpenContextMenu => "open the context menu",
         )
-    }
-}
-
-fn event_push(all_bookmarks: bool, allow_new: bool) -> LogTabEvent {
-    LogTabEvent::Push {
-        all_bookmarks,
-        allow_new,
     }
 }
 

--- a/src/keybinds/mod.rs
+++ b/src/keybinds/mod.rs
@@ -15,6 +15,7 @@ pub use global::GlobalEvent;
 pub use global::GlobalKeybinds;
 pub use log_tab::LogTabEvent;
 pub use log_tab::LogTabKeybinds;
+pub use log_tab::PushScope;
 pub use popup::PopupEvent;
 pub use popup::PopupKeybinds;
 use ratatui::crossterm::event::KeyCode;

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -14,6 +14,7 @@ use crate::background_tasks::BackgroundTasks;
 use crate::background_tasks::TaskResult;
 use crate::background_tasks::TaskSlot;
 use crate::commander::ids::CommitId;
+use crate::commander::jj::PushTarget;
 use crate::commander::log::Head;
 use crate::commander::log::LOG_LINES_PER_HEAD;
 use crate::commander::new_commander;
@@ -26,6 +27,7 @@ use crate::keybinds::LogTabEvent;
 use crate::keybinds::LogTabKeybinds;
 use crate::keybinds::PopupEvent;
 use crate::keybinds::PopupKeybinds;
+use crate::keybinds::PushScope;
 use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
@@ -221,6 +223,38 @@ impl<'a> LogTab<'a> {
         }
     }
 
+    /// Push what `scope` says. Pushing the new bookmarks of a change
+    /// means naming them, as jj only tracks a bookmark the remote does
+    /// not have yet when it is asked for by name.
+    fn handle_push(&self, scope: PushScope) -> Result<Option<AppAction>> {
+        let target = match scope {
+            PushScope::Selected => PushTarget::Revision(Revset::from(&self.head.commit_id)),
+            PushScope::SelectedWithNew => {
+                let message = |text: String| {
+                    Ok(Some(AppAction::SetPopup(Box::new(
+                        MessagePopup::new("Push", text).text_align(Alignment::Left),
+                    ))))
+                };
+
+                let bookmarks = match new_commander()
+                    .get_local_bookmarks(&Revset::from(&self.head.commit_id))
+                {
+                    Ok(bookmarks) => bookmarks,
+                    Err(err) => return message(format!("{err:#}")),
+                };
+                if bookmarks.is_empty() {
+                    return message("This change has no bookmark to push".to_owned());
+                }
+
+                PushTarget::Bookmarks(bookmarks.into_iter().map(|it| it.name).collect())
+            }
+            PushScope::Tracked => PushTarget::Tracked,
+            PushScope::All => PushTarget::All,
+        };
+
+        Ok(Some(AppAction::Run(Command::Push(target))))
+    }
+
     fn handle_event(&mut self, log_tab_event: LogTabEvent) -> Result<Option<AppAction>> {
         match log_tab_event {
             LogTabEvent::ScrollToBottom => {
@@ -312,15 +346,8 @@ impl<'a> LogTab<'a> {
                     self.head.commit_id.as_str().to_owned(),
                 ))));
             }
-            LogTabEvent::Push {
-                all_bookmarks,
-                allow_new,
-            } => {
-                return Ok(Some(AppAction::Run(Command::Push {
-                    commit_id: self.head.commit_id.clone(),
-                    all_bookmarks,
-                    allow_new,
-                })));
+            LogTabEvent::Push(scope) => {
+                return self.handle_push(scope);
             }
             LogTabEvent::Fetch { all_remotes } => {
                 return Ok(Some(AppAction::Run(Command::Fetch { all_remotes })));


### PR DESCRIPTION
jj 0.42.0 dropped `jj git push --allow-new` and folded what it did into the flags naming what to push: `--all` now covers new bookmarks, `--tracked` is what `--all` used to be, and a bookmark named by `-b` is tracked when the remote does not have it yet. We pass `--allow-new`, so jj turns all four of our push bindings down. We now ask for what each binding means rather than for a revision and a flag, which for `ctrl+p` means looking the bookmarks on the selected change up and naming them, `-r` pushing only tracked ones however it is spelled. A change carrying no bookmark has nothing to name, so that says so rather than pushing nothing. None of these spellings exist before 0.42.0, so that is now the oldest jj we take.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
