### PR TITLE
Show the diff format the details panel renders in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The details panel now names the diff format it renders in, in its top
+  right corner
 - Keybinding in the bookmarks tab to point a bookmark at the change the
   selected line stands for (`b`, as in the log tab), which settles a bookmark
   torn between several targets on the one selected, and moves a bookmark to

--- a/src/env.rs
+++ b/src/env.rs
@@ -5,6 +5,7 @@ It is a combination of
 - environment variables
 - command line arguments
 */
+use std::fmt;
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::OnceLock;
@@ -251,6 +252,21 @@ impl DiffFormat {
                 panel_width
             }
             _ => 0,
+        }
+    }
+}
+
+/// How the format is named in the UI, which for an external tool is the
+/// tool itself, as that is what tells the formats it renders apart.
+impl fmt::Display for DiffFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DiffFormat::ColorWords => write!(f, "color-words"),
+            DiffFormat::Git => write!(f, "git"),
+            DiffFormat::DiffTool(Some(tool)) => write!(f, "{tool}"),
+            DiffFormat::DiffTool(None) => write!(f, "diff tool"),
+            DiffFormat::Summary => write!(f, "summary"),
+            DiffFormat::Stat => write!(f, "stat"),
         }
     }
 }

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -92,6 +92,10 @@ impl OutputKey for FileDiffKey {
         Self { head, file, format }
     }
 
+    fn format(&self) -> &DiffFormat {
+        &self.format
+    }
+
     /// A change that has been rewritten still shows the diff it had,
     /// since what the panel shows of it is the file the user selected.
     fn identity(&self) -> Option<(ChangeId, File)> {

--- a/src/ui/panel/commit_show.rs
+++ b/src/ui/panel/commit_show.rs
@@ -35,6 +35,10 @@ impl OutputKey for CommitShowKey {
         Self { id, format }
     }
 
+    fn format(&self) -> &DiffFormat {
+        &self.format
+    }
+
     fn identity(&self) -> Option<ChangeId> {
         (!self.id.divergent).then(|| self.id.change_id.clone())
     }

--- a/src/ui/panel/details_panel.rs
+++ b/src/ui/panel/details_panel.rs
@@ -72,6 +72,7 @@ where
 {
     panel: &'a mut DetailsPanel,
     title: Option<Line<'a>>,
+    title_right: Option<Line<'a>>,
     content: Content,
 }
 
@@ -130,6 +131,7 @@ where
         Self {
             panel,
             title: None,
+            title_right: None,
             content,
         }
     }
@@ -139,6 +141,15 @@ where
         T: Into<Line<'a>>,
     {
         self.title = Some(title.into());
+        self
+    }
+
+    /// Set a second title, in the top right corner of the frame
+    pub fn title_right<T>(&mut self, title: T) -> &mut Self
+    where
+        T: Into<Line<'a>>,
+    {
+        self.title_right = Some(title.into());
         self
     }
 
@@ -153,6 +164,9 @@ where
         // Apply title if provided
         if let Some(title) = &self.title {
             border = border.title_top(title.clone());
+        }
+        if let Some(title) = &self.title_right {
+            border = border.title_top(title.clone().right_aligned());
         }
 
         // Create content widget that uses border

--- a/src/ui/panel/evolog_show.rs
+++ b/src/ui/panel/evolog_show.rs
@@ -38,6 +38,10 @@ impl OutputKey for EvologShowKey {
         }
     }
 
+    fn format(&self) -> &DiffFormat {
+        &self.format
+    }
+
     /// An entry records a version the change has had, which no later
     /// rewrite alters, so the only output that stands in for it is the
     /// same entry rendered in another format.

--- a/src/ui/panel/output_cache.rs
+++ b/src/ui/panel/output_cache.rs
@@ -39,6 +39,9 @@ pub trait OutputKey: Clone + Eq + Hash + Debug + Send + 'static {
 
     fn new(subject: Self::Subject, format: DiffFormat) -> Self;
 
+    /// The format the output is rendered in.
+    fn format(&self) -> &DiffFormat;
+
     /// What this output may stand in for, if anything. A divergent change
     /// has nothing: its change id names more than one commit, and the
     /// output of the wrong one is not worth showing.

--- a/src/ui/panel/output_panel.rs
+++ b/src/ui/panel/output_panel.rs
@@ -9,6 +9,9 @@ UI responsive. What it has rendered goes into a
 use ratatui::crossterm::event::MouseEvent;
 use ratatui::layout::Rect;
 use ratatui::prelude::Frame;
+use ratatui::style::Color;
+use ratatui::style::Style;
+use ratatui::text::Line;
 use ratatui::text::Text;
 use tracing::error;
 
@@ -261,6 +264,13 @@ impl<K: OutputKey> OutputPanel<K> {
             Some(shown) => shown.title.clone(),
             None => self.title.clone(),
         };
+        // The format of what is on screen, which while we wait for a
+        // toggle to take effect is still the one it went up in
+        let format = match &shown {
+            Some(shown) => shown.key.format(),
+            None => &self.diff_format,
+        };
+        let format = Line::styled(format!(" {format} "), Style::new().fg(Color::DarkGray));
 
         if let Some(shown) = shown
             && let Some(value) = self.cache.get(&shown.key)
@@ -277,6 +287,7 @@ impl<K: OutputKey> OutputPanel<K> {
                     .panel
                     .render_context::<LargeStringContent>(document)
                     .title(title)
+                    .title_right(format)
                     .draw(f, area),
                 Err(message) => {
                     let failed = format!("'{}' failed", K::COMMAND);
@@ -285,6 +296,7 @@ impl<K: OutputKey> OutputPanel<K> {
                     self.panel
                         .render_context::<TextContent>(text)
                         .title(title)
+                        .title_right(format)
                         .draw(f, area);
                 }
             }
@@ -296,6 +308,7 @@ impl<K: OutputKey> OutputPanel<K> {
         self.panel
             .render_context::<TextContent>(self.wait.message(K::COMMAND))
             .title(title)
+            .title_right(format)
             .draw(f, area);
     }
 


### PR DESCRIPTION
Toggling the diff format is easy to lose track of: nothing on screen says which one is in effect, and the formats are not always told apart by looking at the output, an external tool least of all. So we put the format in the top right corner of the details panel, opposite the title. It names what is on screen rather than what the panel has been switched to, so that the label and the output it belongs to always agree, even while the new rendering is still being produced.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
