### PR TITLE
Support rendering diffs with a pager like delta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Diff format rendering the Git format with a pager like
+  [delta](https://github.com/dandavison/delta), configured as
+  `blazingjj.diff-pager` and toggled through with `w` like the others
 - The details panel now names the diff format it renders in, in its top
   right corner
 - Keybinding in the bookmarks tab to point a bookmark at the change the

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Built in Rust with Ratatui. Interacts with `jj` CLI.
   - Yank a version's revision to the system clipboard with `Y`
 - Details panel: toggle between color words and git diff with `w`, wrapping
   with `W`
+  - Render the git diff with a pager like delta by configuring
+    `blazingjj.diff-pager`
 - Mouse: scroll the panels, click to select, drag the divider to resize, right
   click for the context menu
 - Config: Configure blazingjj with your jj config
@@ -71,10 +73,14 @@ To build and install a pre-release version: `cargo install --git https://github.
 You can optionally configure the following options through your jj config:
 
 - `blazingjj.highlight-color`: Changes the highlight color. Can use named colors. Defaults to `#323264`
-- `blazingjj.diff-format`: Change the default diff format. Can be `color-words` or `git`. Defaults to `color_words`
+- `blazingjj.diff-format`: Change the default diff format. Can be `color-words`, `git`, `pager`, `summary` or `stat`. Defaults to `color_words`
   - If `blazingjj.diff-format` is not set but `ui.diff.format` is, the latter will be used
 - `blazingjj.diff-tool`: Specify which diff tool to use by default
   - If `blazingjj.diff-tool` is not set but `ui.diff.tool` is, the latter will be used
+- `blazingjj.diff-pager`: Specify a pager rendering the Git format diff, like [delta](https://github.com/dandavison/delta): `jj config set --user blazingjj.diff-pager '["delta", "--width=$width", "--line-numbers"]'`
+  - The pager reads the diff on standard input and writes its rendering to standard output; it must not page, since blazingjj shows the output itself
+  - `$width` in an argument stands for the columns the details panel has, which a pager that cannot find out for itself needs to be told
+  - Setting it makes `pager` the default format, unless `blazingjj.diff-format` says otherwise, and adds it to what `w` toggles through
 - `blazingjj.bookmark-template`: Change the bookmark name template for generated bookmark names. Defaults to `'push-' ++ change_id.short()`
   - If `blazingjj.bookmark-template` is not set but `templates.git_push_bookmark` is, the latter will be used
 - `blazingjj.describe-mode`: What describing a change puts up. Can be `popup` (default) for the built-in editor, or `jj` to hand the terminal to `jj describe` and your own editor
@@ -115,7 +121,7 @@ See all key mappings for the current tab with `?`.
   - Scroll down/up by one line with `Ctrl+e`/`Ctrl+y`
   - Scroll down/up by a half page with `Ctrl+d`/`Ctrl+u`
   - Scroll down/up by a full page with `Ctrl+f`/`Ctrl+b`
-- Change details panel diff format between color words (default) and Git (and diff tool if set) with `w`
+- Change details panel diff format between color words (default) and Git (and a diff pager and diff tool if set) with `w`
 - Toggle details panel wrapping with `W`
 - Open the context menu for what the tab has selected with `Menu` or a right click
 - Open a command popup to run jj commands using `:` (jj prefix not required, e.g. write `new main` instead of `jj new main`)

--- a/src/commander/files.rs
+++ b/src/commander/files.rs
@@ -187,10 +187,9 @@ impl Commander {
         let path = current_file.path.as_deref()?;
 
         let fileset = Self::get_file_revset(path);
-        let mut args = vec!["diff", "-r", head.commit_id.as_str(), &fileset];
-        args.append(&mut diff_format.get_args());
+        let args = vec!["diff", "-r", head.commit_id.as_str(), &fileset];
 
-        let mut command = self.jj(args).color();
+        let mut command = self.jj_diff(args, diff_format).color();
         if ignore_working_copy {
             command = command.ignore_working_copy();
         }
@@ -237,6 +236,7 @@ mod tests {
     use crate::commander::cancel::CancelToken;
     use crate::commander::revset::Revset;
     use crate::commander::tests::TestRepo;
+    use crate::commander::tests::pager;
 
     /// Run the diff of a file to completion, the way a task does
     fn run_file_diff(
@@ -530,6 +530,35 @@ mod tests {
                 true
             )?);
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn the_pager_format_renders_the_git_diff_of_a_file() -> Result<()> {
+        let test_repo = TestRepo::new()?;
+
+        fs::write(test_repo.directory.path().join("README"), b"AAA")?;
+        let file = File {
+            path: Some("README".to_string()),
+            diff_type: Some(DiffType::Added),
+            line: "A README".to_string(),
+        };
+
+        let head = test_repo.commander.get_current_head()?;
+        let output = run_file_diff(
+            &test_repo.commander,
+            &head,
+            &file,
+            &DiffFormat::Pager(pager(r#"["sed", "s/^/rendered: /"]"#)),
+            false,
+        )?
+        .expect("the file has a path to diff");
+
+        assert!(
+            output.contains("rendered: diff --git a/README b/README"),
+            "the git diff did not go through the pager: {output}"
+        );
 
         Ok(())
     }

--- a/src/commander/log.rs
+++ b/src/commander/log.rs
@@ -268,7 +268,7 @@ impl Commander {
         diff_format: &DiffFormat,
         ignore_working_copy: bool,
     ) -> JjCommand {
-        let mut args = vec![
+        let args = vec![
             "evolog",
             "-r",
             commit_id.as_str(),
@@ -277,9 +277,8 @@ impl Commander {
             "--no-graph",
             "--patch",
         ];
-        args.append(&mut diff_format.get_args());
 
-        let mut command = self.jj(args);
+        let mut command = self.jj_diff(args, diff_format);
         if ignore_working_copy {
             command = command.ignore_working_copy();
         }
@@ -295,10 +294,9 @@ impl Commander {
         diff_format: &DiffFormat,
         ignore_working_copy: bool,
     ) -> JjCommand {
-        let mut args = vec!["show", commit_id.as_str()];
-        args.append(&mut diff_format.get_args());
+        let args = vec!["show", commit_id.as_str()];
 
-        let mut command = self.jj(args);
+        let mut command = self.jj_diff(args, diff_format);
         if ignore_working_copy {
             command = command.ignore_working_copy();
         }

--- a/src/commander/mod.rs
+++ b/src/commander/mod.rs
@@ -59,6 +59,7 @@ use version_compare::compare;
 
 use crate::commander::cancel::CancelToken;
 use crate::env::DiffFormat;
+use crate::env::DiffPager;
 use crate::env::Env;
 use crate::env::get_env;
 
@@ -79,10 +80,11 @@ pub const MIN_SETTABLE_WIDTH: usize = 20;
 pub const NO_EDITOR: &str = "blazingjj-no-editor";
 
 impl DiffFormat {
-    pub fn get_args(&self) -> Vec<&str> {
+    fn get_args(&self) -> Vec<&str> {
         match self {
             DiffFormat::ColorWords => vec!["--color-words"],
-            DiffFormat::Git => vec!["--git"],
+            // The pager renders the Git format, so that is what it is fed
+            DiffFormat::Git | DiffFormat::Pager(_) => vec!["--git"],
             DiffFormat::Summary => vec!["--summary"],
             DiffFormat::Stat => vec!["--stat"],
             DiffFormat::DiffTool(Some(tool)) => vec!["--tool", tool],
@@ -192,8 +194,19 @@ impl Commander {
             quiet: true,
             ignore_working_copy: self.ignore_working_copy,
             stdin: None,
+            pager: None,
+            columns: self.columns,
             env_var,
         }
+    }
+
+    /// Start building a single jj invocation showing a diff in the given
+    /// format, which adds the arguments selecting that format and has the
+    /// output rendered by its pager, if it has one.
+    pub fn jj_diff<'a>(&self, mut args: Vec<&'a str>, diff_format: &'a DiffFormat) -> JjCommand {
+        args.extend(diff_format.get_args());
+
+        self.jj(args).pipe_to(diff_format.pager())
     }
 
     /// Check that the version of jj is recent enough to work with blazingjj
@@ -258,6 +271,10 @@ pub struct JjCommand {
     ignore_working_copy: bool,
     /// Data to feed the command on standard input, if any.
     stdin: Option<String>,
+    /// The pager the output of the command is piped through, if any.
+    pager: Option<DiffPager>,
+    /// The width the output is rendered at, as far as it can be set.
+    columns: Option<usize>,
     /// Environment variables for this command.
     env_var: Vec<(String, String)>,
 }
@@ -311,6 +328,13 @@ impl JjCommand {
         self
     }
 
+    /// Pipe the output of the command through `pager`, and take that as the
+    /// output.
+    pub fn pipe_to(mut self, pager: Option<&DiffPager>) -> Self {
+        self.pager = pager.cloned();
+        self
+    }
+
     /// Execute the command and return its standard output.
     pub fn run(self) -> Result<String, CommandError> {
         let stdout = self.execute(Stdio::piped(), &CancelToken::new())?;
@@ -359,7 +383,20 @@ impl JjCommand {
             self.quiet,
         ));
 
-        run_child(command, input, stdout, cancel)
+        let Some(pager) = self.pager.take() else {
+            return run_child(command, input, stdout, cancel);
+        };
+
+        // The pager is what produces the output, so what jj writes is
+        // captured whatever the caller asked for.
+        let piped = run_child(command, input, Stdio::piped(), cancel)?;
+
+        run_child(
+            self.build_pager_command(&pager),
+            Some(piped),
+            stdout,
+            cancel,
+        )
     }
 
     /// Construct a Command ready for execution. The caller adds the output
@@ -372,6 +409,15 @@ impl JjCommand {
             command.arg("--ignore-working-copy");
         }
 
+        command.current_dir(&self.root);
+        command.envs(self.env_var.iter().cloned());
+        command
+    }
+
+    /// Construct a Command running the pager the output goes through
+    fn build_pager_command(&self, pager: &DiffPager) -> Command {
+        let mut command = Command::new(pager.program());
+        command.args(pager.args(self.columns.unwrap_or(0)));
         command.current_dir(&self.root);
         command.envs(self.env_var.iter().cloned());
         command
@@ -665,6 +711,51 @@ pub mod tests {
             .jj(["log", "-r", "@", "--no-graph", "-T", "description"])
             .run()?;
         assert_eq!(description.remove_end_line(), "message from stdin");
+
+        Ok(())
+    }
+
+    /// The pager the given `blazingjj.diff-pager` value configures
+    pub fn pager(setting: &str) -> DiffPager {
+        toml::from_str::<JjConfig>(&format!("blazingjj.diff-pager = {setting}\n"))
+            .expect("the setting is a valid configuration")
+            .diff_pager()
+            .expect("the setting configures a pager")
+    }
+
+    #[test]
+    fn a_pager_renders_what_the_command_wrote() -> Result<()> {
+        let test_repo = TestRepo::new()?;
+
+        let output = test_repo
+            .commander
+            .jj(["status"])
+            .pipe_to(Some(&pager(r#"["sed", "s/^/rendered: /"]"#)))
+            .run()?;
+
+        assert!(
+            output.lines().all(|line| line.starts_with("rendered: ")),
+            "the output did not go through the pager: {output}"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn a_pager_that_fails_fails_the_command() -> Result<()> {
+        let test_repo = TestRepo::new()?;
+
+        let error = test_repo
+            .commander
+            .jj(["status"])
+            .pipe_to(Some(&pager(r#"["sed", "-e", "s/"]"#)))
+            .run()
+            .expect_err("an incomplete script is an error");
+
+        let CommandError::Status(stderr, _) = error else {
+            panic!("expected a non-zero exit status");
+        };
+        assert!(stderr.contains("sed"), "stderr is not reported: {stderr}");
 
         Ok(())
     }

--- a/src/commander/mod.rs
+++ b/src/commander/mod.rs
@@ -348,81 +348,18 @@ impl JjCommand {
         self.build_command().status()
     }
 
-    /// Configure and run the command in a child process `cancel` can kill,
-    /// blocking until it is done, and return its captured standard output.
-    ///
-    /// `stdout` selects how the child's standard output is handled: piped to
-    /// be captured and returned, or null to be discarded. Standard error is
-    /// always captured so it can be surfaced on failure.
+    /// Configure and run the command as a child process, as described in
+    /// [run_child].
     fn execute(mut self, stdout: Stdio, cancel: &CancelToken) -> Result<Vec<u8>, CommandError> {
-        let input = self.stdin.take();
+        let input = self.stdin.take().map(String::into_bytes);
 
         let mut command = self.build_command();
         command.args(get_output_args(
             !self.force_no_color && self.color,
             self.quiet,
         ));
-        command
-            .stdin(if input.is_some() {
-                Stdio::piped()
-            } else {
-                Stdio::null()
-            })
-            .stdout(stdout)
-            .stderr(Stdio::piped());
-        let mut child = command.spawn().map_err(CommandError::Spawn)?;
 
-        let stdin_writer = input.map(|input| spawn_stdin_writer(&mut child, input));
-        let child_stdout = child.stdout.take();
-        let mut child_stderr = child.stderr.take().expect("stderr was piped");
-        // From here on the child can be killed, so every pipe has to be
-        // drained even when the command is going nowhere.
-        cancel.register(child);
-
-        let stderr_reader = thread::spawn(move || {
-            let mut stderr = Vec::new();
-            if let Err(err) = child_stderr.read_to_end(&mut stderr) {
-                error!("Failed to read stderr of child process: {err}");
-            }
-            stderr
-        });
-
-        let mut output = Vec::new();
-        // Every thread and the child have to be collected below whatever
-        // went wrong, so failures are held back rather than returned here.
-        let read_result = child_stdout
-            .map(|mut pipe| pipe.read_to_end(&mut output))
-            .transpose();
-        let stderr = stderr_reader.join().unwrap_or_default();
-        // The child is done reading its input too, either because it read
-        // everything or because it exited and closed the pipe.
-        let write_result = stdin_writer.map(join_stdin_writer).transpose();
-
-        // Every pipe is closed, so the child has finished and there is
-        // nothing left to wait for.
-        let mut child = cancel
-            .take_child()
-            .expect("the child registered above is only taken here");
-        let status = child.wait()?;
-
-        if !status.success() {
-            return Err(CommandError::Status(
-                String::from_utf8_lossy(&stderr).into_owned(),
-                status.code(),
-            ));
-        }
-        // A pipe that broke along the way only matters for a command that
-        // succeeded; for one that failed, its status and stderr say more.
-        write_result?;
-        read_result?;
-        if !stderr.is_empty() {
-            warn!(
-                "Ignoring stderr of successful command:\n{}",
-                String::from_utf8_lossy(&stderr)
-            );
-        }
-
-        Ok(output)
+        run_child(command, input, stdout, cancel)
     }
 
     /// Construct a Command ready for execution. The caller adds the output
@@ -441,12 +378,88 @@ impl JjCommand {
     }
 }
 
+/// Run `command` in a child process `cancel` can kill, blocking until it is
+/// done, and return its captured standard output.
+///
+/// `input` is fed to the child on standard input, if there is any. `stdout`
+/// selects how the child's standard output is handled: piped to be captured
+/// and returned, or null to be discarded. Standard error is always captured
+/// so it can be surfaced on failure.
+fn run_child(
+    mut command: Command,
+    input: Option<Vec<u8>>,
+    stdout: Stdio,
+    cancel: &CancelToken,
+) -> Result<Vec<u8>, CommandError> {
+    command
+        .stdin(if input.is_some() {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        })
+        .stdout(stdout)
+        .stderr(Stdio::piped());
+    let mut child = command.spawn().map_err(CommandError::Spawn)?;
+
+    let stdin_writer = input.map(|input| spawn_stdin_writer(&mut child, input));
+    let child_stdout = child.stdout.take();
+    let mut child_stderr = child.stderr.take().expect("stderr was piped");
+    // From here on the child can be killed, so every pipe has to be
+    // drained even when the command is going nowhere.
+    cancel.register(child);
+
+    let stderr_reader = thread::spawn(move || {
+        let mut stderr = Vec::new();
+        if let Err(err) = child_stderr.read_to_end(&mut stderr) {
+            error!("Failed to read stderr of child process: {err}");
+        }
+        stderr
+    });
+
+    let mut output = Vec::new();
+    // Every thread and the child have to be collected below whatever
+    // went wrong, so failures are held back rather than returned here.
+    let read_result = child_stdout
+        .map(|mut pipe| pipe.read_to_end(&mut output))
+        .transpose();
+    let stderr = stderr_reader.join().unwrap_or_default();
+    // The child is done reading its input too, either because it read
+    // everything or because it exited and closed the pipe.
+    let write_result = stdin_writer.map(join_stdin_writer).transpose();
+
+    // Every pipe is closed, so the child has finished and there is
+    // nothing left to wait for.
+    let mut child = cancel
+        .take_child()
+        .expect("the child registered above is only taken here");
+    let status = child.wait()?;
+
+    if !status.success() {
+        return Err(CommandError::Status(
+            String::from_utf8_lossy(&stderr).into_owned(),
+            status.code(),
+        ));
+    }
+    // A pipe that broke along the way only matters for a command that
+    // succeeded; for one that failed, its status and stderr say more.
+    write_result?;
+    read_result?;
+    if !stderr.is_empty() {
+        warn!(
+            "Ignoring stderr of successful command:\n{}",
+            String::from_utf8_lossy(&stderr)
+        );
+    }
+
+    Ok(output)
+}
+
 /// Feed `input` to a child's standard input from a thread of its own, so
 /// neither side deadlocks on a full pipe buffer. Dropping the handle closes
 /// the pipe, signalling EOF to the child.
-fn spawn_stdin_writer(child: &mut Child, input: String) -> JoinHandle<io::Result<()>> {
+fn spawn_stdin_writer(child: &mut Child, input: Vec<u8>) -> JoinHandle<io::Result<()>> {
     let mut stdin = child.stdin.take().expect("stdin was piped");
-    thread::spawn(move || stdin.write_all(input.as_bytes()))
+    thread::spawn(move || stdin.write_all(&input))
 }
 
 /// Collect the outcome of a [spawn_stdin_writer] thread. A broken pipe means

--- a/src/env.rs
+++ b/src/env.rs
@@ -68,8 +68,9 @@ pub struct JjConfig {
 pub struct JjConfigBlazingjj {
     highlight_color: Color,
     describe_mode: DescribeMode,
-    diff_format: Option<DiffFormat>,
+    diff_format: Option<ConfiguredDiffFormat>,
     diff_tool: Option<String>,
+    diff_pager: Option<DiffPager>,
     bookmark_template: Option<String>,
     layout: JJLayout,
     layout_percent: u16,
@@ -90,6 +91,7 @@ impl Default for JjConfigBlazingjj {
             describe_mode: DescribeMode::default(),
             diff_format: None,
             diff_tool: None,
+            diff_pager: None,
             bookmark_template: None,
             layout: JJLayout::default(),
             keybinds: None,
@@ -116,7 +118,7 @@ pub struct JjConfigUi {
 #[derive(Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "kebab-case", default)]
 pub struct JjConfigUiDiff {
-    format: Option<DiffFormat>,
+    format: Option<ConfiguredDiffFormat>,
     tool: Option<toml::Value>,
 }
 
@@ -129,10 +131,27 @@ impl JjConfig {
     pub fn diff_format(&self) -> DiffFormat {
         self.blazingjj
             .diff_format
-            .clone()
-            .or_else(|| self.ui.diff.format.clone())
+            .or(self.ui.diff.format)
+            .and_then(|configured| self.resolve_diff_format(configured))
+            .or_else(|| self.diff_pager().map(DiffFormat::Pager))
             .or_else(|| self.diff_tool().map(DiffFormat::DiffTool))
             .unwrap_or(DiffFormat::ColorWords)
+    }
+
+    /// The format a configured one names, which for the pager format is
+    /// nothing unless a pager is configured to render it.
+    fn resolve_diff_format(&self, configured: ConfiguredDiffFormat) -> Option<DiffFormat> {
+        Some(match configured {
+            ConfiguredDiffFormat::ColorWords => DiffFormat::ColorWords,
+            ConfiguredDiffFormat::Git => DiffFormat::Git,
+            ConfiguredDiffFormat::Summary => DiffFormat::Summary,
+            ConfiguredDiffFormat::Stat => DiffFormat::Stat,
+            ConfiguredDiffFormat::Pager => DiffFormat::Pager(self.diff_pager()?),
+        })
+    }
+
+    pub fn diff_pager(&self) -> Option<DiffPager> {
+        self.blazingjj.diff_pager.clone()
     }
 
     pub fn diff_tool(&self) -> Option<Option<String>> {
@@ -225,12 +244,86 @@ pub enum DescribeMode {
     Jj,
 }
 
-#[derive(Clone, Debug, Deserialize, Default, PartialEq, Eq, Hash)]
+/// A diff format as `blazingjj.diff-format` and `ui.diff.format` name it.
+/// What a name stands for depends on the rest of the configuration, so it
+/// is resolved into a [DiffFormat] by
+/// [diff_format](JjConfig::diff_format).
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
-pub enum DiffFormat {
-    #[default]
+enum ConfiguredDiffFormat {
     ColorWords,
     Git,
+    Pager,
+    Summary,
+    Stat,
+}
+
+/// What a pager argument says to have the render width substituted into it
+const WIDTH_PLACEHOLDER: &str = "$width";
+
+/// The command a diff in the [pager](DiffFormat::Pager) format is piped
+/// through, like `delta`. It reads a Git format diff on standard input and
+/// writes the rendering to standard output; `$width` in an argument stands
+/// for the number of columns it has to render into.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Hash)]
+#[serde(try_from = "ConfiguredDiffPager")]
+pub struct DiffPager {
+    program: String,
+    args: Vec<String>,
+}
+
+/// A pager as it is configured: the program on its own, or a command line
+/// of the program and its arguments.
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum ConfiguredDiffPager {
+    Program(String),
+    CommandLine(Vec<String>),
+}
+
+impl TryFrom<ConfiguredDiffPager> for DiffPager {
+    type Error = &'static str;
+
+    fn try_from(configured: ConfiguredDiffPager) -> Result<Self, Self::Error> {
+        let (program, args) = match configured {
+            ConfiguredDiffPager::Program(program) => (program, Vec::new()),
+            ConfiguredDiffPager::CommandLine(mut command_line) => {
+                if command_line.is_empty() {
+                    return Err("a diff pager needs a program to run");
+                }
+                let args = command_line.split_off(1);
+                (command_line.remove(0), args)
+            }
+        };
+
+        Ok(Self { program, args })
+    }
+}
+
+impl DiffPager {
+    pub fn program(&self) -> &str {
+        &self.program
+    }
+
+    /// The arguments to run the pager with, rendering into `width`
+    /// columns. An argument asking for a width is left out when there is
+    /// none to give, so the pager falls back to whatever it uses by
+    /// default.
+    pub fn args(&self, width: usize) -> Vec<String> {
+        self.args
+            .iter()
+            .filter(|arg| width > 0 || !arg.contains(WIDTH_PLACEHOLDER))
+            .map(|arg| arg.replace(WIDTH_PLACEHOLDER, &width.to_string()))
+            .collect()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum DiffFormat {
+    ColorWords,
+    Git,
+    /// The Git format, rendered by an external pager
+    Pager(DiffPager),
     DiffTool(Option<String>),
     // Configuration only, [DiffFormat::get_next] does not cycle through these
     Summary,
@@ -238,31 +331,43 @@ pub enum DiffFormat {
 }
 
 impl DiffFormat {
-    pub fn get_next(&self, diff_tool: Option<Option<String>>) -> DiffFormat {
+    /// The format the user gets by toggling this one, which skips whatever
+    /// the configuration has no program for.
+    pub fn get_next(&self, config: &JjConfig) -> DiffFormat {
+        let pager = || config.diff_pager().map(DiffFormat::Pager);
+        let diff_tool = || config.diff_tool().map(DiffFormat::DiffTool);
+
         match self {
-            DiffFormat::ColorWords => DiffFormat::Git,
-            DiffFormat::Git => {
-                if let Some(diff_tool) = diff_tool {
-                    DiffFormat::DiffTool(diff_tool)
-                } else {
-                    DiffFormat::ColorWords
-                }
-            }
-            _ => DiffFormat::ColorWords,
+            DiffFormat::ColorWords => Some(DiffFormat::Git),
+            DiffFormat::Git => pager().or_else(diff_tool),
+            DiffFormat::Pager(_) => diff_tool(),
+            _ => None,
+        }
+        .unwrap_or(DiffFormat::ColorWords)
+    }
+
+    /// The pager the output of this format is piped through, if any.
+    pub fn pager(&self) -> Option<&DiffPager> {
+        match self {
+            DiffFormat::Pager(pager) => Some(pager),
+            _ => None,
         }
     }
 
     /// How wide output in this format is rendered, given the width of the
-    /// panel showing it. The width reaches an external diff tool through the
-    /// COLUMNS environment variable, and `--stat` scales its histogram to
-    /// it; the other formats produce the same output whatever the width,
-    /// and the panel wraps or scrolls it.
+    /// panel showing it. The width reaches an external program through the
+    /// COLUMNS environment variable, a pager through
+    /// [its arguments](DiffPager::args) as well, and `--stat` scales its
+    /// histogram to it; the other formats produce the same output whatever
+    /// the width, and the panel wraps or scrolls it.
     ///
     /// A width too narrow to be passed on makes no difference either, so it
     /// comes out as no width at all rather than as a value of its own.
     pub fn render_width(&self, panel_width: usize) -> usize {
         match self {
-            DiffFormat::DiffTool(_) | DiffFormat::Stat if panel_width >= MIN_SETTABLE_WIDTH => {
+            DiffFormat::DiffTool(_) | DiffFormat::Pager(_) | DiffFormat::Stat
+                if panel_width >= MIN_SETTABLE_WIDTH =>
+            {
                 panel_width
             }
             _ => 0,
@@ -270,13 +375,14 @@ impl DiffFormat {
     }
 }
 
-/// How the format is named in the UI, which for an external tool is the
-/// tool itself, as that is what tells the formats it renders apart.
+/// How the format is named in the UI, which for an external program is
+/// that program, as it is what tells the formats it renders apart.
 impl fmt::Display for DiffFormat {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             DiffFormat::ColorWords => write!(f, "color-words"),
             DiffFormat::Git => write!(f, "git"),
+            DiffFormat::Pager(pager) => write!(f, "{}", pager.program()),
             DiffFormat::DiffTool(Some(tool)) => write!(f, "{tool}"),
             DiffFormat::DiffTool(None) => write!(f, "diff tool"),
             DiffFormat::Summary => write!(f, "summary"),
@@ -309,11 +415,25 @@ mod tests {
 
     const PANEL_WIDTH: usize = 80;
 
+    /// The configuration `jj config list` would print for the given
+    /// settings
+    fn config(settings: &str) -> JjConfig {
+        toml::from_str(settings).expect("the settings are a valid configuration")
+    }
+
+    /// The pager the given `blazingjj.diff-pager` value configures
+    fn pager(setting: &str) -> DiffPager {
+        config(&format!("blazingjj.diff-pager = {setting}\n"))
+            .diff_pager()
+            .expect("the setting configures a pager")
+    }
+
     #[test]
     fn only_formats_that_scale_are_told_the_panel_width() {
         for format in [
             DiffFormat::DiffTool(Some("difft".to_owned())),
             DiffFormat::DiffTool(None),
+            DiffFormat::Pager(pager(r#""delta""#)),
             DiffFormat::Stat,
         ] {
             assert_eq!(format.render_width(PANEL_WIDTH), PANEL_WIDTH, "{format:?}");
@@ -334,6 +454,91 @@ mod tests {
         );
         assert_eq!(diff_tool.render_width(MIN_SETTABLE_WIDTH - 1), 0);
         assert_eq!(diff_tool.render_width(0), 0);
+    }
+
+    #[test]
+    fn a_pager_is_configured_as_a_program_or_as_a_command_line() {
+        let program = pager(r#""delta""#);
+        assert_eq!(program.program(), "delta");
+        assert!(program.args(PANEL_WIDTH).is_empty());
+
+        let command_line = pager(r#"["delta", "--line-numbers"]"#);
+        assert_eq!(command_line.program(), "delta");
+        assert_eq!(command_line.args(PANEL_WIDTH), ["--line-numbers"]);
+
+        // A command line without a program to run is a config error, as a
+        // bad value is for every other setting.
+        let error = toml::from_str::<JjConfig>("blazingjj.diff-pager = []\n")
+            .expect_err("a pager without a program is an error");
+        assert!(
+            error.to_string().contains("a diff pager needs a program"),
+            "the error does not say what is wrong: {error}"
+        );
+    }
+
+    #[test]
+    fn an_argument_asking_for_the_render_width_is_given_it() {
+        let pager = pager(r#"["delta", "--width=$width", "--line-numbers"]"#);
+
+        assert_eq!(
+            pager.args(PANEL_WIDTH),
+            ["--width=80", "--line-numbers"],
+            "the width goes where it is asked for"
+        );
+        assert_eq!(
+            pager.args(0),
+            ["--line-numbers"],
+            "an argument asking for a width there is none of is left out"
+        );
+    }
+
+    #[test]
+    fn a_configured_pager_is_the_format_until_another_one_is_configured() {
+        assert_eq!(
+            config(r#"blazingjj.diff-pager = "delta""#).diff_format(),
+            DiffFormat::Pager(pager(r#""delta""#))
+        );
+        assert_eq!(
+            config("blazingjj.diff-pager = \"delta\"\nblazingjj.diff-format = \"git\"\n")
+                .diff_format(),
+            DiffFormat::Git
+        );
+    }
+
+    #[test]
+    fn the_pager_format_falls_back_to_the_default_without_a_pager_to_run() {
+        assert_eq!(
+            config("blazingjj.diff-format = \"pager\"\nblazingjj.diff-pager = \"delta\"\n")
+                .diff_format(),
+            DiffFormat::Pager(pager(r#""delta""#))
+        );
+        assert_eq!(
+            config("blazingjj.diff-format = \"pager\"\n").diff_format(),
+            DiffFormat::ColorWords
+        );
+    }
+
+    #[test]
+    fn toggling_the_format_leaves_out_what_is_not_configured() {
+        let delta = DiffFormat::Pager(pager(r#""delta""#));
+        let difft = DiffFormat::DiffTool(Some("difft".to_owned()));
+
+        let plain = config("");
+        assert_eq!(DiffFormat::ColorWords.get_next(&plain), DiffFormat::Git);
+        assert_eq!(DiffFormat::Git.get_next(&plain), DiffFormat::ColorWords);
+
+        let with_pager = config(r#"blazingjj.diff-pager = "delta""#);
+        assert_eq!(DiffFormat::Git.get_next(&with_pager), delta);
+        assert_eq!(delta.get_next(&with_pager), DiffFormat::ColorWords);
+
+        let with_both =
+            config("blazingjj.diff-pager = \"delta\"\nblazingjj.diff-tool = \"difft\"\n");
+        assert_eq!(DiffFormat::Git.get_next(&with_both), delta);
+        assert_eq!(delta.get_next(&with_both), difft);
+        assert_eq!(difft.get_next(&with_both), DiffFormat::ColorWords);
+
+        let with_tool = config(r#"blazingjj.diff-tool = "difft""#);
+        assert_eq!(DiffFormat::Git.get_next(&with_tool), difft);
     }
 
     #[test]

--- a/src/ui/panel/output_panel.rs
+++ b/src/ui/panel/output_panel.rs
@@ -252,7 +252,7 @@ impl<K: OutputKey> OutputPanel<K> {
         match event {
             // The next update asks for the output in the new format
             DetailsPanelEvent::ToggleDiffFormat => {
-                self.diff_format = self.diff_format.get_next(get_env().jj_config.diff_tool())
+                self.diff_format = self.diff_format.get_next(&get_env().jj_config)
             }
             event => self.panel.handle_event(event),
         }


### PR DESCRIPTION
Delta only renders a diff as jj's pager, which is unavailable to us:
we run jj with --no-pager and put the output on screen ourselves. So
add a diff format that pipes the Git format through the program
`blazingjj.diff-pager` configures, and the plumbing to run a second
child process on the output of the first.

A pager writing to a pipe cannot find out how wide the panel is, so
`$width` in an argument stands for it. jj colors its output as usual,
which delta passes through for the lines it does not render itself.