### PR TITLE
docs/keybindings: Document rebase and the context menu

### DIFF
--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -2,11 +2,11 @@
 
 ```toml
 # change keybinding
-save = "ctrl+s"
+describe = "d"
 # set multiple keybindings
-save = ["ctrl+s", "ctrl+shift+g"]
+describe = ["d", "ctrl+shift+g"]
 # disable keybinding
-save = false
+describe = false
 ```
 
 In below examples default values are used.
@@ -62,6 +62,11 @@ cancel = "esc"
 
 ### Log tab
 
+Only the log tab has bindings of its own; the other tabs and the keys that
+mark a change (`space`) or jump to the top or bottom of the log
+(`ctrl+home`/`ctrl+end`) are not configurable. `toggle-diff-format` is the
+one details panel key that is, and it applies to the log tab only.
+
 ```toml
 [blazingjj.keybinds.log-tab]
 toggle-diff-format = "w"
@@ -71,6 +76,7 @@ goto-parent = "-"
 create-new = "n"
 create-new-describe = "shift+n"
 duplicate = "shift+d"
+rebase = "ctrl+r"
 squash = "s"
 squash-ignore-immutable = "shift+s"
 edit-change = "e"
@@ -91,4 +97,6 @@ push-all = "shift+p"
 push-all-new = "ctrl+shift+p"
 fetch = "f"
 fetch-all = "shift+f"
+
+open-context-menu = "menu"
 ```


### PR DESCRIPTION
The rebase and open-context-menu bindings were added without being listed here, and the example at the top still changes `save`, which is gone. While we are at it, say which keys cannot be configured, as the log tab section otherwise reads as if every key it does not name were missing rather than fixed.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
