### PR TITLE
Show a scrollbar when the help does not fit on screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The tabs overview takes the mouse: a click switches to the tab clicked, and
   the wheel cycles through the tabs
 - The help popup now scrolls with the mouse wheel
+- The help popup now shows a scrollbar when it does not fit on screen
 - Keybinding for jj absorb (`A`)
 - Global keybindings under `[blazingjj.keybinds]` (`scroll-down`, `scroll-up`,
   `scroll-down-half`, `scroll-up-half`, `focus-current`, `refresh`, `open-help`,

--- a/src/ui/dialog/help.rs
+++ b/src/ui/dialog/help.rs
@@ -13,6 +13,9 @@ use ratatui::widgets::Block;
 use ratatui::widgets::Borders;
 use ratatui::widgets::Clear;
 use ratatui::widgets::Row;
+use ratatui::widgets::Scrollbar;
+use ratatui::widgets::ScrollbarOrientation;
+use ratatui::widgets::ScrollbarState;
 use ratatui::widgets::Table;
 
 use crate::keybinds::PopupEvent;
@@ -272,6 +275,19 @@ impl Component for HelpPopup {
             }
 
             render_stack(f, area, self.scroll, column);
+        }
+
+        if self.max_scroll > 0 {
+            f.render_stateful_widget(
+                Scrollbar::new(ScrollbarOrientation::VerticalRight),
+                Rect {
+                    y: block_inner.y,
+                    height: block_inner.height,
+                    ..area
+                },
+                &mut ScrollbarState::new(self.max_scroll as usize + 1)
+                    .position(self.scroll as usize),
+            );
         }
 
         Ok(())


### PR DESCRIPTION
The help popup is sized to fit what it lists and scrolls once that is taller than the terminal, but nothing on screen says so, so the list looks like it simply ends where it is cut off. We draw a scrollbar over the popup's right border while there is anything to scroll to, as the message popup already does.

Fixes #190

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
