### PR TITLE
keybinds: Make every binding configurable and findable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The help popup now scrolls with the mouse wheel
 - The help popup now shows a scrollbar when it does not fit on screen
 - Keybinding for jj absorb (`A`)
+- Going to the top or bottom of the list (`Ctrl+Home` and `Ctrl+End`) now works
+  in the files, bookmarks and evolog tabs as well, and is configured under
+  `[blazingjj.keybinds]` as `scroll-to-top` and `scroll-to-bottom` alongside
+  the other ways of scrolling
 - Global keybindings under `[blazingjj.keybinds]` (`scroll-down`, `scroll-up`,
   `scroll-down-half`, `scroll-up-half`, `focus-current`, `refresh`, `open-help`,
   `next-tab`, `prev-tab`, `open-context-menu`, `command-popup`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A keybinding on Home, End or the space bar now shows the key's name rather
+  than "Unknown" or a blank
 - The help popup now lists the key that opens the context menu in every tab,
   the bookmarks tab included
 - An operation jj turns down no longer takes the app down with it: the reason

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   revision
 - The tabs overview takes the mouse: a click switches to the tab clicked, and
   the wheel cycles through the tabs
+- The keys the confirmation, set-bookmark and rebase popups have of their own
+  are now configurable, under `[blazingjj.keybinds.confirm-popup]`,
+  `[blazingjj.keybinds.bookmark-set-popup]` and
+  `[blazingjj.keybinds.rebase-popup]`. The first two mark the key a button or
+  option is bound to in its label, or name it after the label where the label
+  has no such letter, rather than marking a letter that a rebinding would move
 - `[blazingjj.keybinds.log-tab] mark-head` for marking a change, which had no
   binding to configure and no line in the help
 - The files, bookmarks and evolog tabs can now have their keybindings
@@ -118,6 +124,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The popups now all scroll alike, so the lists and the help scroll by half a
   page on `Ctrl+d` and `Ctrl+u` and by a page on `Ctrl+f` and `Ctrl+b` as well,
   as the message popup already did
+- A popup's own keys are now matched after the ones every popup answers to,
+  which is what the set-bookmark and confirmation popups already did and the
+  rebase popup did the other way round
 - The line under a popup naming the keys it answers to now names the keys
   they are bound to, rather than the ones they were bound to when it was
   written

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   revision
 - The tabs overview takes the mouse: a click switches to the tab clicked, and
   the wheel cycles through the tabs
+- The files, bookmarks and evolog tabs can now have their keybindings
+  configured, under `[blazingjj.keybinds.files-tab]`,
+  `[blazingjj.keybinds.bookmarks-tab]` and `[blazingjj.keybinds.evolog-tab]`
 - The details panel keybindings are now all configurable: `scroll-down`,
   `scroll-up`, the `scroll-*-half` and `scroll-*-page` bindings, `toggle-wrap`
   and `toggle-diff-format`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `@` in the bookmarks tab now goes to the bookmark on the working copy, or to
+  the one it is standing on, rather than doing nothing while the help offers it
 - A keybinding on Home, End or the space bar now shows the key's name rather
   than "Unknown" or a blank
 - The help popup now lists the key that opens the context menu in every tab,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The line under a popup naming the keys it answers to now names the keys
   they are bound to, rather than the ones they were bound to when it was
   written
+- The help popup now lists every keybinding under a heading for what it does
+  rather than for who binds it: the keys that move around in the main panel --
+  scrolling, `@`, going to the top or bottom of the list, and the context
+  menu -- join the panel's navigation heading rather than the global
+  keybindings, and the files and evolog tabs get a heading per kind of thing
+  their keys do rather than one holding all of them
 - The help popup now lists a tab's main panel keybindings under a heading per
   kind of thing they do -- navigation, changes, bookmarks and remotes,
   clipboard -- rather than as one run, and spreads those headings over a second

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The line under a popup naming the keys it answers to now names the keys
   they are bound to, rather than the ones they were bound to when it was
   written
+- The help popup now lists a tab's main panel keybindings under a heading per
+  kind of thing they do -- navigation, changes, bookmarks and remotes,
+  clipboard -- rather than as one run, and spreads those headings over a second
+  column where the terminal is wide enough to hold one
 - The help popup is now sized to fit what it lists
 - The message popup is now sized to fit its message, rather than always
   taking up most of the screen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `o`, only on what accepts or cancels a popup
 - Escape no longer quits the app; `q` and `Ctrl+c` still do, and
   `[blazingjj.keybinds] quit` can bind it back
+- The details panel is now configured under `[blazingjj.keybinds.details-panel]`
+  and answers to the same keys in every tab. `[blazingjj.keybinds.log-tab]
+  toggle-diff-format`, which only ever reached the log tab's panel, is gone
 
 ### Added
 
@@ -53,6 +56,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   revision
 - The tabs overview takes the mouse: a click switches to the tab clicked, and
   the wheel cycles through the tabs
+- The details panel keybindings are now all configurable: `scroll-down`,
+  `scroll-up`, the `scroll-*-half` and `scroll-*-page` bindings, `toggle-wrap`
+  and `toggle-diff-format`
 - The help popup now scrolls with the mouse wheel
 - The help popup now shows a scrollbar when it does not fit on screen
 - Keybinding for jj absorb (`A`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   revision
 - The tabs overview takes the mouse: a click switches to the tab clicked, and
   the wheel cycles through the tabs
+- `[blazingjj.keybinds.log-tab] mark-head` for marking a change, which had no
+  binding to configure and no line in the help
 - The files, bookmarks and evolog tabs can now have their keybindings
   configured, under `[blazingjj.keybinds.files-tab]`,
   `[blazingjj.keybinds.bookmarks-tab]` and `[blazingjj.keybinds.evolog-tab]`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The keybinds config section is now kebab-cased: `[blazingjj.keybinds.log_tab]` must be
   changed to `[blazingjj.keybinds.log-tab]`
 - The keybindings shared by all tabs are now configured under `[blazingjj.keybinds]`:
-  `focus-current`, `refresh` and `open-help` move there from
-  `[blazingjj.keybinds.log-tab]`, which also loses its `scroll-*` overrides
+  `focus-current`, `refresh`, `open-help` and `open-context-menu` move there
+  from `[blazingjj.keybinds.log-tab]`, which also loses its `scroll-*` overrides
 - jj 0.42.0 or newer is now required
 - The confirmation dialogs are now popups of the app and go away on `q` or
   Escape, like the other popups, rather than on the log tab's `close-popup`
@@ -64,8 +64,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Keybinding for jj absorb (`A`)
 - Global keybindings under `[blazingjj.keybinds]` (`scroll-down`, `scroll-up`,
   `scroll-down-half`, `scroll-up-half`, `focus-current`, `refresh`, `open-help`,
-  `next-tab`, `prev-tab`, `command-popup`, `quit`) that work the same in every
-  tab; `scroll-down` and `scroll-up` scroll the popups as well
+  `next-tab`, `prev-tab`, `open-context-menu`, `command-popup`,
+  `interactive-command-popup`, `quit`) that work the same in every tab;
+  `scroll-down` and `scroll-up` scroll the popups as well
 - The help popup now lists the global keybindings alongside the main and details panel ones
 - Message popup now supports scrolling with a scrollbar
 - Command popup output now preserves ANSI color
@@ -128,6 +129,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The help popup now lists the key that opens the context menu in every tab,
+  the bookmarks tab included
 - An operation jj turns down no longer takes the app down with it: the reason
   goes up in a popup, as it already did for the operations refused before they
   were run

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -64,6 +64,33 @@ accept = "ctrl+s"
 cancel = "esc"
 ```
 
+Three popups have keys of their own besides, for the buttons and options
+they put up. Those are matched after the keys every popup answers to, so
+binding one of them to a key a popup already uses leaves it unreachable.
+The confirmation popup and the set-bookmark popup mark these keys in the
+label of the button or option they press, or name them after it where the
+label has no such letter, so a rebinding shows up there.
+
+```toml
+[blazingjj.keybinds.confirm-popup]
+yes = "y"
+no = "n"
+select-yes = "left"
+select-no = "right"
+
+[blazingjj.keybinds.bookmark-set-popup]
+use-generated-name = "g"
+create-bookmark = "c"
+
+[blazingjj.keybinds.rebase-popup]
+source-with-descendants = "s"
+source-whole-branch = "b"
+source-single-revision = "r"
+target-new-branch = "d"
+target-insert-after = "shift+a"
+target-insert-before = "shift+b"
+```
+
 ### Details panel
 
 These work in the details panel of every tab.

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -23,6 +23,8 @@ scroll-down = ["j", "down"]
 scroll-up = ["k", "up"]
 scroll-down-half = "shift+j"
 scroll-up-half = "shift+k"
+scroll-to-top = "ctrl+home"
+scroll-to-bottom = "ctrl+end"
 
 focus-current = "@"
 refresh = ["shift+r", "f5"]

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -61,17 +61,31 @@ accept = "ctrl+s"
 cancel = "esc"
 ```
 
+### Details panel
+
+These work in the details panel of every tab.
+
+```toml
+[blazingjj.keybinds.details-panel]
+scroll-down = "ctrl+e"
+scroll-up = "ctrl+y"
+scroll-down-half = "ctrl+d"
+scroll-up-half = "ctrl+u"
+scroll-down-page = "ctrl+f"
+scroll-up-page = "ctrl+b"
+
+toggle-diff-format = "w"
+toggle-wrap = "shift+w"
+```
+
 ### Log tab
 
 Only the log tab has bindings of its own; the other tabs and the keys that
 mark a change (`space`) or jump to the top or bottom of the log
-(`ctrl+home`/`ctrl+end`) are not configurable. `toggle-diff-format` is the
-one details panel key that is, and it applies to the log tab only.
+(`ctrl+home`/`ctrl+end`) are not configurable.
 
 ```toml
 [blazingjj.keybinds.log-tab]
-toggle-diff-format = "w"
-
 goto-parent = "-"
 
 create-new = "n"

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -31,6 +31,7 @@ open-help = "?"
 next-tab = "l"
 prev-tab = "h"
 
+open-context-menu = "menu"
 command-popup = ":"
 interactive-command-popup = "!"
 quit = ["q", "ctrl+c"]
@@ -112,6 +113,4 @@ push-all = "shift+p"
 push-all-new = "ctrl+shift+p"
 fetch = "f"
 fetch-all = "shift+f"
-
-open-context-menu = "menu"
 ```

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -81,9 +81,8 @@ toggle-wrap = "shift+w"
 
 ### Log tab
 
-Only the log tab has bindings of its own; the other tabs and the keys that
-mark a change (`space`) or jump to the top or bottom of the log
-(`ctrl+home`/`ctrl+end`) are not configurable.
+The keys that mark a change (`space`) and jump to the top or bottom of the
+log (`ctrl+home`/`ctrl+end`) are not configurable.
 
 ```toml
 [blazingjj.keybinds.log-tab]
@@ -113,4 +112,42 @@ push-all = "shift+p"
 push-all-new = "ctrl+shift+p"
 fetch = "f"
 fetch-all = "shift+f"
+```
+
+### Files tab
+
+```toml
+[blazingjj.keybinds.files-tab]
+untrack = "x"
+restore = "r"
+```
+
+### Bookmarks tab
+
+```toml
+[blazingjj.keybinds.bookmarks-tab]
+toggle-show-all = "a"
+
+create-bookmark = "c"
+rename-bookmark = "r"
+delete-bookmark = "d"
+forget-bookmark = "f"
+track-bookmark = "t"
+untrack-bookmark = "shift+t"
+set-bookmark = "b"
+
+view-in-log = "enter"
+create-new = "n"
+create-new-describe = "shift+n"
+edit-change = "e"
+edit-change-ignore-immutable = "shift+e"
+```
+
+### Evolog tab
+
+```toml
+[blazingjj.keybinds.evolog-tab]
+open-files = "enter"
+duplicate = "shift+d"
+copy-rev = "shift+y"
 ```

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -81,11 +81,9 @@ toggle-wrap = "shift+w"
 
 ### Log tab
 
-The keys that mark a change (`space`) and jump to the top or bottom of the
-log (`ctrl+home`/`ctrl+end`) are not configurable.
-
 ```toml
 [blazingjj.keybinds.log-tab]
+mark-head = "space"
 goto-parent = "-"
 
 create-new = "n"

--- a/src/app.rs
+++ b/src/app.rs
@@ -38,6 +38,7 @@ use crate::event::AppEvent;
 use crate::event::EventSource;
 use crate::keybinds::GlobalEvent;
 use crate::keybinds::GlobalKeybinds;
+use crate::keybinds::HelpSection;
 use crate::keybinds::PopupEvent;
 use crate::keybinds::PopupKeybinds;
 use crate::ui::AppAction;
@@ -174,11 +175,17 @@ impl<'a> App<'a> {
     fn open_help(&mut self) -> Result<()> {
         let global_help = self.global_keybinds.make_help();
         let tab = self.get_current_tab();
-        let popup = HelpPopup::new(
-            tab.make_main_panel_help(),
-            tab.make_details_panel_help(),
-            global_help,
+        let sections = HelpSection::gather(
+            global_help
+                .into_iter()
+                .chain(tab.make_main_panel_help())
+                .chain(tab.make_details_panel_help()),
         );
+
+        let (side, main) = sections
+            .into_iter()
+            .partition(|section| section.section.beside_main_panel());
+        let popup = HelpPopup::new(main, side);
         self.popup = Some(Box::new(popup));
         Ok(())
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -685,6 +685,11 @@ impl<'a> App<'a> {
                             GlobalEvent::FilesTab => self.set_tab(TabId::Files),
                             GlobalEvent::BookmarksTab => self.set_tab(TabId::Bookmarks),
                             GlobalEvent::EvologTab => self.set_tab(TabId::Evolog),
+                            GlobalEvent::OpenContextMenu => {
+                                if let Some(action) = self.get_current_tab().open_context_menu()? {
+                                    self.handle_action(action)?;
+                                }
+                            }
                             GlobalEvent::CommandPopup => {
                                 self.popup =
                                     Some(Box::new(CommandPopup::new(CommandMode::Capture)));

--- a/src/app.rs
+++ b/src/app.rs
@@ -661,6 +661,12 @@ impl<'a> App<'a> {
                                 self.get_current_tab()
                                     .scroll_main_panel(Scroll::UpHalfPage)?;
                             }
+                            GlobalEvent::ScrollToTop => {
+                                self.get_current_tab().scroll_main_panel(Scroll::ToTop)?;
+                            }
+                            GlobalEvent::ScrollToBottom => {
+                                self.get_current_tab().scroll_main_panel(Scroll::ToBottom)?;
+                            }
                             GlobalEvent::FocusCurrent => {
                                 self.get_current_tab().focus_current()?;
                                 // The tabs that read what they show when

--- a/src/commander/bookmarks.rs
+++ b/src/commander/bookmarks.rs
@@ -230,6 +230,23 @@ impl Commander {
         Ok(bookmarks)
     }
 
+    /// The local bookmark `commit_id` is standing on: the one on it, or
+    /// the nearest one behind it. None when there is none behind it at
+    /// all. Two on the same change are settled by name.
+    #[instrument(level = "trace", skip(self))]
+    pub fn get_nearest_bookmark(
+        &self,
+        commit_id: &CommitId,
+    ) -> Result<Option<String>, CommandError> {
+        Ok(self
+            .get_bookmark_ranks(commit_id)?
+            .into_iter()
+            .min_by(|(left, left_rank), (right, right_rank)| {
+                left_rank.cmp(right_rank).then_with(|| left.cmp(right))
+            })
+            .map(|(name, _)| name))
+    }
+
     /// Where each local bookmark on an ancestor of `commit_id` comes in
     /// walking back from it, nearest first, by name. One with more than
     /// one target is ranked by whichever of them is reached first.
@@ -663,6 +680,59 @@ mod tests {
             .collect();
 
         assert!(mismatched.is_empty(), "{mismatched:?}");
+
+        Ok(())
+    }
+
+    #[test]
+    fn get_nearest_bookmark_takes_the_one_on_the_change_itself() -> Result<()> {
+        let test_repo = TestRepo::new()?;
+        let commander = &test_repo.commander;
+
+        commander.create_bookmark("behind")?;
+        commander.run_new(&commander.get_current_head()?.commit_id)?;
+        commander.create_bookmark("on")?;
+        let on = commander.get_current_head()?.commit_id;
+
+        assert_eq!(commander.get_nearest_bookmark(&on)?, Some("on".to_owned()));
+
+        Ok(())
+    }
+
+    /// The change the working copy is standing on is the one it is going
+    /// to end up under, so it is the one to go to when the working copy
+    /// carries no bookmark of its own.
+    #[test]
+    fn get_nearest_bookmark_walks_back_to_the_nearest_one_behind() -> Result<()> {
+        let test_repo = TestRepo::new()?;
+        let commander = &test_repo.commander;
+
+        commander.create_bookmark("far")?;
+        commander.run_new(&commander.get_current_head()?.commit_id)?;
+        commander.create_bookmark("near")?;
+        commander.run_new(&commander.get_current_head()?.commit_id)?;
+
+        assert_eq!(
+            commander.get_nearest_bookmark(&commander.get_current_head()?.commit_id)?,
+            Some("near".to_owned())
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn get_nearest_bookmark_passes_over_one_off_to_the_side() -> Result<()> {
+        let test_repo = TestRepo::new()?;
+        let commander = &test_repo.commander;
+
+        commander.jj(["new", "root()"]).run_void()?;
+        commander.create_bookmark("aside")?;
+        commander.jj(["new", "root()"]).run_void()?;
+
+        assert_eq!(
+            commander.get_nearest_bookmark(&commander.get_current_head()?.commit_id)?,
+            None
+        );
 
         Ok(())
     }

--- a/src/keybinds/bookmark_set_popup.rs
+++ b/src/keybinds/bookmark_set_popup.rs
@@ -1,0 +1,113 @@
+/*! Keys the set-bookmark popup has of its own, for the options it lists
+by the letter they are picked by. They are matched after the keys every
+popup answers to.
+*/
+
+use std::str::FromStr;
+
+use ratatui::crossterm::event::KeyEvent;
+
+use super::Shortcut;
+use super::config::BookmarkSetPopupKeybindsConfig;
+use super::keybinds_store::KeybindsStore;
+use crate::env::keybinds_config;
+use crate::set_keybinds;
+use crate::update_keybinds;
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum BookmarkSetPopupEvent {
+    UseGeneratedName,
+    CreateBookmark,
+
+    Unbound,
+}
+
+#[derive(Debug)]
+pub struct BookmarkSetPopupKeybinds {
+    keys: KeybindsStore<BookmarkSetPopupEvent>,
+}
+
+impl Default for BookmarkSetPopupKeybinds {
+    fn default() -> Self {
+        let mut keys = KeybindsStore::<BookmarkSetPopupEvent>::default();
+        set_keybinds!(
+            keys,
+            BookmarkSetPopupEvent::UseGeneratedName => "g",
+            BookmarkSetPopupEvent::CreateBookmark => "c",
+        );
+        Self { keys }
+    }
+}
+
+impl BookmarkSetPopupKeybinds {
+    /// The bindings as the configuration has them.
+    pub fn new() -> Self {
+        let mut keybinds = Self::default();
+        if let Some(config) =
+            keybinds_config().and_then(|config| config.bookmark_set_popup.as_ref())
+        {
+            keybinds.extend_from_config(config);
+        }
+        keybinds
+    }
+
+    pub fn match_event(&self, event: KeyEvent) -> BookmarkSetPopupEvent {
+        self.keys
+            .match_event(event)
+            .unwrap_or(BookmarkSetPopupEvent::Unbound)
+    }
+
+    /// The shortcut to name `event` by, of those bound to it.
+    pub fn shortcut(&self, event: BookmarkSetPopupEvent) -> Option<Shortcut> {
+        self.keys.get_shortcuts(event).into_iter().next()
+    }
+
+    fn extend_from_config(&mut self, config: &BookmarkSetPopupKeybindsConfig) {
+        update_keybinds!(
+            self.keys,
+            BookmarkSetPopupEvent::UseGeneratedName => config.use_generated_name,
+            BookmarkSetPopupEvent::CreateBookmark => config.create_bookmark,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::crossterm::event::KeyCode;
+    use ratatui::crossterm::event::KeyModifiers;
+
+    use super::*;
+    use crate::keybinds::Keybind;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::empty())
+    }
+
+    #[test]
+    fn test_extend_from_config_replaces_bindings() {
+        let config = BookmarkSetPopupKeybindsConfig {
+            create_bookmark: Some(Keybind::Single(
+                Shortcut::from_str("ctrl+n").expect("shortcut should parse"),
+            )),
+            use_generated_name: None,
+        };
+
+        let mut keybinds = BookmarkSetPopupKeybinds::default();
+        keybinds.extend_from_config(&config);
+
+        assert_eq!(
+            keybinds.match_event(KeyEvent::new(KeyCode::Char('n'), KeyModifiers::CONTROL)),
+            BookmarkSetPopupEvent::CreateBookmark
+        );
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::Char('c'))),
+            BookmarkSetPopupEvent::Unbound
+        );
+
+        // Anything the config leaves out keeps its default.
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::Char('g'))),
+            BookmarkSetPopupEvent::UseGeneratedName
+        );
+    }
+}

--- a/src/keybinds/bookmarks_tab.rs
+++ b/src/keybinds/bookmarks_tab.rs
@@ -32,8 +32,6 @@ pub enum BookmarksTabEvent {
     },
     ViewInLog,
 
-    OpenContextMenu,
-
     Unbound,
 }
 
@@ -55,7 +53,6 @@ impl Default for BookmarksTabKeybinds {
             BookmarksTabEvent::EditChange { ignore_immutable: false } => "e",
             BookmarksTabEvent::EditChange { ignore_immutable: true } => "shift+e",
             BookmarksTabEvent::ViewInLog => "enter",
-            BookmarksTabEvent::OpenContextMenu => "menu",
         );
         Self { keys }
     }

--- a/src/keybinds/bookmarks_tab.rs
+++ b/src/keybinds/bookmarks_tab.rs
@@ -2,6 +2,7 @@ use std::str::FromStr;
 
 use ratatui::crossterm::event::KeyEvent;
 
+use super::HelpSection;
 use super::Shortcut;
 use super::config::BookmarksTabKeybindsConfig;
 use super::keybinds_store::KeybindsStore;
@@ -96,23 +97,40 @@ impl BookmarksTabKeybinds {
             .unwrap_or(BookmarksTabEvent::Unbound)
     }
 
-    pub fn make_help(&self) -> Vec<(String, String)> {
-        make_keybinds_help!(
-            self.keys,
-            BookmarksTabEvent::ToggleShowAll => "show all remotes",
-            BookmarksTabEvent::CreateBookmark => "create bookmark",
-            BookmarksTabEvent::RenameBookmark => "rename bookmark",
-            BookmarksTabEvent::DeleteBookmark => "delete bookmark",
-            BookmarksTabEvent::ForgetBookmark => "forget bookmark",
-            BookmarksTabEvent::TrackBookmark => "track bookmark",
-            BookmarksTabEvent::UntrackBookmark => "untrack bookmark",
-            BookmarksTabEvent::SetBookmark => "set bookmark here",
-            BookmarksTabEvent::ViewInLog => "view in log",
-            BookmarksTabEvent::NewChange { describe: false } => "new from bookmark",
-            BookmarksTabEvent::NewChange { describe: true } => "new and describe",
-            BookmarksTabEvent::EditChange { ignore_immutable: false } => "edit bookmark",
-            BookmarksTabEvent::EditChange { ignore_immutable: true } => "edit bookmark ignoring immutability",
-        )
+    pub fn make_help(&self) -> Vec<HelpSection> {
+        vec![
+            HelpSection::new(
+                "Navigation",
+                make_keybinds_help!(
+                    self.keys,
+                    BookmarksTabEvent::ViewInLog => "view in log",
+                    BookmarksTabEvent::ToggleShowAll => "show all remotes",
+                ),
+            ),
+            HelpSection::new(
+                "Bookmarks and remotes",
+                make_keybinds_help!(
+                    self.keys,
+                    BookmarksTabEvent::CreateBookmark => "create bookmark",
+                    BookmarksTabEvent::RenameBookmark => "rename bookmark",
+                    BookmarksTabEvent::DeleteBookmark => "delete bookmark",
+                    BookmarksTabEvent::ForgetBookmark => "forget bookmark",
+                    BookmarksTabEvent::TrackBookmark => "track bookmark",
+                    BookmarksTabEvent::UntrackBookmark => "untrack bookmark",
+                    BookmarksTabEvent::SetBookmark => "set bookmark here",
+                ),
+            ),
+            HelpSection::new(
+                "Changes",
+                make_keybinds_help!(
+                    self.keys,
+                    BookmarksTabEvent::NewChange { describe: false } => "new from bookmark",
+                    BookmarksTabEvent::NewChange { describe: true } => "new and describe",
+                    BookmarksTabEvent::EditChange { ignore_immutable: false } => "edit bookmark",
+                    BookmarksTabEvent::EditChange { ignore_immutable: true } => "edit bookmark ignoring immutability",
+                ),
+            ),
+        ]
     }
 }
 

--- a/src/keybinds/bookmarks_tab.rs
+++ b/src/keybinds/bookmarks_tab.rs
@@ -2,7 +2,8 @@ use std::str::FromStr;
 
 use ratatui::crossterm::event::KeyEvent;
 
-use super::HelpSection;
+use super::HelpItem;
+use super::Section;
 use super::Shortcut;
 use super::config::BookmarksTabKeybindsConfig;
 use super::keybinds_store::KeybindsStore;
@@ -97,40 +98,25 @@ impl BookmarksTabKeybinds {
             .unwrap_or(BookmarksTabEvent::Unbound)
     }
 
-    pub fn make_help(&self) -> Vec<HelpSection> {
-        vec![
-            HelpSection::new(
-                "Navigation",
-                make_keybinds_help!(
-                    self.keys,
-                    BookmarksTabEvent::ViewInLog => "view in log",
-                    BookmarksTabEvent::ToggleShowAll => "show all remotes",
-                ),
-            ),
-            HelpSection::new(
-                "Bookmarks and remotes",
-                make_keybinds_help!(
-                    self.keys,
-                    BookmarksTabEvent::CreateBookmark => "create bookmark",
-                    BookmarksTabEvent::RenameBookmark => "rename bookmark",
-                    BookmarksTabEvent::DeleteBookmark => "delete bookmark",
-                    BookmarksTabEvent::ForgetBookmark => "forget bookmark",
-                    BookmarksTabEvent::TrackBookmark => "track bookmark",
-                    BookmarksTabEvent::UntrackBookmark => "untrack bookmark",
-                    BookmarksTabEvent::SetBookmark => "set bookmark here",
-                ),
-            ),
-            HelpSection::new(
-                "Changes",
-                make_keybinds_help!(
-                    self.keys,
-                    BookmarksTabEvent::NewChange { describe: false } => "new from bookmark",
-                    BookmarksTabEvent::NewChange { describe: true } => "new and describe",
-                    BookmarksTabEvent::EditChange { ignore_immutable: false } => "edit bookmark",
-                    BookmarksTabEvent::EditChange { ignore_immutable: true } => "edit bookmark ignoring immutability",
-                ),
-            ),
-        ]
+    pub fn make_help(&self) -> Vec<HelpItem> {
+        make_keybinds_help!(
+            self.keys,
+            BookmarksTabEvent::ViewInLog => Section::Navigation, "view in log",
+            BookmarksTabEvent::ToggleShowAll => Section::Navigation, "show all remotes",
+
+            BookmarksTabEvent::NewChange { describe: false } => Section::Changes, "new from bookmark",
+            BookmarksTabEvent::NewChange { describe: true } => Section::Changes, "new and describe",
+            BookmarksTabEvent::EditChange { ignore_immutable: false } => Section::Changes, "edit bookmark",
+            BookmarksTabEvent::EditChange { ignore_immutable: true } => Section::Changes, "edit bookmark ignoring immutability",
+
+            BookmarksTabEvent::CreateBookmark => Section::BookmarksAndRemotes, "create bookmark",
+            BookmarksTabEvent::RenameBookmark => Section::BookmarksAndRemotes, "rename bookmark",
+            BookmarksTabEvent::DeleteBookmark => Section::BookmarksAndRemotes, "delete bookmark",
+            BookmarksTabEvent::ForgetBookmark => Section::BookmarksAndRemotes, "forget bookmark",
+            BookmarksTabEvent::TrackBookmark => Section::BookmarksAndRemotes, "track bookmark",
+            BookmarksTabEvent::UntrackBookmark => Section::BookmarksAndRemotes, "untrack bookmark",
+            BookmarksTabEvent::SetBookmark => Section::BookmarksAndRemotes, "set bookmark here",
+        )
     }
 }
 

--- a/src/keybinds/bookmarks_tab.rs
+++ b/src/keybinds/bookmarks_tab.rs
@@ -3,9 +3,12 @@ use std::str::FromStr;
 use ratatui::crossterm::event::KeyEvent;
 
 use super::Shortcut;
+use super::config::BookmarksTabKeybindsConfig;
 use super::keybinds_store::KeybindsStore;
+use crate::env::keybinds_config;
 use crate::make_keybinds_help;
 use crate::set_keybinds;
+use crate::update_keybinds;
 
 #[derive(Debug)]
 pub struct BookmarksTabKeybinds {
@@ -59,6 +62,34 @@ impl Default for BookmarksTabKeybinds {
 }
 
 impl BookmarksTabKeybinds {
+    /// The bindings as the configuration has them.
+    pub fn new() -> Self {
+        let mut keybinds = Self::default();
+        if let Some(config) = keybinds_config().and_then(|config| config.bookmarks_tab.as_ref()) {
+            keybinds.extend_from_config(config);
+        }
+        keybinds
+    }
+
+    fn extend_from_config(&mut self, config: &BookmarksTabKeybindsConfig) {
+        update_keybinds!(
+            self.keys,
+            BookmarksTabEvent::ToggleShowAll => config.toggle_show_all,
+            BookmarksTabEvent::CreateBookmark => config.create_bookmark,
+            BookmarksTabEvent::RenameBookmark => config.rename_bookmark,
+            BookmarksTabEvent::DeleteBookmark => config.delete_bookmark,
+            BookmarksTabEvent::ForgetBookmark => config.forget_bookmark,
+            BookmarksTabEvent::TrackBookmark => config.track_bookmark,
+            BookmarksTabEvent::UntrackBookmark => config.untrack_bookmark,
+            BookmarksTabEvent::SetBookmark => config.set_bookmark,
+            BookmarksTabEvent::ViewInLog => config.view_in_log,
+            BookmarksTabEvent::NewChange { describe: false } => config.create_new,
+            BookmarksTabEvent::NewChange { describe: true } => config.create_new_describe,
+            BookmarksTabEvent::EditChange { ignore_immutable: false } => config.edit_change,
+            BookmarksTabEvent::EditChange { ignore_immutable: true } => config.edit_change_ignore_immutable,
+        );
+    }
+
     pub fn match_event(&self, event: KeyEvent) -> BookmarksTabEvent {
         self.keys
             .match_event(event)
@@ -85,7 +116,71 @@ impl BookmarksTabKeybinds {
     }
 }
 
-#[test]
-fn test_bookmarks_tab_keybinds_default() {
-    let _ = BookmarksTabKeybinds::default();
+#[cfg(test)]
+mod tests {
+    use ratatui::crossterm::event::KeyCode;
+    use ratatui::crossterm::event::KeyModifiers;
+
+    use super::*;
+    use crate::keybinds::Keybind;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::empty())
+    }
+
+    fn config() -> BookmarksTabKeybindsConfig {
+        BookmarksTabKeybindsConfig {
+            toggle_show_all: None,
+            create_bookmark: None,
+            rename_bookmark: None,
+            delete_bookmark: None,
+            forget_bookmark: None,
+            track_bookmark: None,
+            untrack_bookmark: None,
+            set_bookmark: None,
+            view_in_log: None,
+            create_new: None,
+            create_new_describe: None,
+            edit_change: None,
+            edit_change_ignore_immutable: None,
+        }
+    }
+
+    #[test]
+    fn test_bookmarks_tab_keybinds_default() {
+        let _ = BookmarksTabKeybinds::default();
+    }
+
+    #[test]
+    fn test_extend_from_config_replaces_bindings() {
+        let config = BookmarksTabKeybindsConfig {
+            delete_bookmark: Some(Keybind::Single(
+                Shortcut::from_str("ctrl+x").expect("shortcut should parse"),
+            )),
+            create_new: Some(Keybind::Enable(false)),
+            ..config()
+        };
+
+        let mut keybinds = BookmarksTabKeybinds::default();
+        keybinds.extend_from_config(&config);
+
+        assert_eq!(
+            keybinds.match_event(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::CONTROL)),
+            BookmarksTabEvent::DeleteBookmark
+        );
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::Char('d'))),
+            BookmarksTabEvent::Unbound
+        );
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::Char('n'))),
+            BookmarksTabEvent::Unbound
+        );
+
+        // The two changes a describe tells apart stay apart.
+        assert_eq!(
+            keybinds.match_event(KeyEvent::new(KeyCode::Char('N'), KeyModifiers::SHIFT)),
+            BookmarksTabEvent::NewChange { describe: true }
+        );
+    }
 }

--- a/src/keybinds/config.rs
+++ b/src/keybinds/config.rs
@@ -73,6 +73,7 @@ pub enum Keybind {
 #[derive(Debug, Clone, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct LogTabKeybindsConfig {
+    pub mark_head: Option<Keybind>,
     pub goto_parent: Option<Keybind>,
 
     pub duplicate: Option<Keybind>,

--- a/src/keybinds/config.rs
+++ b/src/keybinds/config.rs
@@ -20,8 +20,23 @@ pub struct KeybindsConfig {
     pub quit: Option<Keybind>,
 
     pub log_tab: Option<LogTabKeybindsConfig>,
+    pub details_panel: Option<DetailsPanelKeybindsConfig>,
     pub popup: Option<PopupKeybindsConfig>,
     pub text_popup: Option<TextPopupKeybindsConfig>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct DetailsPanelKeybindsConfig {
+    pub scroll_down: Option<Keybind>,
+    pub scroll_up: Option<Keybind>,
+    pub scroll_down_half: Option<Keybind>,
+    pub scroll_up_half: Option<Keybind>,
+    pub scroll_down_page: Option<Keybind>,
+    pub scroll_up_page: Option<Keybind>,
+
+    pub toggle_wrap: Option<Keybind>,
+    pub toggle_diff_format: Option<Keybind>,
 }
 
 #[derive(Debug, Clone, serde::Deserialize)]
@@ -54,8 +69,6 @@ pub enum Keybind {
 #[derive(Debug, Clone, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct LogTabKeybindsConfig {
-    pub toggle_diff_format: Option<Keybind>,
-
     pub goto_parent: Option<Keybind>,
 
     pub duplicate: Option<Keybind>,

--- a/src/keybinds/config.rs
+++ b/src/keybinds/config.rs
@@ -29,6 +29,38 @@ pub struct KeybindsConfig {
     pub details_panel: Option<DetailsPanelKeybindsConfig>,
     pub popup: Option<PopupKeybindsConfig>,
     pub text_popup: Option<TextPopupKeybindsConfig>,
+    pub confirm_popup: Option<ConfirmPopupKeybindsConfig>,
+    pub bookmark_set_popup: Option<BookmarkSetPopupKeybindsConfig>,
+    pub rebase_popup: Option<RebasePopupKeybindsConfig>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct ConfirmPopupKeybindsConfig {
+    pub yes: Option<Keybind>,
+    pub no: Option<Keybind>,
+
+    pub select_yes: Option<Keybind>,
+    pub select_no: Option<Keybind>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct BookmarkSetPopupKeybindsConfig {
+    pub use_generated_name: Option<Keybind>,
+    pub create_bookmark: Option<Keybind>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct RebasePopupKeybindsConfig {
+    pub source_with_descendants: Option<Keybind>,
+    pub source_whole_branch: Option<Keybind>,
+    pub source_single_revision: Option<Keybind>,
+
+    pub target_new_branch: Option<Keybind>,
+    pub target_insert_after: Option<Keybind>,
+    pub target_insert_before: Option<Keybind>,
 }
 
 #[derive(Debug, Clone, serde::Deserialize)]

--- a/src/keybinds/config.rs
+++ b/src/keybinds/config.rs
@@ -15,6 +15,7 @@ pub struct KeybindsConfig {
     pub next_tab: Option<Keybind>,
     pub prev_tab: Option<Keybind>,
 
+    pub open_context_menu: Option<Keybind>,
     pub command_popup: Option<Keybind>,
     pub interactive_command_popup: Option<Keybind>,
     pub quit: Option<Keybind>,
@@ -95,6 +96,4 @@ pub struct LogTabKeybindsConfig {
     pub push_all_new: Option<Keybind>,
     pub fetch: Option<Keybind>,
     pub fetch_all: Option<Keybind>,
-
-    pub open_context_menu: Option<Keybind>,
 }

--- a/src/keybinds/config.rs
+++ b/src/keybinds/config.rs
@@ -7,6 +7,8 @@ pub struct KeybindsConfig {
     pub scroll_up: Option<Keybind>,
     pub scroll_down_half: Option<Keybind>,
     pub scroll_up_half: Option<Keybind>,
+    pub scroll_to_top: Option<Keybind>,
+    pub scroll_to_bottom: Option<Keybind>,
 
     pub focus_current: Option<Keybind>,
     pub refresh: Option<Keybind>,

--- a/src/keybinds/config.rs
+++ b/src/keybinds/config.rs
@@ -21,6 +21,9 @@ pub struct KeybindsConfig {
     pub quit: Option<Keybind>,
 
     pub log_tab: Option<LogTabKeybindsConfig>,
+    pub files_tab: Option<FilesTabKeybindsConfig>,
+    pub bookmarks_tab: Option<BookmarksTabKeybindsConfig>,
+    pub evolog_tab: Option<EvologTabKeybindsConfig>,
     pub details_panel: Option<DetailsPanelKeybindsConfig>,
     pub popup: Option<PopupKeybindsConfig>,
     pub text_popup: Option<TextPopupKeybindsConfig>,
@@ -96,4 +99,39 @@ pub struct LogTabKeybindsConfig {
     pub push_all_new: Option<Keybind>,
     pub fetch: Option<Keybind>,
     pub fetch_all: Option<Keybind>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct FilesTabKeybindsConfig {
+    pub untrack: Option<Keybind>,
+    pub restore: Option<Keybind>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct BookmarksTabKeybindsConfig {
+    pub toggle_show_all: Option<Keybind>,
+
+    pub create_bookmark: Option<Keybind>,
+    pub rename_bookmark: Option<Keybind>,
+    pub delete_bookmark: Option<Keybind>,
+    pub forget_bookmark: Option<Keybind>,
+    pub track_bookmark: Option<Keybind>,
+    pub untrack_bookmark: Option<Keybind>,
+    pub set_bookmark: Option<Keybind>,
+
+    pub view_in_log: Option<Keybind>,
+    pub create_new: Option<Keybind>,
+    pub create_new_describe: Option<Keybind>,
+    pub edit_change: Option<Keybind>,
+    pub edit_change_ignore_immutable: Option<Keybind>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct EvologTabKeybindsConfig {
+    pub open_files: Option<Keybind>,
+    pub duplicate: Option<Keybind>,
+    pub copy_rev: Option<Keybind>,
 }

--- a/src/keybinds/confirm_popup.rs
+++ b/src/keybinds/confirm_popup.rs
@@ -1,0 +1,136 @@
+/*! Keys the confirmation popup has of its own, for the buttons it puts
+up. They are matched after the keys every popup answers to.
+*/
+
+use std::str::FromStr;
+
+use ratatui::crossterm::event::KeyEvent;
+
+use super::Shortcut;
+use super::config::ConfirmPopupKeybindsConfig;
+use super::keybinds_store::KeybindsStore;
+use crate::env::keybinds_config;
+use crate::set_keybinds;
+use crate::update_keybinds;
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum ConfirmPopupEvent {
+    /// Answer the question, without going by the selected button.
+    Answer(bool),
+    /// Make `Accept` answer the given way.
+    Select(bool),
+
+    Unbound,
+}
+
+#[derive(Debug)]
+pub struct ConfirmPopupKeybinds {
+    keys: KeybindsStore<ConfirmPopupEvent>,
+}
+
+impl Default for ConfirmPopupKeybinds {
+    fn default() -> Self {
+        let mut keys = KeybindsStore::<ConfirmPopupEvent>::default();
+        set_keybinds!(
+            keys,
+            ConfirmPopupEvent::Answer(true) => "y",
+            ConfirmPopupEvent::Answer(false) => "n",
+            ConfirmPopupEvent::Select(true) => "left",
+            ConfirmPopupEvent::Select(false) => "right",
+        );
+        Self { keys }
+    }
+}
+
+impl ConfirmPopupKeybinds {
+    /// The bindings as the configuration has them.
+    pub fn new() -> Self {
+        let mut keybinds = Self::default();
+        if let Some(config) = keybinds_config().and_then(|config| config.confirm_popup.as_ref()) {
+            keybinds.extend_from_config(config);
+        }
+        keybinds
+    }
+
+    pub fn match_event(&self, event: KeyEvent) -> ConfirmPopupEvent {
+        self.keys
+            .match_event(event)
+            .unwrap_or(ConfirmPopupEvent::Unbound)
+    }
+
+    /// The shortcut to name `event` by, of those bound to it.
+    pub fn shortcut(&self, event: ConfirmPopupEvent) -> Option<Shortcut> {
+        self.keys.get_shortcuts(event).into_iter().next()
+    }
+
+    fn extend_from_config(&mut self, config: &ConfirmPopupKeybindsConfig) {
+        update_keybinds!(
+            self.keys,
+            ConfirmPopupEvent::Answer(true) => config.yes,
+            ConfirmPopupEvent::Answer(false) => config.no,
+            ConfirmPopupEvent::Select(true) => config.select_yes,
+            ConfirmPopupEvent::Select(false) => config.select_no,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::crossterm::event::KeyCode;
+    use ratatui::crossterm::event::KeyModifiers;
+
+    use super::*;
+    use crate::keybinds::Keybind;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::empty())
+    }
+
+    #[test]
+    fn test_match_event_defaults() {
+        let keybinds = ConfirmPopupKeybinds::default();
+
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::Char('y'))),
+            ConfirmPopupEvent::Answer(true)
+        );
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::Left)),
+            ConfirmPopupEvent::Select(true)
+        );
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::Char('z'))),
+            ConfirmPopupEvent::Unbound
+        );
+    }
+
+    #[test]
+    fn test_extend_from_config_replaces_bindings() {
+        let config = ConfirmPopupKeybindsConfig {
+            no: Some(Keybind::Single(
+                Shortcut::from_str("x").expect("shortcut should parse"),
+            )),
+            yes: None,
+            select_yes: None,
+            select_no: None,
+        };
+
+        let mut keybinds = ConfirmPopupKeybinds::default();
+        keybinds.extend_from_config(&config);
+
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::Char('x'))),
+            ConfirmPopupEvent::Answer(false)
+        );
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::Char('n'))),
+            ConfirmPopupEvent::Unbound
+        );
+
+        // Anything the config leaves out keeps its default.
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::Char('y'))),
+            ConfirmPopupEvent::Answer(true)
+        );
+    }
+}

--- a/src/keybinds/details_panel.rs
+++ b/src/keybinds/details_panel.rs
@@ -2,6 +2,8 @@ use std::str::FromStr;
 
 use ratatui::crossterm::event::KeyEvent;
 
+use super::HelpItem;
+use super::Section;
 use super::Shortcut;
 use super::config::DetailsPanelKeybindsConfig;
 use super::keybinds_store::KeybindsStore;
@@ -77,17 +79,17 @@ impl DetailsPanelKeybinds {
         );
     }
 
-    pub fn make_help(&self) -> Vec<(String, String)> {
+    pub fn make_help(&self) -> Vec<HelpItem> {
         make_keybinds_help!(
             self.keys,
-            DetailsPanelEvent::ScrollDown => "scroll down",
-            DetailsPanelEvent::ScrollUp => "scroll up",
-            DetailsPanelEvent::ScrollDownHalfPage => "scroll down by ½ page",
-            DetailsPanelEvent::ScrollUpHalfPage => "scroll up by ½ page",
-            DetailsPanelEvent::ScrollDownPage => "scroll down by page",
-            DetailsPanelEvent::ScrollUpPage => "scroll up by page",
-            DetailsPanelEvent::ToggleDiffFormat => "toggle diff format",
-            DetailsPanelEvent::ToggleWrap => "toggle wrapping",
+            DetailsPanelEvent::ScrollDown => Section::DetailsPanel, "scroll down",
+            DetailsPanelEvent::ScrollUp => Section::DetailsPanel, "scroll up",
+            DetailsPanelEvent::ScrollDownHalfPage => Section::DetailsPanel, "scroll down by ½ page",
+            DetailsPanelEvent::ScrollUpHalfPage => Section::DetailsPanel, "scroll up by ½ page",
+            DetailsPanelEvent::ScrollDownPage => Section::DetailsPanel, "scroll down by page",
+            DetailsPanelEvent::ScrollUpPage => Section::DetailsPanel, "scroll up by page",
+            DetailsPanelEvent::ToggleDiffFormat => Section::DetailsPanel, "toggle diff format",
+            DetailsPanelEvent::ToggleWrap => Section::DetailsPanel, "toggle wrapping",
         )
     }
 }

--- a/src/keybinds/details_panel.rs
+++ b/src/keybinds/details_panel.rs
@@ -2,11 +2,13 @@ use std::str::FromStr;
 
 use ratatui::crossterm::event::KeyEvent;
 
-use super::Keybind;
 use super::Shortcut;
+use super::config::DetailsPanelKeybindsConfig;
 use super::keybinds_store::KeybindsStore;
+use crate::env::keybinds_config;
 use crate::make_keybinds_help;
 use crate::set_keybinds;
+use crate::update_keybinds;
 
 #[derive(Debug)]
 pub struct DetailsPanelKeybinds {
@@ -45,17 +47,34 @@ impl Default for DetailsPanelKeybinds {
 }
 
 impl DetailsPanelKeybinds {
+    /// The bindings as the configuration has them, which every tab's
+    /// details panel answers to alike.
+    pub fn new() -> Self {
+        let mut keybinds = Self::default();
+        if let Some(config) = keybinds_config().and_then(|config| config.details_panel.as_ref()) {
+            keybinds.extend_from_config(config);
+        }
+        keybinds
+    }
+
     pub fn match_event(&self, event: KeyEvent) -> DetailsPanelEvent {
         self.keys
             .match_event(event)
             .unwrap_or(DetailsPanelEvent::Unbound)
     }
 
-    pub fn extend_from_config(&mut self, toggle_diff_format: Option<&Keybind>) {
-        if let Some(k) = toggle_diff_format {
-            self.keys
-                .replace_action_from_config(DetailsPanelEvent::ToggleDiffFormat, k);
-        }
+    fn extend_from_config(&mut self, config: &DetailsPanelKeybindsConfig) {
+        update_keybinds!(
+            self.keys,
+            DetailsPanelEvent::ScrollDown => config.scroll_down,
+            DetailsPanelEvent::ScrollUp => config.scroll_up,
+            DetailsPanelEvent::ScrollDownHalfPage => config.scroll_down_half,
+            DetailsPanelEvent::ScrollUpHalfPage => config.scroll_up_half,
+            DetailsPanelEvent::ScrollDownPage => config.scroll_down_page,
+            DetailsPanelEvent::ScrollUpPage => config.scroll_up_page,
+            DetailsPanelEvent::ToggleWrap => config.toggle_wrap,
+            DetailsPanelEvent::ToggleDiffFormat => config.toggle_diff_format,
+        );
     }
 
     pub fn make_help(&self) -> Vec<(String, String)> {
@@ -73,7 +92,60 @@ impl DetailsPanelKeybinds {
     }
 }
 
-#[test]
-fn test_details_panel_keybinds_default() {
-    let _ = DetailsPanelKeybinds::default();
+#[cfg(test)]
+mod tests {
+    use ratatui::crossterm::event::KeyCode;
+    use ratatui::crossterm::event::KeyModifiers;
+
+    use super::*;
+    use crate::keybinds::Keybind;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::empty())
+    }
+
+    fn bind(shortcut: &str) -> Keybind {
+        Keybind::Single(Shortcut::from_str(shortcut).expect("shortcut should parse"))
+    }
+
+    #[test]
+    fn test_details_panel_keybinds_default() {
+        let _ = DetailsPanelKeybinds::default();
+    }
+
+    #[test]
+    fn test_extend_from_config_replaces_bindings() {
+        let config = DetailsPanelKeybindsConfig {
+            toggle_diff_format: Some(bind("ctrl+w")),
+            toggle_wrap: Some(Keybind::Enable(false)),
+            scroll_down: None,
+            scroll_up: None,
+            scroll_down_half: None,
+            scroll_up_half: None,
+            scroll_down_page: None,
+            scroll_up_page: None,
+        };
+
+        let mut keybinds = DetailsPanelKeybinds::default();
+        keybinds.extend_from_config(&config);
+
+        assert_eq!(
+            keybinds.match_event(KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL)),
+            DetailsPanelEvent::ToggleDiffFormat
+        );
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::Char('w'))),
+            DetailsPanelEvent::Unbound
+        );
+        assert_eq!(
+            keybinds.match_event(KeyEvent::new(KeyCode::Char('W'), KeyModifiers::SHIFT)),
+            DetailsPanelEvent::Unbound
+        );
+
+        // Anything the config leaves out keeps its default.
+        assert_eq!(
+            keybinds.match_event(KeyEvent::new(KeyCode::Char('e'), KeyModifiers::CONTROL)),
+            DetailsPanelEvent::ScrollDown
+        );
+    }
 }

--- a/src/keybinds/evolog_tab.rs
+++ b/src/keybinds/evolog_tab.rs
@@ -2,6 +2,7 @@ use std::str::FromStr;
 
 use ratatui::crossterm::event::KeyEvent;
 
+use super::HelpSection;
 use super::Shortcut;
 use super::config::EvologTabKeybindsConfig;
 use super::keybinds_store::KeybindsStore;
@@ -62,13 +63,16 @@ impl EvologTabKeybinds {
             .unwrap_or(EvologTabEvent::Unbound)
     }
 
-    pub fn make_help(&self) -> Vec<(String, String)> {
-        make_keybinds_help!(
-            self.keys,
-            EvologTabEvent::OpenFiles => "see files of this version",
-            EvologTabEvent::Duplicate => "duplicate this version as a new change",
-            EvologTabEvent::CopyRev => "yank revision to clipboard",
-        )
+    pub fn make_help(&self) -> Vec<HelpSection> {
+        vec![HelpSection::new(
+            "Main panel",
+            make_keybinds_help!(
+                self.keys,
+                EvologTabEvent::OpenFiles => "see files of this version",
+                EvologTabEvent::Duplicate => "duplicate this version as a new change",
+                EvologTabEvent::CopyRev => "yank revision to clipboard",
+            ),
+        )]
     }
 }
 

--- a/src/keybinds/evolog_tab.rs
+++ b/src/keybinds/evolog_tab.rs
@@ -18,8 +18,6 @@ pub enum EvologTabEvent {
     Duplicate,
     CopyRev,
 
-    OpenContextMenu,
-
     Unbound,
 }
 
@@ -31,7 +29,6 @@ impl Default for EvologTabKeybinds {
             EvologTabEvent::OpenFiles => "enter",
             EvologTabEvent::Duplicate => "shift+d",
             EvologTabEvent::CopyRev => "shift+y",
-            EvologTabEvent::OpenContextMenu => "menu",
         );
         Self { keys }
     }
@@ -50,7 +47,6 @@ impl EvologTabKeybinds {
             EvologTabEvent::OpenFiles => "see files of this version",
             EvologTabEvent::Duplicate => "duplicate this version as a new change",
             EvologTabEvent::CopyRev => "yank revision to clipboard",
-            EvologTabEvent::OpenContextMenu => "open the context menu",
         )
     }
 }

--- a/src/keybinds/evolog_tab.rs
+++ b/src/keybinds/evolog_tab.rs
@@ -3,9 +3,12 @@ use std::str::FromStr;
 use ratatui::crossterm::event::KeyEvent;
 
 use super::Shortcut;
+use super::config::EvologTabKeybindsConfig;
 use super::keybinds_store::KeybindsStore;
+use crate::env::keybinds_config;
 use crate::make_keybinds_help;
 use crate::set_keybinds;
+use crate::update_keybinds;
 
 #[derive(Debug)]
 pub struct EvologTabKeybinds {
@@ -35,6 +38,24 @@ impl Default for EvologTabKeybinds {
 }
 
 impl EvologTabKeybinds {
+    /// The bindings as the configuration has them.
+    pub fn new() -> Self {
+        let mut keybinds = Self::default();
+        if let Some(config) = keybinds_config().and_then(|config| config.evolog_tab.as_ref()) {
+            keybinds.extend_from_config(config);
+        }
+        keybinds
+    }
+
+    fn extend_from_config(&mut self, config: &EvologTabKeybindsConfig) {
+        update_keybinds!(
+            self.keys,
+            EvologTabEvent::OpenFiles => config.open_files,
+            EvologTabEvent::Duplicate => config.duplicate,
+            EvologTabEvent::CopyRev => config.copy_rev,
+        );
+    }
+
     pub fn match_event(&self, event: KeyEvent) -> EvologTabEvent {
         self.keys
             .match_event(event)
@@ -51,7 +72,49 @@ impl EvologTabKeybinds {
     }
 }
 
-#[test]
-fn test_evolog_tab_keybinds_default() {
-    let _ = EvologTabKeybinds::default();
+#[cfg(test)]
+mod tests {
+    use ratatui::crossterm::event::KeyCode;
+    use ratatui::crossterm::event::KeyModifiers;
+
+    use super::*;
+    use crate::keybinds::Keybind;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::empty())
+    }
+
+    #[test]
+    fn test_evolog_tab_keybinds_default() {
+        let _ = EvologTabKeybinds::default();
+    }
+
+    #[test]
+    fn test_extend_from_config_replaces_bindings() {
+        let config = EvologTabKeybindsConfig {
+            duplicate: Some(Keybind::Single(
+                Shortcut::from_str("ctrl+d").expect("shortcut should parse"),
+            )),
+            open_files: None,
+            copy_rev: None,
+        };
+
+        let mut keybinds = EvologTabKeybinds::default();
+        keybinds.extend_from_config(&config);
+
+        assert_eq!(
+            keybinds.match_event(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL)),
+            EvologTabEvent::Duplicate
+        );
+        assert_eq!(
+            keybinds.match_event(KeyEvent::new(KeyCode::Char('D'), KeyModifiers::SHIFT)),
+            EvologTabEvent::Unbound
+        );
+
+        // Anything the config leaves out keeps its default.
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::Enter)),
+            EvologTabEvent::OpenFiles
+        );
+    }
 }

--- a/src/keybinds/evolog_tab.rs
+++ b/src/keybinds/evolog_tab.rs
@@ -2,7 +2,8 @@ use std::str::FromStr;
 
 use ratatui::crossterm::event::KeyEvent;
 
-use super::HelpSection;
+use super::HelpItem;
+use super::Section;
 use super::Shortcut;
 use super::config::EvologTabKeybindsConfig;
 use super::keybinds_store::KeybindsStore;
@@ -63,16 +64,13 @@ impl EvologTabKeybinds {
             .unwrap_or(EvologTabEvent::Unbound)
     }
 
-    pub fn make_help(&self) -> Vec<HelpSection> {
-        vec![HelpSection::new(
-            "Main panel",
-            make_keybinds_help!(
-                self.keys,
-                EvologTabEvent::OpenFiles => "see files of this version",
-                EvologTabEvent::Duplicate => "duplicate this version as a new change",
-                EvologTabEvent::CopyRev => "yank revision to clipboard",
-            ),
-        )]
+    pub fn make_help(&self) -> Vec<HelpItem> {
+        make_keybinds_help!(
+            self.keys,
+            EvologTabEvent::OpenFiles => Section::Navigation, "see files of this version",
+            EvologTabEvent::Duplicate => Section::Changes, "duplicate this version as a new change",
+            EvologTabEvent::CopyRev => Section::Clipboard, "yank revision to clipboard",
+        )
     }
 }
 

--- a/src/keybinds/files_tab.rs
+++ b/src/keybinds/files_tab.rs
@@ -17,8 +17,6 @@ pub enum FilesTabEvent {
     Untrack,
     Restore,
 
-    OpenContextMenu,
-
     Unbound,
 }
 
@@ -29,7 +27,6 @@ impl Default for FilesTabKeybinds {
             keys,
             FilesTabEvent::Untrack => "x",
             FilesTabEvent::Restore => "r",
-            FilesTabEvent::OpenContextMenu => "menu",
         );
         Self { keys }
     }
@@ -47,7 +44,6 @@ impl FilesTabKeybinds {
             self.keys,
             FilesTabEvent::Untrack => "untrack file",
             FilesTabEvent::Restore => "restore file",
-            FilesTabEvent::OpenContextMenu => "open the context menu",
         )
     }
 }

--- a/src/keybinds/files_tab.rs
+++ b/src/keybinds/files_tab.rs
@@ -2,7 +2,8 @@ use std::str::FromStr;
 
 use ratatui::crossterm::event::KeyEvent;
 
-use super::HelpSection;
+use super::HelpItem;
+use super::Section;
 use super::Shortcut;
 use super::config::FilesTabKeybindsConfig;
 use super::keybinds_store::KeybindsStore;
@@ -60,15 +61,12 @@ impl FilesTabKeybinds {
             .unwrap_or(FilesTabEvent::Unbound)
     }
 
-    pub fn make_help(&self) -> Vec<HelpSection> {
-        vec![HelpSection::new(
-            "Main panel",
-            make_keybinds_help!(
-                self.keys,
-                FilesTabEvent::Untrack => "untrack file",
-                FilesTabEvent::Restore => "restore file",
-            ),
-        )]
+    pub fn make_help(&self) -> Vec<HelpItem> {
+        make_keybinds_help!(
+            self.keys,
+            FilesTabEvent::Untrack => Section::Files, "untrack file",
+            FilesTabEvent::Restore => Section::Files, "restore file",
+        )
     }
 }
 

--- a/src/keybinds/files_tab.rs
+++ b/src/keybinds/files_tab.rs
@@ -2,6 +2,7 @@ use std::str::FromStr;
 
 use ratatui::crossterm::event::KeyEvent;
 
+use super::HelpSection;
 use super::Shortcut;
 use super::config::FilesTabKeybindsConfig;
 use super::keybinds_store::KeybindsStore;
@@ -59,12 +60,15 @@ impl FilesTabKeybinds {
             .unwrap_or(FilesTabEvent::Unbound)
     }
 
-    pub fn make_help(&self) -> Vec<(String, String)> {
-        make_keybinds_help!(
-            self.keys,
-            FilesTabEvent::Untrack => "untrack file",
-            FilesTabEvent::Restore => "restore file",
-        )
+    pub fn make_help(&self) -> Vec<HelpSection> {
+        vec![HelpSection::new(
+            "Main panel",
+            make_keybinds_help!(
+                self.keys,
+                FilesTabEvent::Untrack => "untrack file",
+                FilesTabEvent::Restore => "restore file",
+            ),
+        )]
     }
 }
 

--- a/src/keybinds/files_tab.rs
+++ b/src/keybinds/files_tab.rs
@@ -3,9 +3,12 @@ use std::str::FromStr;
 use ratatui::crossterm::event::KeyEvent;
 
 use super::Shortcut;
+use super::config::FilesTabKeybindsConfig;
 use super::keybinds_store::KeybindsStore;
+use crate::env::keybinds_config;
 use crate::make_keybinds_help;
 use crate::set_keybinds;
+use crate::update_keybinds;
 
 #[derive(Debug)]
 pub struct FilesTabKeybinds {
@@ -33,6 +36,23 @@ impl Default for FilesTabKeybinds {
 }
 
 impl FilesTabKeybinds {
+    /// The bindings as the configuration has them.
+    pub fn new() -> Self {
+        let mut keybinds = Self::default();
+        if let Some(config) = keybinds_config().and_then(|config| config.files_tab.as_ref()) {
+            keybinds.extend_from_config(config);
+        }
+        keybinds
+    }
+
+    fn extend_from_config(&mut self, config: &FilesTabKeybindsConfig) {
+        update_keybinds!(
+            self.keys,
+            FilesTabEvent::Untrack => config.untrack,
+            FilesTabEvent::Restore => config.restore,
+        );
+    }
+
     pub fn match_event(&self, event: KeyEvent) -> FilesTabEvent {
         self.keys
             .match_event(event)
@@ -48,7 +68,46 @@ impl FilesTabKeybinds {
     }
 }
 
-#[test]
-fn test_files_tab_keybinds_default() {
-    let _ = FilesTabKeybinds::default();
+#[cfg(test)]
+mod tests {
+    use ratatui::crossterm::event::KeyCode;
+    use ratatui::crossterm::event::KeyModifiers;
+
+    use super::*;
+    use crate::keybinds::Keybind;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::empty())
+    }
+
+    #[test]
+    fn test_files_tab_keybinds_default() {
+        let _ = FilesTabKeybinds::default();
+    }
+
+    #[test]
+    fn test_extend_from_config_replaces_bindings() {
+        let config = FilesTabKeybindsConfig {
+            untrack: Some(Keybind::Single(
+                Shortcut::from_str("u").expect("shortcut should parse"),
+            )),
+            restore: Some(Keybind::Enable(false)),
+        };
+
+        let mut keybinds = FilesTabKeybinds::default();
+        keybinds.extend_from_config(&config);
+
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::Char('u'))),
+            FilesTabEvent::Untrack
+        );
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::Char('x'))),
+            FilesTabEvent::Unbound
+        );
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::Char('r'))),
+            FilesTabEvent::Unbound
+        );
+    }
 }

--- a/src/keybinds/global.rs
+++ b/src/keybinds/global.rs
@@ -2,6 +2,8 @@ use std::str::FromStr;
 
 use ratatui::crossterm::event::KeyEvent;
 
+use super::HelpItem;
+use super::Section;
 use super::Shortcut;
 use super::config::KeybindsConfig;
 use super::keybinds_store::KeybindsStore;
@@ -103,28 +105,29 @@ impl GlobalKeybinds {
         );
     }
 
-    pub fn make_help(&self) -> Vec<(String, String)> {
+    pub fn make_help(&self) -> Vec<HelpItem> {
         make_keybinds_help!(
             self.keys,
-            GlobalEvent::ScrollDown => "scroll down",
-            GlobalEvent::ScrollUp => "scroll up",
-            GlobalEvent::ScrollDownHalf => "scroll down by ½ page",
-            GlobalEvent::ScrollUpHalf => "scroll up by ½ page",
-            GlobalEvent::ScrollToTop => "go to the top of the list",
-            GlobalEvent::ScrollToBottom => "go to the bottom of the list",
-            GlobalEvent::FocusCurrent => "go to current change",
-            GlobalEvent::Refresh => "refresh",
-            GlobalEvent::NextTab => "next tab",
-            GlobalEvent::PrevTab => "previous tab",
-            GlobalEvent::LogTab => "log tab",
-            GlobalEvent::FilesTab => "files tab",
-            GlobalEvent::BookmarksTab => "bookmarks tab",
-            GlobalEvent::EvologTab => "evolog tab",
-            GlobalEvent::OpenContextMenu => "open the context menu",
-            GlobalEvent::CommandPopup => "run jj command",
-            GlobalEvent::InteractiveCommandPopup => "run jj command interactively",
-            GlobalEvent::OpenHelp => "open help",
-            GlobalEvent::Quit => "quit",
+            GlobalEvent::ScrollDown => Section::Navigation, "scroll down",
+            GlobalEvent::ScrollUp => Section::Navigation, "scroll up",
+            GlobalEvent::ScrollDownHalf => Section::Navigation, "scroll down by ½ page",
+            GlobalEvent::ScrollUpHalf => Section::Navigation, "scroll up by ½ page",
+            GlobalEvent::ScrollToTop => Section::Navigation, "go to the top of the list",
+            GlobalEvent::ScrollToBottom => Section::Navigation, "go to the bottom of the list",
+            GlobalEvent::FocusCurrent => Section::Navigation, "go to current change",
+            GlobalEvent::OpenContextMenu => Section::Navigation, "open the context menu",
+
+            GlobalEvent::Refresh => Section::App, "refresh",
+            GlobalEvent::NextTab => Section::App, "next tab",
+            GlobalEvent::PrevTab => Section::App, "previous tab",
+            GlobalEvent::LogTab => Section::App, "log tab",
+            GlobalEvent::FilesTab => Section::App, "files tab",
+            GlobalEvent::BookmarksTab => Section::App, "bookmarks tab",
+            GlobalEvent::EvologTab => Section::App, "evolog tab",
+            GlobalEvent::CommandPopup => Section::App, "run jj command",
+            GlobalEvent::InteractiveCommandPopup => Section::App, "run jj command interactively",
+            GlobalEvent::OpenHelp => Section::App, "open help",
+            GlobalEvent::Quit => Section::App, "quit",
         )
     }
 }
@@ -277,22 +280,22 @@ mod tests {
             keybinds.match_event(key(KeyCode::Char('?'))),
             GlobalEvent::Unbound
         );
-        assert!(
-            keybinds
-                .make_help()
-                .contains(&("[disabled]".to_owned(), "open help".to_owned()))
-        );
+        assert!(keybinds.make_help().contains(&HelpItem {
+            section: Section::App,
+            keys: "[disabled]".to_owned(),
+            description: "open help".to_owned(),
+        }));
     }
 
     #[test]
     fn test_make_help_lists_every_default_binding() {
         let help = GlobalKeybinds::default().make_help();
 
-        assert!(help.iter().all(|(keys, _)| keys != "[disabled]"));
-        let (keys, _) = help
+        assert!(help.iter().all(|item| item.keys != "[disabled]"));
+        let refresh = help
             .iter()
-            .find(|(_, desc)| desc == "refresh")
+            .find(|item| item.description == "refresh")
             .expect("refresh should be listed");
-        assert_eq!(keys, "Shift+r/F5");
+        assert_eq!(refresh.keys, "Shift+r/F5");
     }
 }

--- a/src/keybinds/global.rs
+++ b/src/keybinds/global.rs
@@ -21,6 +21,8 @@ pub enum GlobalEvent {
     ScrollUp,
     ScrollDownHalf,
     ScrollUpHalf,
+    ScrollToTop,
+    ScrollToBottom,
 
     FocusCurrent,
     Refresh,
@@ -53,6 +55,8 @@ impl Default for GlobalKeybinds {
             GlobalEvent::ScrollUp => "up",
             GlobalEvent::ScrollDownHalf => "shift+j",
             GlobalEvent::ScrollUpHalf => "shift+k",
+            GlobalEvent::ScrollToTop => "ctrl+home",
+            GlobalEvent::ScrollToBottom => "ctrl+end",
             GlobalEvent::FocusCurrent => "@",
             GlobalEvent::Refresh => "shift+r",
             GlobalEvent::Refresh => "f5",
@@ -85,6 +89,8 @@ impl GlobalKeybinds {
             GlobalEvent::ScrollUp => config.scroll_up,
             GlobalEvent::ScrollDownHalf => config.scroll_down_half,
             GlobalEvent::ScrollUpHalf => config.scroll_up_half,
+            GlobalEvent::ScrollToTop => config.scroll_to_top,
+            GlobalEvent::ScrollToBottom => config.scroll_to_bottom,
             GlobalEvent::FocusCurrent => config.focus_current,
             GlobalEvent::Refresh => config.refresh,
             GlobalEvent::OpenHelp => config.open_help,
@@ -104,6 +110,8 @@ impl GlobalKeybinds {
             GlobalEvent::ScrollUp => "scroll up",
             GlobalEvent::ScrollDownHalf => "scroll down by ½ page",
             GlobalEvent::ScrollUpHalf => "scroll up by ½ page",
+            GlobalEvent::ScrollToTop => "go to the top of the list",
+            GlobalEvent::ScrollToBottom => "go to the bottom of the list",
             GlobalEvent::FocusCurrent => "go to current change",
             GlobalEvent::Refresh => "refresh",
             GlobalEvent::NextTab => "next tab",
@@ -156,6 +164,10 @@ mod tests {
         assert_eq!(
             keybinds.match_event(key(KeyCode::Char('@'))),
             GlobalEvent::FocusCurrent
+        );
+        assert_eq!(
+            keybinds.match_event(KeyEvent::new(KeyCode::Home, KeyModifiers::CONTROL)),
+            GlobalEvent::ScrollToTop
         );
         assert_eq!(
             keybinds.match_event(key(KeyCode::F(5))),

--- a/src/keybinds/global.rs
+++ b/src/keybinds/global.rs
@@ -33,6 +33,7 @@ pub enum GlobalEvent {
     BookmarksTab,
     EvologTab,
 
+    OpenContextMenu,
     CommandPopup,
     InteractiveCommandPopup,
     OpenHelp,
@@ -61,6 +62,7 @@ impl Default for GlobalKeybinds {
             GlobalEvent::FilesTab => "2",
             GlobalEvent::BookmarksTab => "3",
             GlobalEvent::EvologTab => "4",
+            GlobalEvent::OpenContextMenu => "menu",
             GlobalEvent::CommandPopup => ":",
             GlobalEvent::InteractiveCommandPopup => "!",
             GlobalEvent::OpenHelp => "?",
@@ -88,6 +90,7 @@ impl GlobalKeybinds {
             GlobalEvent::OpenHelp => config.open_help,
             GlobalEvent::NextTab => config.next_tab,
             GlobalEvent::PrevTab => config.prev_tab,
+            GlobalEvent::OpenContextMenu => config.open_context_menu,
             GlobalEvent::CommandPopup => config.command_popup,
             GlobalEvent::InteractiveCommandPopup => config.interactive_command_popup,
             GlobalEvent::Quit => config.quit,
@@ -109,6 +112,7 @@ impl GlobalKeybinds {
             GlobalEvent::FilesTab => "files tab",
             GlobalEvent::BookmarksTab => "bookmarks tab",
             GlobalEvent::EvologTab => "evolog tab",
+            GlobalEvent::OpenContextMenu => "open the context menu",
             GlobalEvent::CommandPopup => "run jj command",
             GlobalEvent::InteractiveCommandPopup => "run jj command interactively",
             GlobalEvent::OpenHelp => "open help",
@@ -160,6 +164,10 @@ mod tests {
         assert_eq!(
             keybinds.match_event(key(KeyCode::Char('2'))),
             GlobalEvent::FilesTab
+        );
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::Menu)),
+            GlobalEvent::OpenContextMenu
         );
         assert_eq!(
             keybinds.match_event(key(KeyCode::Char(':'))),

--- a/src/keybinds/log_tab.rs
+++ b/src/keybinds/log_tab.rs
@@ -2,7 +2,8 @@ use std::str::FromStr;
 
 use ratatui::crossterm::event::KeyEvent;
 
-use super::HelpSection;
+use super::HelpItem;
+use super::Section;
 use super::Shortcut;
 use super::config::LogTabKeybindsConfig;
 use super::keybinds_store::KeybindsStore;
@@ -142,58 +143,38 @@ impl LogTabKeybinds {
         );
     }
 
-    pub fn make_main_panel_help(&self) -> Vec<HelpSection> {
-        vec![
-            HelpSection::new(
-                "Navigation",
-                make_keybinds_help!(
-                    self.keys,
-                    LogTabEvent::GotoParent => "go to parent commit",
-                    LogTabEvent::OpenFiles => "see files",
-                    LogTabEvent::OpenEvolog => "see how the change evolved",
-                    LogTabEvent::EditRevset => "set revset",
-                ),
-            ),
-            HelpSection::new(
-                "Changes",
-                make_keybinds_help!(
-                    self.keys,
-                    LogTabEvent::ToggleHeadMark => "mark change to act on",
-                    LogTabEvent::CreateNew { describe: false } => "new change",
-                    LogTabEvent::CreateNew { describe: true } => "new with message",
-                    LogTabEvent::Describe => "describe change",
-                    LogTabEvent::EditChange { ignore_immutable: false } => "edit change",
-                    LogTabEvent::EditChange { ignore_immutable: true } => "edit change ignoring immutability",
-                    LogTabEvent::Duplicate => "duplicate change",
-                    LogTabEvent::Abandon => "abandon change",
-                    LogTabEvent::Rebase => "rebase @ onto it",
-                    LogTabEvent::Squash { ignore_immutable: false } => "squash @ into it",
-                    LogTabEvent::Squash { ignore_immutable: true } => "squash @ into it, ignoring immutability",
-                    LogTabEvent::Absorb => "absorb into its mutable ancestors",
-                ),
-            ),
-            HelpSection::new(
-                "Bookmarks and remotes",
-                make_keybinds_help!(
-                    self.keys,
-                    LogTabEvent::SetBookmark => "set bookmark",
-                    LogTabEvent::Fetch { all_remotes: false } => "git fetch",
-                    LogTabEvent::Fetch { all_remotes: true } => "git fetch all remotes",
-                    LogTabEvent::Push(PushScope::Selected) => "git push",
-                    LogTabEvent::Push(PushScope::SelectedWithNew) => "git push, tracking new bookmarks",
-                    LogTabEvent::Push(PushScope::Tracked) => "git push all tracked bookmarks",
-                    LogTabEvent::Push(PushScope::All) => "git push all bookmarks, new ones included",
-                ),
-            ),
-            HelpSection::new(
-                "Clipboard",
-                make_keybinds_help!(
-                    self.keys,
-                    LogTabEvent::CopyChangeId => "yank change id",
-                    LogTabEvent::CopyRev => "yank revision",
-                ),
-            ),
-        ]
+    pub fn make_main_panel_help(&self) -> Vec<HelpItem> {
+        make_keybinds_help!(
+            self.keys,
+            LogTabEvent::GotoParent => Section::Navigation, "go to parent commit",
+            LogTabEvent::OpenFiles => Section::Navigation, "see files",
+            LogTabEvent::OpenEvolog => Section::Navigation, "see how the change evolved",
+            LogTabEvent::EditRevset => Section::Navigation, "set revset",
+
+            LogTabEvent::ToggleHeadMark => Section::Changes, "mark change to act on",
+            LogTabEvent::CreateNew { describe: false } => Section::Changes, "new change",
+            LogTabEvent::CreateNew { describe: true } => Section::Changes, "new with message",
+            LogTabEvent::Describe => Section::Changes, "describe change",
+            LogTabEvent::EditChange { ignore_immutable: false } => Section::Changes, "edit change",
+            LogTabEvent::EditChange { ignore_immutable: true } => Section::Changes, "edit change ignoring immutability",
+            LogTabEvent::Duplicate => Section::Changes, "duplicate change",
+            LogTabEvent::Abandon => Section::Changes, "abandon change",
+            LogTabEvent::Rebase => Section::Changes, "rebase @ onto it",
+            LogTabEvent::Squash { ignore_immutable: false } => Section::Changes, "squash @ into it",
+            LogTabEvent::Squash { ignore_immutable: true } => Section::Changes, "squash @ into it, ignoring immutability",
+            LogTabEvent::Absorb => Section::Changes, "absorb into its mutable ancestors",
+
+            LogTabEvent::SetBookmark => Section::BookmarksAndRemotes, "set bookmark",
+            LogTabEvent::Fetch { all_remotes: false } => Section::BookmarksAndRemotes, "git fetch",
+            LogTabEvent::Fetch { all_remotes: true } => Section::BookmarksAndRemotes, "git fetch all remotes",
+            LogTabEvent::Push(PushScope::Selected) => Section::BookmarksAndRemotes, "git push",
+            LogTabEvent::Push(PushScope::SelectedWithNew) => Section::BookmarksAndRemotes, "git push, tracking new bookmarks",
+            LogTabEvent::Push(PushScope::Tracked) => Section::BookmarksAndRemotes, "git push all tracked bookmarks",
+            LogTabEvent::Push(PushScope::All) => Section::BookmarksAndRemotes, "git push all bookmarks, new ones included",
+
+            LogTabEvent::CopyChangeId => Section::Clipboard, "yank change id",
+            LogTabEvent::CopyRev => Section::Clipboard, "yank revision",
+        )
     }
 }
 

--- a/src/keybinds/log_tab.rs
+++ b/src/keybinds/log_tab.rs
@@ -2,6 +2,7 @@ use std::str::FromStr;
 
 use ratatui::crossterm::event::KeyEvent;
 
+use super::HelpSection;
 use super::Shortcut;
 use super::config::LogTabKeybindsConfig;
 use super::keybinds_store::KeybindsStore;
@@ -140,35 +141,59 @@ impl LogTabKeybinds {
             LogTabEvent::Fetch { all_remotes: true } => config.fetch_all,
         );
     }
-    pub fn make_main_panel_help(&self) -> Vec<(String, String)> {
-        make_keybinds_help!(
-            self.keys,
-            LogTabEvent::GotoParent => "go to parent commit",
-            LogTabEvent::ToggleHeadMark => "mark change to act on",
-            LogTabEvent::OpenFiles => "see files",
-            LogTabEvent::OpenEvolog => "see how the change evolved",
-            LogTabEvent::EditRevset => "set revset",
-            LogTabEvent::Describe => "describe change",
-            LogTabEvent::Duplicate => "duplicate change",
-            LogTabEvent::EditChange { ignore_immutable: false } => "edit change",
-            LogTabEvent::EditChange { ignore_immutable: true } => "edit change ignoring immutability",
-            LogTabEvent::CreateNew { describe: false } => "new change",
-            LogTabEvent::CreateNew { describe: true } => "new with message",
-            LogTabEvent::Abandon => "abandon change",
-            LogTabEvent::Absorb => "absorb selected change into its mutable ancestors",
-            LogTabEvent::Rebase => "rebase @ to the selected change",
-            LogTabEvent::Squash { ignore_immutable: false } => "squash @ into the selected change",
-            LogTabEvent::Squash { ignore_immutable: true } => "squash @ into the selected change ignoring immutability",
-            LogTabEvent::SetBookmark => "set bookmark",
-            LogTabEvent::CopyChangeId => "yank change id to clipboard",
-            LogTabEvent::CopyRev => "yank revision to clipboard",
-            LogTabEvent::Fetch { all_remotes: false } => "git fetch",
-            LogTabEvent::Fetch { all_remotes: true } => "git fetch all remotes",
-            LogTabEvent::Push(PushScope::Selected) => "git push",
-            LogTabEvent::Push(PushScope::SelectedWithNew) => "git push, tracking new bookmarks",
-            LogTabEvent::Push(PushScope::Tracked) => "git push all tracked bookmarks",
-            LogTabEvent::Push(PushScope::All) => "git push all bookmarks, new ones included",
-        )
+
+    pub fn make_main_panel_help(&self) -> Vec<HelpSection> {
+        vec![
+            HelpSection::new(
+                "Navigation",
+                make_keybinds_help!(
+                    self.keys,
+                    LogTabEvent::GotoParent => "go to parent commit",
+                    LogTabEvent::OpenFiles => "see files",
+                    LogTabEvent::OpenEvolog => "see how the change evolved",
+                    LogTabEvent::EditRevset => "set revset",
+                ),
+            ),
+            HelpSection::new(
+                "Changes",
+                make_keybinds_help!(
+                    self.keys,
+                    LogTabEvent::ToggleHeadMark => "mark change to act on",
+                    LogTabEvent::CreateNew { describe: false } => "new change",
+                    LogTabEvent::CreateNew { describe: true } => "new with message",
+                    LogTabEvent::Describe => "describe change",
+                    LogTabEvent::EditChange { ignore_immutable: false } => "edit change",
+                    LogTabEvent::EditChange { ignore_immutable: true } => "edit change ignoring immutability",
+                    LogTabEvent::Duplicate => "duplicate change",
+                    LogTabEvent::Abandon => "abandon change",
+                    LogTabEvent::Rebase => "rebase @ onto it",
+                    LogTabEvent::Squash { ignore_immutable: false } => "squash @ into it",
+                    LogTabEvent::Squash { ignore_immutable: true } => "squash @ into it, ignoring immutability",
+                    LogTabEvent::Absorb => "absorb into its mutable ancestors",
+                ),
+            ),
+            HelpSection::new(
+                "Bookmarks and remotes",
+                make_keybinds_help!(
+                    self.keys,
+                    LogTabEvent::SetBookmark => "set bookmark",
+                    LogTabEvent::Fetch { all_remotes: false } => "git fetch",
+                    LogTabEvent::Fetch { all_remotes: true } => "git fetch all remotes",
+                    LogTabEvent::Push(PushScope::Selected) => "git push",
+                    LogTabEvent::Push(PushScope::SelectedWithNew) => "git push, tracking new bookmarks",
+                    LogTabEvent::Push(PushScope::Tracked) => "git push all tracked bookmarks",
+                    LogTabEvent::Push(PushScope::All) => "git push all bookmarks, new ones included",
+                ),
+            ),
+            HelpSection::new(
+                "Clipboard",
+                make_keybinds_help!(
+                    self.keys,
+                    LogTabEvent::CopyChangeId => "yank change id",
+                    LogTabEvent::CopyRev => "yank revision",
+                ),
+            ),
+        ]
     }
 }
 

--- a/src/keybinds/log_tab.rs
+++ b/src/keybinds/log_tab.rs
@@ -118,6 +118,7 @@ impl LogTabKeybinds {
     fn extend_from_config(&mut self, config: &LogTabKeybindsConfig) {
         update_keybinds!(
             self.keys,
+            LogTabEvent::ToggleHeadMark => config.mark_head,
             LogTabEvent::GotoParent => config.goto_parent,
             LogTabEvent::Duplicate => config.duplicate,
             LogTabEvent::CreateNew { describe: false } => config.create_new,
@@ -148,6 +149,7 @@ impl LogTabKeybinds {
         make_keybinds_help!(
             self.keys,
             LogTabEvent::GotoParent => "go to parent commit",
+            LogTabEvent::ToggleHeadMark => "mark change to act on",
             LogTabEvent::OpenFiles => "see files",
             LogTabEvent::OpenEvolog => "see how the change evolved",
             LogTabEvent::EditRevset => "set revset",

--- a/src/keybinds/log_tab.rs
+++ b/src/keybinds/log_tab.rs
@@ -18,9 +18,6 @@ pub struct LogTabKeybinds {
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum LogTabEvent {
-    ScrollToBottom,
-    ScrollToTop,
-
     ToggleHeadMark,
 
     GotoParent,
@@ -64,8 +61,6 @@ impl Default for LogTabKeybinds {
         let mut keys = KeybindsStore::<LogTabEvent>::default();
         set_keybinds!(
             keys,
-            LogTabEvent::ScrollToBottom => "ctrl+end",
-            LogTabEvent::ScrollToTop => "ctrl+home",
             LogTabEvent::ToggleHeadMark => "space",
             LogTabEvent::GotoParent => "-",
             LogTabEvent::Duplicate => "shift+d",

--- a/src/keybinds/log_tab.rs
+++ b/src/keybinds/log_tab.rs
@@ -3,9 +3,9 @@ use std::str::FromStr;
 use ratatui::crossterm::event::KeyEvent;
 
 use super::Shortcut;
-use super::config::KeybindsConfig;
 use super::config::LogTabKeybindsConfig;
 use super::keybinds_store::KeybindsStore;
+use crate::env::keybinds_config;
 use crate::make_keybinds_help;
 use crate::set_keybinds;
 use crate::update_keybinds;
@@ -98,6 +98,15 @@ impl Default for LogTabKeybinds {
 }
 
 impl LogTabKeybinds {
+    /// The bindings as the configuration has them.
+    pub fn new() -> Self {
+        let mut keybinds = Self::default();
+        if let Some(config) = keybinds_config().and_then(|config| config.log_tab.as_ref()) {
+            keybinds.extend_from_config(config);
+        }
+        keybinds
+    }
+
     pub fn match_event(&self, event: KeyEvent) -> LogTabEvent {
         if let Some(action) = self.keys.match_event(event) {
             action
@@ -105,13 +114,8 @@ impl LogTabKeybinds {
             LogTabEvent::Unbound
         }
     }
-    pub fn extend_from_config(&mut self, config: &KeybindsConfig) {
-        if let Some(ref log_tab) = config.log_tab {
-            self.extend_from_log_tab_config(log_tab);
-        }
-    }
 
-    fn extend_from_log_tab_config(&mut self, config: &LogTabKeybindsConfig) {
+    fn extend_from_config(&mut self, config: &LogTabKeybindsConfig) {
         update_keybinds!(
             self.keys,
             LogTabEvent::GotoParent => config.goto_parent,

--- a/src/keybinds/log_tab.rs
+++ b/src/keybinds/log_tab.rs
@@ -43,8 +43,6 @@ pub enum LogTabEvent {
     Push(PushScope),
     Fetch { all_remotes: bool },
 
-    OpenContextMenu,
-
     Unbound,
 }
 
@@ -93,7 +91,6 @@ impl Default for LogTabKeybinds {
             LogTabEvent::Push(PushScope::All) => "ctrl+shift+p",
             LogTabEvent::Fetch { all_remotes: false } => "f",
             LogTabEvent::Fetch { all_remotes: true } => "shift+f",
-            LogTabEvent::OpenContextMenu => "menu",
         );
 
         Self { keys }
@@ -141,7 +138,6 @@ impl LogTabKeybinds {
             LogTabEvent::Push(PushScope::All) => config.push_all_new,
             LogTabEvent::Fetch { all_remotes: false } => config.fetch,
             LogTabEvent::Fetch { all_remotes: true } => config.fetch_all,
-            LogTabEvent::OpenContextMenu => config.open_context_menu,
         );
     }
     pub fn make_main_panel_help(&self) -> Vec<(String, String)> {
@@ -171,7 +167,6 @@ impl LogTabKeybinds {
             LogTabEvent::Push(PushScope::SelectedWithNew) => "git push, tracking new bookmarks",
             LogTabEvent::Push(PushScope::Tracked) => "git push all tracked bookmarks",
             LogTabEvent::Push(PushScope::All) => "git push all bookmarks, new ones included",
-            LogTabEvent::OpenContextMenu => "open the context menu",
         )
     }
 }

--- a/src/keybinds/mod.rs
+++ b/src/keybinds/mod.rs
@@ -173,7 +173,11 @@ impl Display for Shortcut {
             KeyCode::Down => "Down".to_string(),
             KeyCode::PageDown => "PageDown".to_string(),
             KeyCode::PageUp => "PageUp".to_string(),
+            KeyCode::Home => "Home".to_string(),
+            KeyCode::End => "End".to_string(),
             KeyCode::F(n) => format!("F{n}"),
+            // A space of its own would be read as no key at all.
+            KeyCode::Char(' ') => "Space".to_string(),
             KeyCode::Char(c) => c.to_string(),
             KeyCode::Esc => "Esc".to_string(),
             KeyCode::Menu => "Menu".to_string(),
@@ -254,6 +258,39 @@ mod tests {
         for (s, expected) in table {
             assert_eq!(
                 Shortcut::from_str(s),
+                expected,
+                "Shortcut::from_str(\"{s}\")"
+            );
+        }
+    }
+
+    /// Every key a binding can be given has to have a name to show it
+    /// by, or the help offers a key the user cannot make out.
+    #[test]
+    fn test_shortcut_display() {
+        let table = [
+            ("q", "q"),
+            ("ctrl+shift+q", "Control+Shift+q"),
+            ("space", "Space"),
+            ("enter", "Enter"),
+            ("esc", "Esc"),
+            ("left", "Left"),
+            ("right", "Right"),
+            ("up", "Up"),
+            ("down", "Down"),
+            ("home", "Home"),
+            ("end", "End"),
+            ("ctrl+end", "Control+End"),
+            ("pagedown", "PageDown"),
+            ("pageup", "PageUp"),
+            ("menu", "Menu"),
+            ("f5", "F5"),
+        ];
+
+        for (s, expected) in table {
+            let shortcut = Shortcut::from_str(s).expect("shortcut should parse");
+            assert_eq!(
+                shortcut.to_string(),
                 expected,
                 "Shortcut::from_str(\"{s}\")"
             );

--- a/src/keybinds/mod.rs
+++ b/src/keybinds/mod.rs
@@ -1,10 +1,14 @@
 use std::fmt::Display;
 use std::str::FromStr;
 
+pub use bookmark_set_popup::BookmarkSetPopupEvent;
+pub use bookmark_set_popup::BookmarkSetPopupKeybinds;
 pub use bookmarks_tab::BookmarksTabEvent;
 pub use bookmarks_tab::BookmarksTabKeybinds;
 pub use config::Keybind;
 pub use config::KeybindsConfig;
+pub use confirm_popup::ConfirmPopupEvent;
+pub use confirm_popup::ConfirmPopupKeybinds;
 pub use details_panel::DetailsPanelEvent;
 pub use details_panel::DetailsPanelKeybinds;
 pub use evolog_tab::EvologTabEvent;
@@ -22,8 +26,10 @@ use ratatui::crossterm::event::KeyCode;
 use ratatui::crossterm::event::KeyEvent;
 use ratatui::crossterm::event::KeyModifiers;
 
+mod bookmark_set_popup;
 mod bookmarks_tab;
 mod config;
+mod confirm_popup;
 mod details_panel;
 mod evolog_tab;
 mod files_tab;
@@ -99,6 +105,15 @@ impl Shortcut {
     pub fn new_mod_key(modifiers: KeyModifiers, key: KeyCode) -> Self {
         Self { key, modifiers }
     }
+    /// The character the shortcut is, where it is a plain one that no
+    /// modifier goes with.
+    pub fn as_char(&self) -> Option<char> {
+        match self.key {
+            KeyCode::Char(c) if self.modifiers.is_empty() => Some(c),
+            _ => None,
+        }
+    }
+
     pub fn from_event(event: KeyEvent) -> Self {
         Self {
             key: match event.code {

--- a/src/keybinds/mod.rs
+++ b/src/keybinds/mod.rs
@@ -44,6 +44,23 @@ pub struct Keybinds {
     log_tab: LogTabKeybinds,
 }*/
 
+/// A titled run of keybindings, as the help lists them. A panel with
+/// enough of them to be worth sorting through hands the help one per
+/// kind of thing its keys do; one with a handful hands it a single
+/// section titled after the panel.
+#[derive(Clone, Debug)]
+pub struct HelpSection {
+    pub title: &'static str,
+    /// The keys and what each of them does
+    pub items: Vec<(String, String)>,
+}
+
+impl HelpSection {
+    pub fn new(title: &'static str, items: Vec<(String, String)>) -> Self {
+        Self { title, items }
+    }
+}
+
 /// Add keybindings to [`keybinds_store::KeybindsStore`]. Checks that shortcuts not duplicated
 #[macro_export]
 macro_rules! set_keybinds {

--- a/src/keybinds/mod.rs
+++ b/src/keybinds/mod.rs
@@ -44,20 +44,89 @@ pub struct Keybinds {
     log_tab: LogTabKeybinds,
 }*/
 
-/// A titled run of keybindings, as the help lists them. A panel with
-/// enough of them to be worth sorting through hands the help one per
-/// kind of thing its keys do; one with a handful hands it a single
-/// section titled after the panel.
+/// The kind of thing a keybinding does, under which the help lists it.
+/// Which one a binding belongs to follows from what it does, not from
+/// who binds it, so the keys for moving around in the main panel are one
+/// section whether a tab or the app as a whole binds them.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Section {
+    Navigation,
+    Changes,
+    Files,
+    BookmarksAndRemotes,
+    Clipboard,
+    DetailsPanel,
+    /// What the app does, rather than what it does to the repo
+    App,
+}
+
+impl Section {
+    /// Every section, in the order the help lists them
+    const ORDER: [Self; 7] = [
+        Self::Navigation,
+        Self::Changes,
+        Self::Files,
+        Self::BookmarksAndRemotes,
+        Self::Clipboard,
+        Self::DetailsPanel,
+        Self::App,
+    ];
+
+    pub fn title(self) -> &'static str {
+        match self {
+            Self::Navigation => "Navigation",
+            Self::Changes => "Changes",
+            Self::Files => "Files",
+            Self::BookmarksAndRemotes => "Bookmarks and remotes",
+            Self::Clipboard => "Clipboard",
+            Self::DetailsPanel => "Details panel",
+            Self::App => "Global",
+        }
+    }
+
+    /// Whether the help lists the section beside what the main panel
+    /// answers to rather than among it.
+    pub fn beside_main_panel(self) -> bool {
+        matches!(self, Self::DetailsPanel | Self::App)
+    }
+}
+
+/// A keybinding as the help lists it
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HelpItem {
+    pub section: Section,
+    /// The keys bound to it, or `[disabled]` where there are none
+    pub keys: String,
+    pub description: String,
+}
+
+/// The keybindings of one section, as the help lists them
 #[derive(Clone, Debug)]
 pub struct HelpSection {
-    pub title: &'static str,
+    pub section: Section,
     /// The keys and what each of them does
     pub items: Vec<(String, String)>,
 }
 
 impl HelpSection {
-    pub fn new(title: &'static str, items: Vec<(String, String)>) -> Self {
-        Self { title, items }
+    /// The `items` gathered into the sections they belong to, in the
+    /// order the help lists those; a section nothing belongs to is left
+    /// out.
+    pub fn gather(items: impl IntoIterator<Item = HelpItem>) -> Vec<Self> {
+        let items: Vec<HelpItem> = items.into_iter().collect();
+
+        Section::ORDER
+            .into_iter()
+            .filter_map(|section| {
+                let items: Vec<(String, String)> = items
+                    .iter()
+                    .filter(|item| item.section == section)
+                    .map(|item| (item.keys.clone(), item.description.clone()))
+                    .collect();
+
+                (!items.is_empty()).then_some(Self { section, items })
+            })
+            .collect()
     }
 }
 
@@ -88,10 +157,12 @@ macro_rules! update_keybinds {
     };
 }
 
+/// The help entry of every listed action: what it does, the section it
+/// belongs to, and the keys it is bound to.
 #[macro_export]
 macro_rules! make_keybinds_help {
     () => {};
-    ($keys:expr, $($action:expr => $desc:literal),* $(,)?) => {
+    ($keys:expr, $($action:expr => $section:expr, $desc:literal),* $(,)?) => {
         #[allow(clippy::vec_init_then_push)]
         {
             let mut res = vec![];
@@ -101,11 +172,15 @@ macro_rules! make_keybinds_help {
                     .map(|s| s.to_string())
                     .collect::<Vec<_>>()
                     .join("/");
-                if shortcuts.is_empty() {
-                    res.push(("[disabled]".to_string(), $desc.to_string()));
-                } else {
-                    res.push((shortcuts, $desc.to_string()));
-                }
+                res.push($crate::keybinds::HelpItem {
+                    section: $section,
+                    keys: if shortcuts.is_empty() {
+                        "[disabled]".to_string()
+                    } else {
+                        shortcuts
+                    },
+                    description: $desc.to_string(),
+                });
             )*
             res
         }
@@ -243,6 +318,47 @@ mod tests {
         pub fn new_key(key: KeyCode) -> Self {
             Self::new_mod_key(KeyModifiers::empty(), key)
         }
+    }
+
+    fn item(section: Section, key: &str) -> HelpItem {
+        HelpItem {
+            section,
+            keys: key.to_owned(),
+            description: format!("do {key}"),
+        }
+    }
+
+    fn listed(key: &str) -> (String, String) {
+        (key.to_owned(), format!("do {key}"))
+    }
+
+    #[test]
+    fn test_gathering_puts_the_sections_in_the_order_the_help_lists_them() {
+        let sections = HelpSection::gather([
+            item(Section::App, "q"),
+            item(Section::Changes, "n"),
+            item(Section::Navigation, "j"),
+        ]);
+
+        let titles: Vec<Section> = sections.iter().map(|section| section.section).collect();
+        assert_eq!(
+            titles,
+            vec![Section::Navigation, Section::Changes, Section::App]
+        );
+    }
+
+    /// The keys of a section come from whoever binds them, so those the
+    /// app binds and those a tab binds end up under the one heading.
+    #[test]
+    fn test_gathering_collects_a_section_from_every_source() {
+        let sections = HelpSection::gather([
+            item(Section::Navigation, "j"),
+            item(Section::Changes, "n"),
+            item(Section::Navigation, "-"),
+        ]);
+
+        assert_eq!(sections.len(), 2);
+        assert_eq!(sections[0].items, vec![listed("j"), listed("-")]);
     }
 
     #[test]

--- a/src/keybinds/rebase_popup.rs
+++ b/src/keybinds/rebase_popup.rs
@@ -5,8 +5,11 @@ use std::str::FromStr; // used by set_keybinds macro
 use ratatui::crossterm::event::KeyEvent;
 
 use super::Shortcut;
+use super::config::RebasePopupKeybindsConfig;
 use super::keybinds_store::KeybindsStore;
+use crate::env::keybinds_config;
 use crate::set_keybinds;
+use crate::update_keybinds;
 
 /// How should rebase cut revisions from source
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -60,11 +63,77 @@ impl Default for Keybinds {
 }
 
 impl Keybinds {
+    /// The bindings as the configuration has them.
+    pub fn new() -> Self {
+        let mut keybinds = Self::default();
+        if let Some(config) = keybinds_config().and_then(|config| config.rebase_popup.as_ref()) {
+            keybinds.extend_from_config(config);
+        }
+        keybinds
+    }
+
     pub fn match_event(&self, event: KeyEvent) -> PopupAction {
         if let Some(action) = self.keys.match_event(event) {
             action
         } else {
             PopupAction::None
         }
+    }
+
+    fn extend_from_config(&mut self, config: &RebasePopupKeybindsConfig) {
+        update_keybinds!(
+            self.keys,
+            PopupAction::SetSourceMode(CutOption::IncludeDescendants) => config.source_with_descendants,
+            PopupAction::SetSourceMode(CutOption::IncludeBranch) => config.source_whole_branch,
+            PopupAction::SetSourceMode(CutOption::SingleRevision) => config.source_single_revision,
+            PopupAction::SetTargetMode(PasteOption::NewBranch) => config.target_new_branch,
+            PopupAction::SetTargetMode(PasteOption::InsertAfter) => config.target_insert_after,
+            PopupAction::SetTargetMode(PasteOption::InsertBefore) => config.target_insert_before,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::crossterm::event::KeyCode;
+    use ratatui::crossterm::event::KeyModifiers;
+
+    use super::*;
+    use crate::keybinds::Keybind;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::empty())
+    }
+
+    #[test]
+    fn test_extend_from_config_replaces_bindings() {
+        let config = RebasePopupKeybindsConfig {
+            source_single_revision: Some(Keybind::Single(
+                Shortcut::from_str("1").expect("shortcut should parse"),
+            )),
+            source_with_descendants: None,
+            source_whole_branch: None,
+            target_new_branch: None,
+            target_insert_after: None,
+            target_insert_before: None,
+        };
+
+        let mut keybinds = Keybinds::default();
+        keybinds.extend_from_config(&config);
+
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::Char('1'))),
+            PopupAction::SetSourceMode(CutOption::SingleRevision)
+        );
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::Char('r'))),
+            PopupAction::None
+        );
+
+        // Anything the config leaves out keeps its default.
+        assert_eq!(
+            keybinds.match_event(key(KeyCode::Char('b'))),
+            PopupAction::SetSourceMode(CutOption::IncludeBranch)
+        );
     }
 }

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -263,7 +263,7 @@ impl BookmarksTab {
 
     /// The menu of what can be done to the selected bookmark, put at
     /// `anchor` or centered when there is nowhere to point at.
-    fn open_context_menu(&self, anchor: Option<Position>) -> Option<AppAction> {
+    fn context_menu(&self, anchor: Option<Position>) -> Option<AppAction> {
         Some(AppAction::SetPopup(Box::new(bookmarks_context_menu(
             self.config.clone(),
             anchor,
@@ -356,12 +356,6 @@ impl BookmarksTab {
                     return Ok(Some(AppAction::ViewLog(head.clone())));
                 }
             }
-            BookmarksTabEvent::OpenContextMenu => {
-                return Ok(self.open_context_menu(
-                    self.get_current_bookmark_index()
-                        .and_then(|index| self.bookmarks_pane.item_anchor(index, 1)),
-                ));
-            }
             // Not an operation of its own; the key handler deals with it.
             BookmarksTabEvent::Unbound => {}
         }
@@ -399,6 +393,13 @@ impl Tab for BookmarksTab {
             Scroll::UpHalfPage => half_page.saturating_neg(),
         });
         Ok(())
+    }
+
+    fn open_context_menu(&self) -> Result<Option<AppAction>> {
+        Ok(self.context_menu(
+            self.get_current_bookmark_index()
+                .and_then(|index| self.bookmarks_pane.item_anchor(index, 1)),
+        ))
     }
 
     fn make_main_panel_help(&self) -> Vec<(String, String)> {
@@ -568,7 +569,7 @@ impl Component for BookmarksTab {
                         self.bookmark = Some(bookmark);
                         self.show_bookmark();
                         let anchor = Position::new(mouse.column, mouse.row);
-                        return Ok(self.open_context_menu(Some(anchor)).into());
+                        return Ok(self.context_menu(Some(anchor)).into());
                     }
                 }
                 MouseInput::Handled => {}

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -385,13 +385,7 @@ impl Tab for BookmarksTab {
     }
 
     fn scroll_main_panel(&mut self, scroll: Scroll) -> Result<()> {
-        let half_page = self.bookmarks_pane.visible_items() / 2;
-        self.scroll_bookmarks(match scroll {
-            Scroll::Down => 1,
-            Scroll::Up => -1,
-            Scroll::DownHalfPage => half_page,
-            Scroll::UpHalfPage => half_page.saturating_neg(),
-        });
+        self.scroll_bookmarks(scroll.distance(self.bookmarks_pane.visible_items()));
         Ok(())
     }
 

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -26,7 +26,7 @@ use crate::keybinds::BookmarksTabEvent;
 use crate::keybinds::BookmarksTabKeybinds;
 use crate::keybinds::DetailsPanelEvent;
 use crate::keybinds::DetailsPanelKeybinds;
-use crate::keybinds::HelpSection;
+use crate::keybinds::HelpItem;
 use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
@@ -436,11 +436,11 @@ impl Tab for BookmarksTab {
         ))
     }
 
-    fn make_main_panel_help(&self) -> Vec<HelpSection> {
+    fn make_main_panel_help(&self) -> Vec<HelpItem> {
         self.keybinds.make_help()
     }
 
-    fn make_details_panel_help(&self) -> Vec<(String, String)> {
+    fn make_details_panel_help(&self) -> Vec<HelpItem> {
         self.details_keybinds.make_help()
     }
 }

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -194,6 +194,18 @@ impl BookmarksTab {
         self.show_bookmark();
     }
 
+    /// The first listed bookmark `matches` takes.
+    fn find_bookmark(&self, matches: impl Fn(&Bookmark, &Head) -> bool) -> Option<BookmarkLine> {
+        self.bookmarks_output
+            .iter()
+            .flatten()
+            .find(|line| match line {
+                BookmarkLine::Parsed { bookmark, head, .. } => matches(bookmark, head),
+                BookmarkLine::Unparsable(_) => false,
+            })
+            .cloned()
+    }
+
     /// Have the details panel show the change the selected bookmark
     /// points at.
     fn show_bookmark(&mut self) {
@@ -386,6 +398,33 @@ impl Tab for BookmarksTab {
 
     fn scroll_main_panel(&mut self, scroll: Scroll) -> Result<()> {
         self.scroll_bookmarks(scroll.distance(self.bookmarks_pane.visible_items()));
+        Ok(())
+    }
+
+    /// Go to the bookmark on the working copy, or failing that the one
+    /// the working copy is standing on, which is the bookmark the change
+    /// it holds is going to end up under. Stays where it is when there
+    /// is no bookmark behind the working copy at all.
+    fn focus_current(&mut self) -> Result<()> {
+        let current = new_commander().get_current_head()?;
+
+        // A bookmark on the working copy is in the list we already hold,
+        // so finding one there saves asking jj what lies behind it.
+        let mut found = self.find_bookmark(|_, head| *head == current);
+        if found.is_none()
+            && let Some(name) = new_commander().get_nearest_bookmark(&current.commit_id)?
+        {
+            found = self
+                .find_bookmark(|bookmark, _| bookmark.remote.is_none() && bookmark.name == name);
+        }
+
+        let Some(found) = found else {
+            return Ok(());
+        };
+
+        self.bookmark = Some(found);
+        self.show_bookmark();
+
         Ok(())
     }
 

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -26,6 +26,7 @@ use crate::keybinds::BookmarksTabEvent;
 use crate::keybinds::BookmarksTabKeybinds;
 use crate::keybinds::DetailsPanelEvent;
 use crate::keybinds::DetailsPanelKeybinds;
+use crate::keybinds::HelpSection;
 use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
@@ -435,7 +436,7 @@ impl Tab for BookmarksTab {
         ))
     }
 
-    fn make_main_panel_help(&self) -> Vec<(String, String)> {
+    fn make_main_panel_help(&self) -> Vec<HelpSection> {
         self.keybinds.make_help()
     }
 

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -118,7 +118,7 @@ impl BookmarksTab {
         let config = get_env().jj_config.clone();
         let pane_divider = PaneDivider::new(config.layout_percent());
         let keybinds = BookmarksTabKeybinds::default();
-        let details_keybinds = DetailsPanelKeybinds::default();
+        let details_keybinds = DetailsPanelKeybinds::new();
 
         Self {
             bookmarks_output: Ok(Vec::new()),

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -117,7 +117,7 @@ impl BookmarksTab {
     pub fn new(background_tasks: BackgroundTasks) -> Self {
         let config = get_env().jj_config.clone();
         let pane_divider = PaneDivider::new(config.layout_percent());
-        let keybinds = BookmarksTabKeybinds::default();
+        let keybinds = BookmarksTabKeybinds::new();
         let details_keybinds = DetailsPanelKeybinds::new();
 
         Self {

--- a/src/ui/dialog/bookmark_set.rs
+++ b/src/ui/dialog/bookmark_set.rs
@@ -1,7 +1,6 @@
 use ansi_to_tui::IntoText;
 use anyhow::Result;
 use ratatui::crossterm::event::Event;
-use ratatui::crossterm::event::KeyCode;
 use ratatui::layout::Alignment;
 use ratatui::layout::Constraint;
 use ratatui::layout::Direction;
@@ -27,6 +26,8 @@ use crate::commander::ids::ChangeId;
 use crate::commander::ids::CommitId;
 use crate::commander::new_commander;
 use crate::env::JjConfig;
+use crate::keybinds::BookmarkSetPopupEvent;
+use crate::keybinds::BookmarkSetPopupKeybinds;
 use crate::keybinds::PopupEvent;
 use crate::keybinds::PopupKeybinds;
 use crate::ui::AppAction;
@@ -35,6 +36,7 @@ use crate::ui::ComponentInputResult;
 use crate::ui::styles::create_popup_block;
 use crate::ui::utils::centered_rect;
 use crate::ui::utils::centered_rect_line_height;
+use crate::ui::utils::mark_key;
 
 enum BookmarkSetOption {
     CreateBookmark,
@@ -54,6 +56,7 @@ pub struct BookmarkSetPopup<'a> {
     creating: Option<TextArea<'a>>,
     keybinds: PopupKeybinds,
     name_keybinds: PopupKeybinds,
+    own_keybinds: BookmarkSetPopupKeybinds,
 }
 
 fn generate_options(change_id: Option<&ChangeId>, commit_id: &CommitId) -> Vec<BookmarkSetOption> {
@@ -110,6 +113,7 @@ impl BookmarkSetPopup<'_> {
             creating: None,
             keybinds: PopupKeybinds::dialog(),
             name_keybinds: PopupKeybinds::text_line(),
+            own_keybinds: BookmarkSetPopupKeybinds::new(),
         }
     }
 
@@ -145,6 +149,11 @@ impl BookmarkSetPopup<'_> {
                 commit_id: self.commit_id.clone(),
             }),
         ]))
+    }
+
+    /// An option's line, marking the key that picks it.
+    fn label(&self, option: &str, event: BookmarkSetPopupEvent) -> String {
+        mark_key(option, self.own_keybinds.shortcut(event))
     }
 
     /// The name generated for the change the popup was opened for, if
@@ -201,12 +210,12 @@ impl Component for BookmarkSetPopup<'_> {
                 .constraints([Constraint::Fill(1), Constraint::Length(2)])
                 .split(block.inner(area));
 
+            let create = self.label("Create bookmark", BookmarkSetPopupEvent::CreateBookmark);
+            let generate = self.label("Generate bookmark", BookmarkSetPopupEvent::UseGeneratedName);
             let list_items = self.options.iter().map(|option| match option {
-                BookmarkSetOption::CreateBookmark => {
-                    Text::raw("(C)reate bookmark").fg(Color::Yellow)
-                }
+                BookmarkSetOption::CreateBookmark => Text::raw(create.clone()).fg(Color::Yellow),
                 BookmarkSetOption::GeneratedName(generated_name, exists) => {
-                    let mut text = format!("(G)enerate bookmark: {generated_name}");
+                    let mut text = format!("{generate}: {generated_name}");
                     if *exists {
                         text.push_str(" (exists)");
                     }
@@ -315,14 +324,16 @@ impl Component for BookmarkSetPopup<'_> {
                 }
                 // The options carry the letter they are picked by, so
                 // those keys are the popup's own.
-                PopupEvent::Unbound => match key.code {
-                    KeyCode::Char('g') => {
+                PopupEvent::Unbound => match self.own_keybinds.match_event(key) {
+                    BookmarkSetPopupEvent::UseGeneratedName => {
                         if let Some(name) = self.generated_name() {
                             return Ok(self.set_bookmark(name));
                         }
                     }
-                    KeyCode::Char('c') => self.on_creating(),
-                    _ => return Ok(ComponentInputResult::NotHandled),
+                    BookmarkSetPopupEvent::CreateBookmark => self.on_creating(),
+                    BookmarkSetPopupEvent::Unbound => {
+                        return Ok(ComponentInputResult::NotHandled);
+                    }
                 },
             }
 

--- a/src/ui/dialog/confirm.rs
+++ b/src/ui/dialog/confirm.rs
@@ -5,7 +5,6 @@ yes.
 use anyhow::Result;
 use ratatui::Frame;
 use ratatui::crossterm::event::Event;
-use ratatui::crossterm::event::KeyCode;
 use ratatui::crossterm::event::KeyEventKind;
 use ratatui::layout::Alignment;
 use ratatui::layout::Constraint;
@@ -24,17 +23,18 @@ use ratatui::widgets::Paragraph;
 use ratatui::widgets::Wrap;
 
 use crate::env::JjConfig;
+use crate::keybinds::ConfirmPopupEvent;
+use crate::keybinds::ConfirmPopupKeybinds;
 use crate::keybinds::PopupEvent;
 use crate::keybinds::PopupKeybinds;
 use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
 use crate::ui::utils::centered_rect_fixed;
+use crate::ui::utils::mark_key;
 
-const YES: &str = "(Y)es";
-const YES_KEY: char = 'y';
-const NO: &str = "(N)o";
-const NO_KEY: char = 'n';
+const YES: &str = "Yes";
+const NO: &str = "No";
 
 /// Blank cells around the question, and either side of a button label.
 const PADDING: u16 = 2;
@@ -54,6 +54,7 @@ pub struct ConfirmPopup {
     yes_selected: bool,
     config: JjConfig,
     keybinds: PopupKeybinds,
+    own_keybinds: ConfirmPopupKeybinds,
 }
 
 impl ConfirmPopup {
@@ -71,6 +72,7 @@ impl ConfirmPopup {
             yes_selected: true,
             config,
             keybinds: PopupKeybinds::dialog(),
+            own_keybinds: ConfirmPopupKeybinds::new(),
         }
     }
 
@@ -91,11 +93,19 @@ impl ConfirmPopup {
 
     /// What a button label takes with the padding either side of it.
     fn button_width(label: &str) -> u16 {
-        label.len() as u16 + PADDING * 2
+        label.chars().count() as u16 + PADDING * 2
     }
 
-    /// A button label, marked when Enter is what presses it.
-    fn button(&self, label: &'static str, selected: bool) -> Paragraph<'static> {
+    /// A button label, marking the key that presses it.
+    fn label(&self, answer: &str, yes: bool) -> String {
+        mark_key(
+            answer,
+            self.own_keybinds.shortcut(ConfirmPopupEvent::Answer(yes)),
+        )
+    }
+
+    /// A button, marked when Enter is what presses it.
+    fn button(&self, label: String, selected: bool) -> Paragraph<'static> {
         let style = if selected {
             Style::default()
                 .bg(self.config.highlight_color())
@@ -108,8 +118,10 @@ impl ConfirmPopup {
     }
 
     fn draw_buttons(&self, f: &mut Frame<'_>, area: Rect) {
-        let yes_width = Self::button_width(YES);
-        let no_width = Self::button_width(NO);
+        let yes = self.label(YES, true);
+        let no = self.label(NO, false);
+        let yes_width = Self::button_width(&yes);
+        let no_width = Self::button_width(&no);
         let margin = area.width.saturating_sub(yes_width + no_width) / 2;
 
         let chunks = Layout::default()
@@ -122,8 +134,8 @@ impl ConfirmPopup {
             ])
             .split(area);
 
-        f.render_widget(self.button(YES, self.yes_selected), chunks[1]);
-        f.render_widget(self.button(NO, !self.yes_selected), chunks[2]);
+        f.render_widget(self.button(yes, self.yes_selected), chunks[1]);
+        f.render_widget(self.button(no, !self.yes_selected), chunks[2]);
     }
 }
 
@@ -186,12 +198,10 @@ impl Component for ConfirmPopup {
 
         // The answers are the buttons the question puts up, so they are
         // its own keys rather than any popup's.
-        match key.code {
-            KeyCode::Left => self.yes_selected = true,
-            KeyCode::Right => self.yes_selected = false,
-            KeyCode::Char(YES_KEY) => return self.answer(true),
-            KeyCode::Char(NO_KEY) => return self.answer(false),
-            _ => {}
+        match self.own_keybinds.match_event(key) {
+            ConfirmPopupEvent::Answer(yes) => return self.answer(yes),
+            ConfirmPopupEvent::Select(yes) => self.yes_selected = yes,
+            ConfirmPopupEvent::Unbound => {}
         }
 
         Ok(ComponentInputResult::Handled)
@@ -203,6 +213,7 @@ mod tests {
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
     use ratatui::buffer::Buffer;
+    use ratatui::crossterm::event::KeyCode;
     use ratatui::crossterm::event::KeyEvent;
     use ratatui::text::Line;
 
@@ -210,6 +221,10 @@ mod tests {
     use crate::commander::ids::ChangeId;
     use crate::commander::ids::CommitId;
     use crate::commander::log::Head;
+
+    /// The buttons as the default bindings mark them
+    const MARKED_YES: &str = "(Y)es";
+    const MARKED_NO: &str = "(N)o";
 
     /// A question raising a recognisable action when answered yes.
     fn popup() -> ConfirmPopup {
@@ -309,25 +324,25 @@ mod tests {
             "{rows:?}"
         );
         let buttons = rows.len() - 2;
-        assert!(rows[buttons].contains(YES), "{rows:?}");
-        assert!(rows[buttons].contains(NO), "{rows:?}");
+        assert!(rows[buttons].contains(MARKED_YES), "{rows:?}");
+        assert!(rows[buttons].contains(MARKED_NO), "{rows:?}");
     }
 
     #[test]
     fn yes_is_the_button_enter_presses_until_the_other_is_picked() {
         let mut popup = popup();
 
-        assert!(is_selected(&render(&mut popup), YES));
-        assert!(!is_selected(&render(&mut popup), NO));
+        assert!(is_selected(&render(&mut popup), MARKED_YES));
+        assert!(!is_selected(&render(&mut popup), MARKED_NO));
 
         press(&mut popup, KeyCode::Right);
 
-        assert!(is_selected(&render(&mut popup), NO));
-        assert!(!is_selected(&render(&mut popup), YES));
+        assert!(is_selected(&render(&mut popup), MARKED_NO));
+        assert!(!is_selected(&render(&mut popup), MARKED_YES));
 
         press(&mut popup, KeyCode::Left);
 
-        assert!(is_selected(&render(&mut popup), YES));
+        assert!(is_selected(&render(&mut popup), MARKED_YES));
     }
 
     #[test]
@@ -354,11 +369,11 @@ mod tests {
     #[test]
     fn a_button_can_be_pressed_by_its_letter_whichever_is_picked() {
         assert_eq!(
-            closed_with(press(&mut popup(), KeyCode::Char(YES_KEY))),
+            closed_with(press(&mut popup(), KeyCode::Char('y'))),
             Some(Some("confirmed".into()))
         );
         assert_eq!(
-            closed_with(press(&mut popup(), KeyCode::Char(NO_KEY))),
+            closed_with(press(&mut popup(), KeyCode::Char('n'))),
             Some(None)
         );
     }

--- a/src/ui/dialog/help.rs
+++ b/src/ui/dialog/help.rs
@@ -18,6 +18,7 @@ use ratatui::widgets::ScrollbarOrientation;
 use ratatui::widgets::ScrollbarState;
 use ratatui::widgets::Table;
 
+use crate::keybinds::HelpSection;
 use crate::keybinds::PopupEvent;
 use crate::keybinds::PopupKeybinds;
 use crate::ui::Component;
@@ -88,17 +89,53 @@ fn contents_width(columns: &[Vec<Section>]) -> u16 {
     columns_width + SEPARATOR_WIDTH * columns.len().saturating_sub(1) as u16
 }
 
+/// The `sections` split into two stacks of as near the same height as they
+/// go, keeping the order they came in.
+fn halve<'a>(sections: &[Section<'a>]) -> Vec<Vec<Section<'a>>> {
+    if sections.len() < 2 {
+        return vec![sections.to_vec()];
+    }
+
+    let total = stack_height(sections);
+    let cut = (1..sections.len())
+        .min_by_key(|cut| {
+            let above = stack_height(&sections[..*cut]);
+            above.abs_diff(total - above)
+        })
+        .unwrap_or(1);
+
+    vec![sections[..cut].to_vec(), sections[cut..].to_vec()]
+}
+
 /// How to arrange the popup's sections in the `width` available for them: the
-/// main panel bindings beside the details panel and global ones, or, when that
-/// does not fit, all of them stacked in a single column, which only needs the
-/// width of the widest of them.
-fn columns<'a>([main, details, global]: [Section<'a>; 3], width: u16) -> Vec<Vec<Section<'a>>> {
-    let halves = vec![vec![main], vec![details, global]];
+/// main panel bindings across two columns beside the details panel and global
+/// ones, or in a single column beside them, or, when even that does not fit,
+/// all of them stacked in one column, which only needs the width of the widest
+/// of them.
+///
+/// A tab sorts its bindings into a section per kind of thing they do, and
+/// spreading those over the width there is keeps the popup short enough to
+/// take in without scrolling.
+fn columns<'a>(
+    main: Vec<Section<'a>>,
+    details: Section<'a>,
+    global: Section<'a>,
+    width: u16,
+) -> Vec<Vec<Section<'a>>> {
+    let side = vec![details, global];
+
+    let mut spread = halve(&main);
+    spread.push(side.clone());
+    if spread.len() > 2 && contents_width(&spread) <= width {
+        return spread;
+    }
+
+    let halves = vec![main, side];
     if contents_width(&halves) <= width {
         return halves;
     }
 
-    vec![vec![main, details, global]]
+    vec![halves.into_iter().flatten().collect()]
 }
 
 /// Renders the `sections` stacked in `area`, with a rule between them and
@@ -166,7 +203,9 @@ fn place(viewport: Rect, scroll: u16, top: u16, height: u16) -> Option<(Rect, u1
 }
 
 pub struct HelpPopup {
-    pub main_items: Vec<(String, String)>,
+    /// The main panel's bindings, in a section per kind of thing they
+    /// do where the tab has enough of them to sort
+    pub main_sections: Vec<HelpSection>,
     pub details_items: Vec<(String, String)>,
     pub global_items: Vec<(String, String)>,
     max_scroll: u16,
@@ -178,12 +217,12 @@ pub struct HelpPopup {
 
 impl HelpPopup {
     pub fn new(
-        main_items: Vec<(String, String)>,
+        main_sections: Vec<HelpSection>,
         details_items: Vec<(String, String)>,
         global_items: Vec<(String, String)>,
     ) -> Self {
         Self {
-            main_items,
+            main_sections,
             details_items,
             global_items,
             max_scroll: 0,
@@ -210,20 +249,21 @@ impl Component for HelpPopup {
         let [extra_width, extra_height] = chrome(&block, area);
 
         let columns = columns(
-            [
-                Section {
-                    title: "Main panel",
-                    items: &self.main_items,
-                },
-                Section {
-                    title: "Details panel",
-                    items: &self.details_items,
-                },
-                Section {
-                    title: "Global",
-                    items: &self.global_items,
-                },
-            ],
+            self.main_sections
+                .iter()
+                .map(|section| Section {
+                    title: section.title,
+                    items: &section.items,
+                })
+                .collect(),
+            Section {
+                title: "Details panel",
+                items: &self.details_items,
+            },
+            Section {
+                title: "Global",
+                items: &self.global_items,
+            },
             area.width.saturating_sub(extra_width),
         );
 
@@ -366,34 +406,64 @@ mod tests {
         let main = section(2, 1, 10);
         let details = section(2, 2, 8);
         let global = section(3, 2, 6);
-        let sections = [
-            Section {
-                title: "Main panel",
-                items: &main,
-            },
-            Section {
-                title: "Details panel",
-                items: &details,
-            },
-            Section {
-                title: "Global",
-                items: &global,
-            },
-        ];
+        let main = vec![Section {
+            title: "Main panel",
+            items: &main,
+        }];
+        let details = Section {
+            title: "Details panel",
+            items: &details,
+        };
+        let global = Section {
+            title: "Global",
+            items: &global,
+        };
 
         // The main panel bindings need 15 columns, the other two 14 together
-        let halves = columns(sections, 32);
+        let halves = columns(main.clone(), details, global, 32);
         assert_eq!(halves.len(), 2);
         assert_eq!(contents_width(&halves), 32);
 
         // A column short of that, everything stacks up in a single column,
         // which only has to hold the widest keys next to the widest
         // description.
-        let stacked = columns(sections, 31);
+        let stacked = columns(main, details, global, 31);
         assert_eq!(stacked.len(), 1);
         assert_eq!(contents_width(&stacked), 16);
         // Every section spends a row on its title, with a rule between them
         assert_eq!(stack_height(&stacked[0]), 12);
+    }
+
+    /// A tab with several sections has them spread over the width there
+    /// is rather than piled into one tall column.
+    #[test]
+    fn test_the_main_panel_sections_spread_across_two_columns() {
+        let items = section(4, 1, 10);
+        let side_items = section(2, 2, 6);
+        let main: Vec<Section> = ["Navigation", "Changes", "Bookmarks"]
+            .into_iter()
+            .map(|title| Section {
+                title,
+                items: &items,
+            })
+            .collect();
+        let side = |title| Section {
+            title,
+            items: &side_items,
+        };
+
+        // Three sections of 5 rows split 2 and 1, so the tallest column
+        // holds 11 rows rather than the 17 of all three in one.
+        let spread = columns(main.clone(), side("Details panel"), side("Global"), 48);
+        assert_eq!(spread.len(), 3);
+        assert_eq!(stack_height(&spread[0]), 11);
+        assert_eq!(stack_height(&spread[1]), 5);
+
+        // A column short of that, the main panel takes a single column
+        // again, tall as that leaves the popup.
+        let halves = columns(main, side("Details panel"), side("Global"), 47);
+        assert_eq!(halves.len(), 2);
+        assert_eq!(stack_height(&halves[0]), 17);
     }
 
     #[test]

--- a/src/ui/dialog/help.rs
+++ b/src/ui/dialog/help.rs
@@ -118,12 +118,9 @@ fn halve<'a>(sections: &[Section<'a>]) -> Vec<Vec<Section<'a>>> {
 /// take in without scrolling.
 fn columns<'a>(
     main: Vec<Section<'a>>,
-    details: Section<'a>,
-    global: Section<'a>,
+    side: Vec<Section<'a>>,
     width: u16,
 ) -> Vec<Vec<Section<'a>>> {
-    let side = vec![details, global];
-
     let mut spread = halve(&main);
     spread.push(side.clone());
     if spread.len() > 2 && contents_width(&spread) <= width {
@@ -136,6 +133,17 @@ fn columns<'a>(
     }
 
     vec![halves.into_iter().flatten().collect()]
+}
+
+/// The `sections` as the popup lists them, under the title of each
+fn listed(sections: &[HelpSection]) -> Vec<Section<'_>> {
+    sections
+        .iter()
+        .map(|section| Section {
+            title: section.section.title(),
+            items: &section.items,
+        })
+        .collect()
 }
 
 /// Renders the `sections` stacked in `area`, with a rule between them and
@@ -203,11 +211,12 @@ fn place(viewport: Rect, scroll: u16, top: u16, height: u16) -> Option<(Rect, u1
 }
 
 pub struct HelpPopup {
-    /// The main panel's bindings, in a section per kind of thing they
-    /// do where the tab has enough of them to sort
+    /// What the main panel answers to, a section per kind of thing its
+    /// keys do
     pub main_sections: Vec<HelpSection>,
-    pub details_items: Vec<(String, String)>,
-    pub global_items: Vec<(String, String)>,
+    /// The sections listed beside those, for the details panel and the
+    /// app as a whole
+    pub side_sections: Vec<HelpSection>,
     max_scroll: u16,
     scroll: u16,
     /// Height of what the popup shows at once, updated on every draw
@@ -216,15 +225,10 @@ pub struct HelpPopup {
 }
 
 impl HelpPopup {
-    pub fn new(
-        main_sections: Vec<HelpSection>,
-        details_items: Vec<(String, String)>,
-        global_items: Vec<(String, String)>,
-    ) -> Self {
+    pub fn new(main_sections: Vec<HelpSection>, side_sections: Vec<HelpSection>) -> Self {
         Self {
             main_sections,
-            details_items,
-            global_items,
+            side_sections,
             max_scroll: 0,
             // Can't use TableState as it's broken: https://github.com/ratatui-org/ratatui/issues/1179
             scroll: 0,
@@ -249,21 +253,8 @@ impl Component for HelpPopup {
         let [extra_width, extra_height] = chrome(&block, area);
 
         let columns = columns(
-            self.main_sections
-                .iter()
-                .map(|section| Section {
-                    title: section.title,
-                    items: &section.items,
-                })
-                .collect(),
-            Section {
-                title: "Details panel",
-                items: &self.details_items,
-            },
-            Section {
-                title: "Global",
-                items: &self.global_items,
-            },
+            listed(&self.main_sections),
+            listed(&self.side_sections),
             area.width.saturating_sub(extra_width),
         );
 
@@ -410,24 +401,26 @@ mod tests {
             title: "Main panel",
             items: &main,
         }];
-        let details = Section {
-            title: "Details panel",
-            items: &details,
-        };
-        let global = Section {
-            title: "Global",
-            items: &global,
-        };
+        let side = vec![
+            Section {
+                title: "Details panel",
+                items: &details,
+            },
+            Section {
+                title: "Global",
+                items: &global,
+            },
+        ];
 
         // The main panel bindings need 15 columns, the other two 14 together
-        let halves = columns(main.clone(), details, global, 32);
+        let halves = columns(main.clone(), side.clone(), 32);
         assert_eq!(halves.len(), 2);
         assert_eq!(contents_width(&halves), 32);
 
         // A column short of that, everything stacks up in a single column,
         // which only has to hold the widest keys next to the widest
         // description.
-        let stacked = columns(main, details, global, 31);
+        let stacked = columns(main, side, 31);
         assert_eq!(stacked.len(), 1);
         assert_eq!(contents_width(&stacked), 16);
         // Every section spends a row on its title, with a rule between them
@@ -447,21 +440,24 @@ mod tests {
                 items: &items,
             })
             .collect();
-        let side = |title| Section {
-            title,
-            items: &side_items,
-        };
+        let side: Vec<Section> = ["Details panel", "Global"]
+            .into_iter()
+            .map(|title| Section {
+                title,
+                items: &side_items,
+            })
+            .collect();
 
         // Three sections of 5 rows split 2 and 1, so the tallest column
         // holds 11 rows rather than the 17 of all three in one.
-        let spread = columns(main.clone(), side("Details panel"), side("Global"), 48);
+        let spread = columns(main.clone(), side.clone(), 48);
         assert_eq!(spread.len(), 3);
         assert_eq!(stack_height(&spread[0]), 11);
         assert_eq!(stack_height(&spread[1]), 5);
 
         // A column short of that, the main panel takes a single column
         // again, tall as that leaves the popup.
-        let halves = columns(main, side("Details panel"), side("Global"), 47);
+        let halves = columns(main, side, 47);
         assert_eq!(halves.len(), 2);
         assert_eq!(stack_height(&halves[0]), 17);
     }
@@ -488,7 +484,7 @@ mod tests {
 
     #[test]
     fn test_scroll_is_clamped_to_max() {
-        let mut popup = HelpPopup::new(vec![], vec![], vec![]);
+        let mut popup = HelpPopup::new(vec![], vec![]);
         popup.max_scroll = 2;
 
         for _ in 0..5 {
@@ -508,7 +504,7 @@ mod tests {
 
     #[test]
     fn test_the_wheel_scrolls_more_than_a_row_at_a_time() {
-        let mut popup = HelpPopup::new(vec![], vec![], vec![]);
+        let mut popup = HelpPopup::new(vec![], vec![]);
         popup.max_scroll = 10;
 
         popup

--- a/src/ui/dialog/rebase.rs
+++ b/src/ui/dialog/rebase.rs
@@ -14,8 +14,8 @@
 
     Esc: Cancel    Enter: Rebase
 ~~~
-It has keyboard shortcuts s, b, r, d, shift+a, shift+b for selecting
-a radiobutton, and shortcuts Enter, Esc, q for closing the popup.
+A radio button is selected by s, b, r, d, shift+a or shift+b, and the
+popup is closed by Enter, Esc or q, both as configured.
 
 
 */
@@ -71,7 +71,7 @@ pub struct RebasePopup {
 impl RebasePopup {
     pub fn new(source_rev: Head, target_rev: Head) -> Self {
         Self {
-            keybinds: Keybinds::default(),
+            keybinds: Keybinds::new(),
             popup_keybinds: PopupKeybinds::dialog(),
             source_rev,
             target_rev,
@@ -187,27 +187,25 @@ impl Component for RebasePopup {
             return Ok(ComponentInputResult::Handled);
         };
 
-        // What the popup itself binds comes first, so that a key it
-        // needs is not taken by the keys every popup answers to.
+        match self.popup_keybinds.match_event(key) {
+            PopupEvent::Accept => {
+                return Ok(ComponentInputResult::HandledAction(AppAction::Multiple(
+                    vec![AppAction::ClosePopup, AppAction::Run(self.command())],
+                )));
+            }
+            PopupEvent::Cancel => {
+                return Ok(ComponentInputResult::HandledAction(AppAction::ClosePopup));
+            }
+            _ => {}
+        }
+
         match self.keybinds.match_event(key) {
-            PopupAction::SetSourceMode(m) => {
-                self.source_mode = m;
-                return Ok(ComponentInputResult::Handled);
-            }
-            PopupAction::SetTargetMode(m) => {
-                self.target_mode = m;
-                return Ok(ComponentInputResult::Handled);
-            }
+            PopupAction::SetSourceMode(m) => self.source_mode = m,
+            PopupAction::SetTargetMode(m) => self.target_mode = m,
             PopupAction::None => {}
         }
 
-        match self.popup_keybinds.match_event(key) {
-            PopupEvent::Accept => Ok(ComponentInputResult::HandledAction(AppAction::Multiple(
-                vec![AppAction::ClosePopup, AppAction::Run(self.command())],
-            ))),
-            PopupEvent::Cancel => Ok(ComponentInputResult::HandledAction(AppAction::ClosePopup)),
-            _ => Ok(ComponentInputResult::Handled),
-        }
+        Ok(ComponentInputResult::Handled)
     }
 }
 

--- a/src/ui/evolog_tab.rs
+++ b/src/ui/evolog_tab.rs
@@ -25,7 +25,7 @@ use crate::keybinds::DetailsPanelEvent;
 use crate::keybinds::DetailsPanelKeybinds;
 use crate::keybinds::EvologTabEvent;
 use crate::keybinds::EvologTabKeybinds;
-use crate::keybinds::HelpSection;
+use crate::keybinds::HelpItem;
 use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
@@ -195,11 +195,11 @@ impl Tab for EvologTab<'_> {
         Ok(self.context_menu(self.entry_panel.selected_position()))
     }
 
-    fn make_main_panel_help(&self) -> Vec<HelpSection> {
+    fn make_main_panel_help(&self) -> Vec<HelpItem> {
         self.keybinds.make_help()
     }
 
-    fn make_details_panel_help(&self) -> Vec<(String, String)> {
+    fn make_details_panel_help(&self) -> Vec<HelpItem> {
         self.details_keybinds.make_help()
     }
 }

--- a/src/ui/evolog_tab.rs
+++ b/src/ui/evolog_tab.rs
@@ -71,7 +71,7 @@ impl<'a> EvologTab<'a> {
             pane_divider: PaneDivider::new(config.layout_percent()),
             config,
             keybinds: EvologTabKeybinds::default(),
-            details_keybinds: DetailsPanelKeybinds::default(),
+            details_keybinds: DetailsPanelKeybinds::new(),
 
             stale: true,
         }

--- a/src/ui/evolog_tab.rs
+++ b/src/ui/evolog_tab.rs
@@ -70,7 +70,7 @@ impl<'a> EvologTab<'a> {
 
             pane_divider: PaneDivider::new(config.layout_percent()),
             config,
-            keybinds: EvologTabKeybinds::default(),
+            keybinds: EvologTabKeybinds::new(),
             details_keybinds: DetailsPanelKeybinds::new(),
 
             stale: true,

--- a/src/ui/evolog_tab.rs
+++ b/src/ui/evolog_tab.rs
@@ -118,7 +118,7 @@ impl<'a> EvologTab<'a> {
 
     /// The menu of what can be done to the selected version, put at
     /// `anchor` or centered when there is nowhere to point at.
-    fn open_context_menu(&self, anchor: Option<Position>) -> Option<AppAction> {
+    fn context_menu(&self, anchor: Option<Position>) -> Option<AppAction> {
         Some(AppAction::SetPopup(Box::new(evolog_context_menu(
             self.config.clone(),
             anchor,
@@ -145,9 +145,6 @@ impl<'a> EvologTab<'a> {
                 return Ok(Some(AppAction::Run(Command::Copy(
                     entry.commit_id.as_str().to_owned(),
                 ))));
-            }
-            EvologTabEvent::OpenContextMenu => {
-                return Ok(self.open_context_menu(self.entry_panel.selected_position()));
             }
             // Not an operation of its own; the key handler deals with it.
             EvologTabEvent::Unbound => {}
@@ -197,6 +194,10 @@ impl Tab for EvologTab<'_> {
     fn focus_current(&mut self) -> Result<()> {
         self.set_head(&new_commander().get_current_head()?);
         Ok(())
+    }
+
+    fn open_context_menu(&self) -> Result<Option<AppAction>> {
+        Ok(self.context_menu(self.entry_panel.selected_position()))
     }
 
     fn make_main_panel_help(&self) -> Vec<(String, String)> {
@@ -276,7 +277,7 @@ impl Component for EvologTab<'_> {
                         self.entry_panel.set_head_in_place(entry);
                         self.sync_entry_output();
                         let anchor = Position::new(mouse.column, mouse.row);
-                        return Ok(self.open_context_menu(Some(anchor)).into());
+                        return Ok(self.context_menu(Some(anchor)).into());
                     }
                 }
                 MouseInput::Handled => {}

--- a/src/ui/evolog_tab.rs
+++ b/src/ui/evolog_tab.rs
@@ -25,6 +25,7 @@ use crate::keybinds::DetailsPanelEvent;
 use crate::keybinds::DetailsPanelKeybinds;
 use crate::keybinds::EvologTabEvent;
 use crate::keybinds::EvologTabKeybinds;
+use crate::keybinds::HelpSection;
 use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
@@ -194,7 +195,7 @@ impl Tab for EvologTab<'_> {
         Ok(self.context_menu(self.entry_panel.selected_position()))
     }
 
-    fn make_main_panel_help(&self) -> Vec<(String, String)> {
+    fn make_main_panel_help(&self) -> Vec<HelpSection> {
         self.keybinds.make_help()
     }
 

--- a/src/ui/evolog_tab.rs
+++ b/src/ui/evolog_tab.rs
@@ -181,13 +181,7 @@ impl Tab for EvologTab<'_> {
     }
 
     fn scroll_main_panel(&mut self, scroll: Scroll) -> Result<()> {
-        let half_page = self.entry_panel.visible_heads() / 2;
-        self.scroll_entries(match scroll {
-            Scroll::Down => 1,
-            Scroll::Up => -1,
-            Scroll::DownHalfPage => half_page,
-            Scroll::UpHalfPage => half_page.saturating_neg(),
-        });
+        self.scroll_entries(scroll.distance(self.entry_panel.visible_heads()));
         Ok(())
     }
 

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -233,7 +233,7 @@ impl FilesTab {
 
     /// The menu of what can be done to the selected file, put at
     /// `anchor` or centered when there is nowhere to point at.
-    fn open_context_menu(&self, anchor: Option<Position>) -> Option<AppAction> {
+    fn context_menu(&self, anchor: Option<Position>) -> Option<AppAction> {
         let file = self.file.as_ref()?;
 
         Some(AppAction::SetPopup(Box::new(files_context_menu(
@@ -253,10 +253,6 @@ impl FilesTab {
                 .file
                 .clone()
                 .map(|file| AppAction::Run(Command::RestoreFile(file)))),
-            FilesTabEvent::OpenContextMenu => Ok(self.open_context_menu(
-                self.get_current_file_index()
-                    .and_then(|index| self.files_pane.item_anchor(index, 1)),
-            )),
             // Not an operation of its own; the key handler deals with it.
             FilesTabEvent::Unbound => Ok(None),
         }
@@ -324,6 +320,13 @@ impl Tab for FilesTab {
     fn focus_current(&mut self) -> Result<()> {
         self.set_head(&new_commander().get_current_head()?);
         Ok(())
+    }
+
+    fn open_context_menu(&self) -> Result<Option<AppAction>> {
+        Ok(self.context_menu(
+            self.get_current_file_index()
+                .and_then(|index| self.files_pane.item_anchor(index, 1)),
+        ))
     }
 
     fn make_main_panel_help(&self) -> Vec<(String, String)> {
@@ -495,7 +498,7 @@ impl Component for FilesTab {
                         self.file = Some(file);
                         self.show_diff();
                         let anchor = Position::new(mouse.column, mouse.row);
-                        return Ok(self.open_context_menu(Some(anchor)).into());
+                        return Ok(self.context_menu(Some(anchor)).into());
                     }
                 }
                 MouseInput::Handled => {}

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -28,7 +28,7 @@ use crate::keybinds::DetailsPanelEvent;
 use crate::keybinds::DetailsPanelKeybinds;
 use crate::keybinds::FilesTabEvent;
 use crate::keybinds::FilesTabKeybinds;
-use crate::keybinds::HelpSection;
+use crate::keybinds::HelpItem;
 use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
@@ -324,11 +324,11 @@ impl Tab for FilesTab {
         ))
     }
 
-    fn make_main_panel_help(&self) -> Vec<HelpSection> {
+    fn make_main_panel_help(&self) -> Vec<HelpItem> {
         self.keybinds.make_help()
     }
 
-    fn make_details_panel_help(&self) -> Vec<(String, String)> {
+    fn make_details_panel_help(&self) -> Vec<HelpItem> {
         self.details_keybinds.make_help()
     }
 }

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -307,13 +307,7 @@ impl Tab for FilesTab {
     }
 
     fn scroll_main_panel(&mut self, scroll: Scroll) -> Result<()> {
-        let half_page = self.files_pane.visible_items() / 2;
-        self.scroll_files(match scroll {
-            Scroll::Down => 1,
-            Scroll::Up => -1,
-            Scroll::DownHalfPage => half_page,
-            Scroll::UpHalfPage => half_page.saturating_neg(),
-        });
+        self.scroll_files(scroll.distance(self.files_pane.visible_items()));
         Ok(())
     }
 

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -145,7 +145,7 @@ impl FilesTab {
         let config = get_env().jj_config.clone();
         let pane_divider = PaneDivider::new(config.layout_percent());
         let keybinds = FilesTabKeybinds::default();
-        let details_keybinds = DetailsPanelKeybinds::default();
+        let details_keybinds = DetailsPanelKeybinds::new();
 
         Self {
             head: current_head.clone(),

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -28,6 +28,7 @@ use crate::keybinds::DetailsPanelEvent;
 use crate::keybinds::DetailsPanelKeybinds;
 use crate::keybinds::FilesTabEvent;
 use crate::keybinds::FilesTabKeybinds;
+use crate::keybinds::HelpSection;
 use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
@@ -323,7 +324,7 @@ impl Tab for FilesTab {
         ))
     }
 
-    fn make_main_panel_help(&self) -> Vec<(String, String)> {
+    fn make_main_panel_help(&self) -> Vec<HelpSection> {
         self.keybinds.make_help()
     }
 

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -144,7 +144,7 @@ impl FilesTab {
     pub fn new(current_head: &Head, background_tasks: BackgroundTasks) -> Self {
         let config = get_env().jj_config.clone();
         let pane_divider = PaneDivider::new(config.layout_percent());
-        let keybinds = FilesTabKeybinds::default();
+        let keybinds = FilesTabKeybinds::new();
         let details_keybinds = DetailsPanelKeybinds::new();
 
         Self {

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -93,15 +93,9 @@ impl<'a> LogTab<'a> {
     #[instrument(level = "info", name = "Initializing log tab", parent = None, skip(background_tasks))]
     pub fn new(background_tasks: BackgroundTasks, head: Head) -> Self {
         let mut keybinds = LogTabKeybinds::default();
-        let mut details_keybinds = DetailsPanelKeybinds::default();
+        let details_keybinds = DetailsPanelKeybinds::new();
         if let Some(keybinds_config) = get_env().jj_config.keybinds() {
             keybinds.extend_from_config(keybinds_config);
-            details_keybinds.extend_from_config(
-                keybinds_config
-                    .log_tab
-                    .as_ref()
-                    .and_then(|c| c.toggle_diff_format.as_ref()),
-            );
         }
 
         let config = get_env().jj_config.clone();

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -248,14 +248,6 @@ impl<'a> LogTab<'a> {
 
     fn handle_event(&mut self, log_tab_event: LogTabEvent) -> Result<Option<AppAction>> {
         match log_tab_event {
-            LogTabEvent::ScrollToBottom => {
-                self.log_panel.scroll_relative(isize::MAX);
-                self.sync_head_output();
-            }
-            LogTabEvent::ScrollToTop => {
-                self.log_panel.scroll_relative(-isize::MAX);
-                self.sync_head_output();
-            }
             LogTabEvent::ToggleHeadMark => {
                 self.log_panel.toggle_head_mark();
                 self.sync_head_output();
@@ -381,13 +373,8 @@ impl Tab for LogTab<'_> {
     }
 
     fn scroll_main_panel(&mut self, scroll: Scroll) -> Result<()> {
-        let half_page = self.log_panel.visible_heads() / 2;
-        self.log_panel.scroll_relative(match scroll {
-            Scroll::Down => 1,
-            Scroll::Up => -1,
-            Scroll::DownHalfPage => half_page,
-            Scroll::UpHalfPage => half_page.saturating_neg(),
-        });
+        self.log_panel
+            .scroll_relative(scroll.distance(self.log_panel.visible_heads()));
         self.sync_head_output();
         Ok(())
     }

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -23,6 +23,7 @@ use crate::env::JjConfig;
 use crate::env::get_env;
 use crate::keybinds::DetailsPanelEvent;
 use crate::keybinds::DetailsPanelKeybinds;
+use crate::keybinds::HelpSection;
 use crate::keybinds::LogTabEvent;
 use crate::keybinds::LogTabKeybinds;
 use crate::keybinds::PopupEvent;
@@ -388,7 +389,7 @@ impl Tab for LogTab<'_> {
         self.context_menu(self.log_panel.selected_position())
     }
 
-    fn make_main_panel_help(&self) -> Vec<(String, String)> {
+    fn make_main_panel_help(&self) -> Vec<HelpSection> {
         self.keybinds.make_main_panel_help()
     }
 

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -23,7 +23,7 @@ use crate::env::JjConfig;
 use crate::env::get_env;
 use crate::keybinds::DetailsPanelEvent;
 use crate::keybinds::DetailsPanelKeybinds;
-use crate::keybinds::HelpSection;
+use crate::keybinds::HelpItem;
 use crate::keybinds::LogTabEvent;
 use crate::keybinds::LogTabKeybinds;
 use crate::keybinds::PopupEvent;
@@ -389,11 +389,11 @@ impl Tab for LogTab<'_> {
         self.context_menu(self.log_panel.selected_position())
     }
 
-    fn make_main_panel_help(&self) -> Vec<HelpSection> {
+    fn make_main_panel_help(&self) -> Vec<HelpItem> {
         self.keybinds.make_main_panel_help()
     }
 
-    fn make_details_panel_help(&self) -> Vec<(String, String)> {
+    fn make_details_panel_help(&self) -> Vec<HelpItem> {
         self.details_keybinds.make_help()
     }
 }

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -92,11 +92,8 @@ The main functions are:
 impl<'a> LogTab<'a> {
     #[instrument(level = "info", name = "Initializing log tab", parent = None, skip(background_tasks))]
     pub fn new(background_tasks: BackgroundTasks, head: Head) -> Self {
-        let mut keybinds = LogTabKeybinds::default();
+        let keybinds = LogTabKeybinds::new();
         let details_keybinds = DetailsPanelKeybinds::new();
-        if let Some(keybinds_config) = get_env().jj_config.keybinds() {
-            keybinds.extend_from_config(keybinds_config);
-        }
 
         let config = get_env().jj_config.clone();
         let pane_divider = PaneDivider::new(config.layout_percent());

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -168,7 +168,7 @@ impl<'a> LogTab<'a> {
 
     /// The menu of what can be done to the selected change, put at
     /// `anchor` or centered when there is nowhere to point at.
-    fn open_context_menu(&self, anchor: Option<Position>) -> Result<Option<AppAction>> {
+    fn context_menu(&self, anchor: Option<Position>) -> Result<Option<AppAction>> {
         Ok(Some(AppAction::SetPopup(Box::new(log_context_menu(
             self.config.clone(),
             anchor,
@@ -350,10 +350,6 @@ impl<'a> LogTab<'a> {
                 return self.handle_goto_parent();
             }
 
-            LogTabEvent::OpenContextMenu => {
-                return self.open_context_menu(self.log_panel.selected_position());
-            }
-
             LogTabEvent::Unbound => {}
         };
         Ok(None)
@@ -402,6 +398,10 @@ impl Tab for LogTab<'_> {
     fn focus_current(&mut self) -> Result<()> {
         self.set_head(new_commander().get_current_head()?);
         Ok(())
+    }
+
+    fn open_context_menu(&self) -> Result<Option<AppAction>> {
+        self.context_menu(self.log_panel.selected_position())
     }
 
     fn make_main_panel_help(&self) -> Vec<(String, String)> {
@@ -552,7 +552,7 @@ impl Component for LogTab<'_> {
                         self.log_panel.set_head_in_place(head);
                         self.sync_head_output();
                         let anchor = Position::new(mouse_event.column, mouse_event.row);
-                        return Ok(self.open_context_menu(Some(anchor))?.into());
+                        return Ok(self.context_menu(Some(anchor))?.into());
                     }
                 }
                 MouseInput::Handled => {}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -139,6 +139,10 @@ pub trait Tab: Component {
         Ok(())
     }
 
+    /// The menu of what can be done to what the tab has selected, put
+    /// where the selection is.
+    fn open_context_menu(&self) -> Result<Option<AppAction>>;
+
     /// Keybindings of the main panel, for the help popup.
     fn make_main_panel_help(&self) -> Vec<(String, String)>;
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -90,6 +90,23 @@ pub enum Scroll {
     Up,
     DownHalfPage,
     UpHalfPage,
+    ToTop,
+    ToBottom,
+}
+
+impl Scroll {
+    /// How far to move in a list of `page` entries, as far as there is
+    /// to go for the ends.
+    fn distance(self, page: isize) -> isize {
+        match self {
+            Scroll::Down => 1,
+            Scroll::Up => -1,
+            Scroll::DownHalfPage => page / 2,
+            Scroll::UpHalfPage => (page / 2).saturating_neg(),
+            Scroll::ToBottom => isize::MAX,
+            Scroll::ToTop => -isize::MAX,
+        }
+    }
 }
 
 pub trait Component {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -17,7 +17,7 @@ use crate::app::command::Command;
 use crate::background_tasks::TaskResult;
 use crate::commander::JjCommand;
 use crate::commander::log::Head;
-use crate::keybinds::HelpSection;
+use crate::keybinds::HelpItem;
 
 /// Action commmands from component to application
 pub enum AppAction {
@@ -162,8 +162,8 @@ pub trait Tab: Component {
     fn open_context_menu(&self) -> Result<Option<AppAction>>;
 
     /// Keybindings of the main panel, for the help popup.
-    fn make_main_panel_help(&self) -> Vec<HelpSection>;
+    fn make_main_panel_help(&self) -> Vec<HelpItem>;
 
     /// Keybindings of the details panel, for the help popup.
-    fn make_details_panel_help(&self) -> Vec<(String, String)>;
+    fn make_details_panel_help(&self) -> Vec<HelpItem>;
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -17,6 +17,7 @@ use crate::app::command::Command;
 use crate::background_tasks::TaskResult;
 use crate::commander::JjCommand;
 use crate::commander::log::Head;
+use crate::keybinds::HelpSection;
 
 /// Action commmands from component to application
 pub enum AppAction {
@@ -161,7 +162,7 @@ pub trait Tab: Component {
     fn open_context_menu(&self) -> Result<Option<AppAction>>;
 
     /// Keybindings of the main panel, for the help popup.
-    fn make_main_panel_help(&self) -> Vec<(String, String)>;
+    fn make_main_panel_help(&self) -> Vec<HelpSection>;
 
     /// Keybindings of the details panel, for the help popup.
     fn make_details_panel_help(&self) -> Vec<(String, String)>;

--- a/src/ui/utils.rs
+++ b/src/ui/utils.rs
@@ -20,6 +20,7 @@ use ratatui::text::Text;
 use ratatui::widgets::Block;
 
 use crate::env::JJLayout;
+use crate::keybinds::Shortcut;
 
 /// Tracks the split position between two panes and handles drag-to-resize mouse events.
 pub struct PaneDivider {
@@ -194,6 +195,27 @@ pub fn centered_rect_fixed(area: Rect, width: u16, height: u16) -> Rect {
     }
 }
 
+/// `label` with the key that picks it marked: parens around the first
+/// character of the label the key is, or the key's name after the label
+/// where the label holds no such character.
+pub fn mark_key(label: &str, shortcut: Option<Shortcut>) -> String {
+    let Some(shortcut) = shortcut else {
+        return label.to_owned();
+    };
+
+    if let Some(key) = shortcut.as_char()
+        && let Some((at, marked)) = label
+            .char_indices()
+            .find(|(_, c)| c.eq_ignore_ascii_case(&key))
+    {
+        let (before, rest) = label.split_at(at);
+        let after = &rest[marked.len_utf8()..];
+        return format!("{before}({marked}){after}");
+    }
+
+    format!("{label} ({shortcut})")
+}
+
 /// An error under a red title, with any ANSI escape sequences in its
 /// message honoured.
 pub fn error_text<'a>(
@@ -361,7 +383,27 @@ pub fn tabs_to_spaces(line: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
+
+    /// A label marks the key that picks it in place where the key is one
+    /// of its characters, and names it after the label otherwise.
+    #[test]
+    fn test_mark_key() {
+        let bind = |shortcut| Some(Shortcut::from_str(shortcut).expect("shortcut should parse"));
+
+        assert_eq!(mark_key("Yes", bind("y")), "(Y)es");
+        assert_eq!(mark_key("No", bind("n")), "(N)o");
+        assert_eq!(mark_key("Create bookmark", bind("k")), "Create boo(k)mark");
+        // A key the label does not hold, or one no single character
+        // stands for, goes after it.
+        assert_eq!(mark_key("Yes", bind("q")), "Yes (q)");
+        assert_eq!(mark_key("Yes", bind("ctrl+y")), "Yes (Control+y)");
+        assert_eq!(mark_key("Yes", bind("enter")), "Yes (Enter)");
+        // A binding that has been disabled leaves the label alone.
+        assert_eq!(mark_key("Yes", None), "Yes");
+    }
 
     #[test]
     fn an_error_is_shown_under_its_title() -> Result<(), ansi_to_tui::Error> {


### PR DESCRIPTION
Only the log tab reads the keybindings configuration, so every key of
the other three tabs, of the details panel that hangs off each of them,
and of the popups that have keys of their own is fixed. What is
configurable is not always in the right place either: the details panel
and the context menu are bound per tab, so they can drift apart, and
going to the top or bottom of a list only works in the log. Give each
of them a config section of its own, and move what means the same thing
everywhere into the global bindings.

Once everything is configurable the help has to be worth reading, since
it is now the only place the current bindings can be found. It sorts a
tab's bindings by what they do rather than listing them in one run, and
spreads the headings over a second column where the terminal is wide
enough, which keeps the log tab's twenty-seven bindings on one screen.
Which heading a binding falls under is a property of the action, so the
keys the app binds everywhere are listed with the panel's own where
they do the same kind of thing.

Two behavioural fixes came out of the same work and are kept separate:
`@` did nothing in the bookmarks tab though the help offered it, and
Home, End and space had no name to show, so a binding on one of them
read as "Control+Unknown" or as a blank.