### PR TITLE
Keep a popup up when jj turns down what was typed in it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   as editing one from the log does
 - `d` in the bookmarks tab no longer offers to delete a bookmark that is not
   there to be deleted
+- What jj said about a bookmark name it turned down now wraps in the popup that
+  puts the question back, rather than being cut off at the edge
 - The help popup no longer drops the global keybindings when the terminal is too
   short to hold them next to the details panel ones
 - The help popup now scrolls its three keybinding lists as a whole rather than

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   leaving the tab on the change it was on until the view is refreshed by hand
 - Creating a change from the bookmarks tab now brings the view up to date,
   rather than leaving it to the next poll
+- A bookmark name the set-bookmark dialog cannot put on a change is no longer
+  lost: the dialog comes back with the name and what jj said about it
 - Editing the change a bookmark points at now brings the other tabs up to date,
   as editing one from the log does
 - `d` in the bookmarks tab no longer offers to delete a bookmark that is not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   where it would be pointed at a single change to resolve it
 - Switching tabs right after an operation no longer briefly shows what they
   held before it
+- A describe jj turns down no longer loses what was written: the editor stays
+  up with the description and what jj said about it
 - Going to the current change (`@`) now shows it right away, rather than
   leaving the tab on the change it was on until the view is refreshed by hand
 - Creating a change from the bookmarks tab now brings the view up to date,

--- a/src/app/command.rs
+++ b/src/app/command.rs
@@ -20,6 +20,7 @@ use crate::background_tasks::TaskOutput;
 use crate::background_tasks::TaskSlot;
 use crate::commander::bookmarks::Bookmark;
 use crate::commander::files::File;
+use crate::commander::ids::ChangeId;
 use crate::commander::ids::CommitId;
 use crate::commander::jj::NewInsertMode;
 use crate::commander::jj::PushTarget;
@@ -50,6 +51,13 @@ pub enum NewSource {
     Marks,
     /// A single change, named by the selection or by a bookmark.
     Change,
+}
+
+/// The change the set-bookmark dialog was opened for, which is all it
+/// takes to put it back up.
+pub struct BookmarkSetDialog {
+    pub config: JjConfig,
+    pub change_id: Option<ChangeId>,
 }
 
 pub enum Command {
@@ -104,6 +112,9 @@ pub enum Command {
     SetBookmark {
         name: String,
         commit_id: CommitId,
+        /// What the set-bookmark dialog needs to come back up when the
+        /// name is refused, for the asking that goes through it.
+        dialog: Option<Box<BookmarkSetDialog>>,
     },
     DeleteBookmark(String),
     ForgetBookmark(String),
@@ -276,12 +287,26 @@ impl Command {
                     )))),
                 }
             }
-            Command::SetBookmark { name, commit_id } => {
-                match new_commander().set_bookmark_commit(&name, &commit_id) {
-                    Ok(()) => Ok(Some(AppAction::MarkTabsStale)),
-                    Err(err) => Ok(Some(refused("Set bookmark", err))),
-                }
-            }
+            Command::SetBookmark {
+                name,
+                commit_id,
+                dialog,
+            } => match new_commander().set_bookmark_commit(&name, &commit_id) {
+                Ok(()) => Ok(Some(AppAction::MarkTabsStale)),
+                // Put the question back with the name that was refused,
+                // which is usually one to correct rather than one to
+                // give up on.
+                Err(err) => Ok(Some(match dialog {
+                    Some(dialog) => AppAction::SetPopup(Box::new(BookmarkSetPopup::refused(
+                        dialog.config,
+                        dialog.change_id,
+                        commit_id,
+                        name,
+                        err,
+                    ))),
+                    None => refused("Set bookmark", err),
+                })),
+            },
             Command::DeleteBookmark(name) => match new_commander().delete_bookmark(&name) {
                 Ok(()) => Ok(Some(AppAction::MarkTabsStale)),
                 Err(err) => Ok(Some(refused("Delete", err))),
@@ -560,6 +585,7 @@ pub fn ask_set_bookmark(config: JjConfig, bookmark: &Bookmark, head: &Head) -> A
         Command::SetBookmark {
             name: bookmark.name.clone(),
             commit_id: head.commit_id.clone(),
+            dialog: None,
         },
     )
 }

--- a/src/app/command.rs
+++ b/src/app/command.rs
@@ -34,6 +34,7 @@ use crate::ui::dialog::BookmarkNameMode;
 use crate::ui::dialog::BookmarkNamePopup;
 use crate::ui::dialog::BookmarkSetPopup;
 use crate::ui::dialog::ConfirmPopup;
+use crate::ui::dialog::DescribePopup;
 use crate::ui::dialog::LoaderPopup;
 use crate::ui::dialog::MessagePopup;
 use crate::ui::dialog::RebasePopup;
@@ -198,10 +199,18 @@ impl Command {
             Command::Describe { head, description } => {
                 match new_commander().run_describe(&head.commit_id, &description) {
                     Ok(()) => Ok(Some(AppAction::Multiple(vec![
+                        AppAction::ClosePopup,
                         AppAction::ViewLog(new_commander().get_head_latest(&head)?),
                         AppAction::MarkTabsStale,
                     ]))),
-                    Err(err) => Ok(Some(refused("Describe", err))),
+                    // Put the editor back with what was written, since a
+                    // refused description is one to correct rather than
+                    // one to lose.
+                    Err(err) => Ok(Some(AppAction::SetPopup(Box::new(DescribePopup::refused(
+                        head,
+                        description,
+                        err,
+                    ))))),
                 }
             }
             Command::Rebase {

--- a/src/ui/dialog/bookmark_name.rs
+++ b/src/ui/dialog/bookmark_name.rs
@@ -1,4 +1,3 @@
-use ansi_to_tui::IntoText;
 use anyhow::Result;
 use ratatui::Frame;
 use ratatui::crossterm::event::Event;
@@ -26,6 +25,7 @@ use crate::keybinds::PopupKeybinds;
 use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
+use crate::ui::styles::refusal;
 use crate::ui::utils::centered_rect_line_height;
 
 pub enum BookmarkNameMode {
@@ -105,13 +105,16 @@ impl Component for BookmarkNamePopup<'_> {
             .border_type(BorderType::Rounded)
             .border_style(Style::default().fg(Color::Green));
 
-        let error_lines = self
+        // The width the popup is about to get, which the answer has to
+        // be wrapped to before we know how tall to make it.
+        let width = block.inner(centered_rect_line_height(area, 30, 0)).width;
+        let error = self
             .error
             .as_ref()
-            .map(|e| e.to_string().into_text().unwrap().lines);
-        let error_height = error_lines.as_ref().map_or(0, |l| l.len() + 1);
+            .map(|error| refusal(&error.to_string(), width));
+        let error_height = error.as_ref().map_or(0, |(_, height)| *height);
 
-        let area = centered_rect_line_height(area, 30, 5 + error_height as u16);
+        let area = centered_rect_line_height(area, 30, 5 + error_height);
         f.render_widget(Clear, area);
         f.render_widget(&block, area);
 
@@ -119,23 +122,15 @@ impl Component for BookmarkNamePopup<'_> {
             .direction(Direction::Vertical)
             .constraints([
                 Constraint::Fill(1),
-                Constraint::Length(error_height as u16),
+                Constraint::Length(error_height),
                 Constraint::Length(2),
             ])
             .split(block.inner(area));
 
         f.render_widget(&self.textarea, popup_chunks[0]);
 
-        if let Some(error_lines) = error_lines {
-            f.render_widget(
-                Paragraph::new(error_lines).block(
-                    Block::default()
-                        .borders(Borders::TOP)
-                        .border_type(BorderType::Rounded)
-                        .border_style(Style::default().fg(Color::DarkGray)),
-                ),
-                popup_chunks[1],
-            );
+        if let Some((error, _)) = error {
+            f.render_widget(error, popup_chunks[1]);
         }
 
         f.render_widget(

--- a/src/ui/dialog/bookmark_set.rs
+++ b/src/ui/dialog/bookmark_set.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use ansi_to_tui::IntoText;
 use anyhow::Result;
 use ratatui::crossterm::event::Event;
@@ -18,8 +20,10 @@ use ratatui::widgets::Clear;
 use ratatui::widgets::List;
 use ratatui::widgets::ListState;
 use ratatui::widgets::Paragraph;
+use ratatui_textarea::CursorMove;
 use ratatui_textarea::TextArea;
 
+use crate::app::command::BookmarkSetDialog;
 use crate::app::command::Command;
 use crate::commander::bookmarks::Bookmark;
 use crate::commander::ids::ChangeId;
@@ -34,6 +38,7 @@ use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
 use crate::ui::styles::create_popup_block;
+use crate::ui::styles::refusal;
 use crate::ui::utils::centered_rect;
 use crate::ui::utils::centered_rect_line_height;
 use crate::ui::utils::mark_key;
@@ -54,6 +59,8 @@ pub struct BookmarkSetPopup<'a> {
     list_height: u16,
     config: JjConfig,
     creating: Option<TextArea<'a>>,
+    /// What was said about the name that was refused, shown alongside it.
+    error: Option<String>,
     keybinds: PopupKeybinds,
     name_keybinds: PopupKeybinds,
     own_keybinds: BookmarkSetPopupKeybinds,
@@ -111,9 +118,29 @@ impl BookmarkSetPopup<'_> {
             config,
             commit_id,
             creating: None,
+            error: None,
             keybinds: PopupKeybinds::dialog(),
             name_keybinds: PopupKeybinds::text_line(),
             own_keybinds: BookmarkSetPopupKeybinds::new(),
+        }
+    }
+
+    /// The name field again with the name that was refused and what was
+    /// said about it, whether it was typed or picked.
+    pub fn refused(
+        config: JjConfig,
+        change_id: Option<ChangeId>,
+        commit_id: CommitId,
+        name: String,
+        err: impl Display,
+    ) -> Self {
+        let mut creating = TextArea::new(vec![name]);
+        creating.move_cursor(CursorMove::End);
+
+        Self {
+            creating: Some(creating),
+            error: Some(format!("{err:#}")),
+            ..Self::new(config, change_id, commit_id)
         }
     }
 
@@ -147,6 +174,10 @@ impl BookmarkSetPopup<'_> {
             AppAction::Run(Command::SetBookmark {
                 name,
                 commit_id: self.commit_id.clone(),
+                dialog: Some(Box::new(BookmarkSetDialog {
+                    config: self.config.clone(),
+                    change_id: self.change_id.clone(),
+                })),
             }),
         ]))
     }
@@ -170,16 +201,30 @@ impl Component for BookmarkSetPopup<'_> {
     fn draw(&mut self, f: &mut ratatui::prelude::Frame<'_>, area: Rect) -> Result<()> {
         if let Some(creating) = self.creating.as_ref() {
             let block = create_popup_block("Create bookmark");
-            let area = centered_rect_line_height(area, 30, 5);
+            // The width the popup is about to get, which the answer has
+            // to be wrapped to before we know how tall to make it.
+            let width = block.inner(centered_rect_line_height(area, 30, 0)).width;
+            let error = self.error.as_ref().map(|error| refusal(error, width));
+            let error_height = error.as_ref().map_or(0, |(_, height)| *height);
+
+            let area = centered_rect_line_height(area, 30, 5 + error_height);
             f.render_widget(Clear, area);
             f.render_widget(&block, area);
 
             let popup_chunks = Layout::default()
                 .direction(Direction::Vertical)
-                .constraints([Constraint::Fill(1), Constraint::Length(2)])
+                .constraints([
+                    Constraint::Fill(1),
+                    Constraint::Length(error_height),
+                    Constraint::Length(2),
+                ])
                 .split(block.inner(area));
 
             f.render_widget(creating, popup_chunks[0]);
+
+            if let Some((error, _)) = error {
+                f.render_widget(error, popup_chunks[1]);
+            }
 
             let help = Paragraph::new(vec![self.name_keybinds.hint("accept").into()])
                 .fg(Color::DarkGray)
@@ -191,7 +236,7 @@ impl Component for BookmarkSetPopup<'_> {
                         .border_style(Style::default().fg(Color::DarkGray)),
                 );
 
-            f.render_widget(help, popup_chunks[1]);
+            f.render_widget(help, popup_chunks[2]);
         } else {
             let block = Block::bordered()
                 .title(Span::styled(

--- a/src/ui/dialog/describe.rs
+++ b/src/ui/dialog/describe.rs
@@ -1,4 +1,5 @@
 use std::cmp::max;
+use std::fmt::Display;
 
 use anyhow::Result;
 use ratatui::Frame;
@@ -32,6 +33,7 @@ use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
 use crate::ui::Interactive;
+use crate::ui::styles::refusal;
 use crate::ui::utils::centered_rect_fixed;
 
 /// Put the user in front of an editor for `head`'s description, in whichever
@@ -53,9 +55,10 @@ pub fn describe_action(
     })
 }
 
-struct DescribePopup<'a> {
+pub struct DescribePopup<'a> {
     head: Head,
     textarea: TextArea<'a>,
+    error: Option<String>,
     keybinds: PopupKeybinds,
 }
 
@@ -66,7 +69,17 @@ impl DescribePopup<'_> {
         DescribePopup {
             head,
             textarea,
+            error: None,
             keybinds: PopupKeybinds::text(),
+        }
+    }
+
+    /// The editor again with the description that was refused and what
+    /// was said about it, so that it is not lost to a failed describe.
+    pub fn refused(head: Head, description: String, err: impl Display) -> DescribePopup<'static> {
+        DescribePopup {
+            error: Some(format!("{err:#}")),
+            ..Self::new(head, description.split('\n').map(str::to_owned).collect())
         }
     }
 }
@@ -81,20 +94,35 @@ impl Component for DescribePopup<'_> {
 
         const MAX_COMMIT_WIDTH: u16 = 72;
         const MIN_COMMIT_HEIGHT: u16 = 5;
+        let width = (MAX_COMMIT_WIDTH + 2).min(area.width);
+        let error = self
+            .error
+            .as_ref()
+            .map(|error| refusal(error, width.saturating_sub(2)));
+        let error_height = error.as_ref().map_or(0, |(_, height)| *height);
+
         let area = centered_rect_fixed(
             area,
-            MAX_COMMIT_WIDTH + 2,
-            max(MIN_COMMIT_HEIGHT + 4, area.height / 2),
+            width,
+            max(MIN_COMMIT_HEIGHT + 4 + error_height, area.height / 2),
         );
         f.render_widget(Clear, area);
         f.render_widget(&block, area);
 
         let popup_chunks = Layout::default()
             .direction(Direction::Vertical)
-            .constraints([Constraint::Fill(1), Constraint::Length(2)])
+            .constraints([
+                Constraint::Fill(1),
+                Constraint::Length(error_height),
+                Constraint::Length(2),
+            ])
             .split(block.inner(area));
 
         f.render_widget(&self.textarea, popup_chunks[0]);
+
+        if let Some((error, _)) = error {
+            f.render_widget(error, popup_chunks[1]);
+        }
 
         let help = Paragraph::new(vec![self.keybinds.hint("accept").into()])
             .fg(Color::DarkGray)
@@ -105,7 +133,7 @@ impl Component for DescribePopup<'_> {
                     .border_type(BorderType::Rounded)
                     .border_style(Style::default().fg(Color::DarkGray)),
             );
-        f.render_widget(help, popup_chunks[1]);
+        f.render_widget(help, popup_chunks[2]);
 
         Ok(())
     }
@@ -115,15 +143,14 @@ impl Component for DescribePopup<'_> {
             && key.kind == KeyEventKind::Press
         {
             match self.keybinds.match_event(key) {
+                // The popup stays up until the describe has gone
+                // through, so that a refused description is not lost.
                 PopupEvent::Accept => {
-                    return Ok(ComponentInputResult::HandledAction(AppAction::Multiple(
-                        vec![
-                            AppAction::ClosePopup,
-                            AppAction::Run(Command::Describe {
-                                head: self.head.clone(),
-                                description: self.textarea.lines().join("\n"),
-                            }),
-                        ],
+                    return Ok(ComponentInputResult::HandledAction(AppAction::Run(
+                        Command::Describe {
+                            head: self.head.clone(),
+                            description: self.textarea.lines().join("\n"),
+                        },
                     )));
                 }
                 PopupEvent::Cancel => {

--- a/src/ui/dialog/mod.rs
+++ b/src/ui/dialog/mod.rs
@@ -32,6 +32,7 @@ pub use context_menu::bookmarks_context_menu;
 pub use context_menu::evolog_context_menu;
 pub use context_menu::files_context_menu;
 pub use context_menu::log_context_menu;
+pub use describe::DescribePopup;
 pub use describe::describe_action;
 pub use help::HelpPopup;
 pub use loader::LoaderPopup;

--- a/src/ui/styles.rs
+++ b/src/ui/styles.rs
@@ -1,12 +1,16 @@
 use std::sync::LazyLock;
 
+use ansi_to_tui::IntoText;
 use ratatui::layout::Alignment;
 use ratatui::style::Color;
 use ratatui::style::Style;
 use ratatui::text::Span;
 use ratatui::widgets::Block;
 use ratatui::widgets::BorderType;
+use ratatui::widgets::Borders;
 use ratatui::widgets::Padding;
+use ratatui::widgets::Paragraph;
+use ratatui::widgets::Wrap;
 
 pub static POPUP_BLOCK: LazyLock<Block<'static>> = LazyLock::new(|| {
     Block::<'static>::bordered()
@@ -16,9 +20,39 @@ pub static POPUP_BLOCK: LazyLock<Block<'static>> = LazyLock::new(|| {
 });
 pub static POPUP_BLOCK_TITLE_STYLE: LazyLock<Style> = LazyLock::new(|| Style::new().bold().cyan());
 
+/// What a popup puts under the field it asks in when what was typed was
+/// turned down: the answer, boxed off from the field and wrapped to
+/// `width`, and the rows it takes there.
+pub fn refusal(answer: &str, width: u16) -> (Paragraph<'static>, u16) {
+    let paragraph = Paragraph::new(answer.into_text().unwrap())
+        .wrap(Wrap { trim: false })
+        .block(
+            Block::default()
+                .borders(Borders::TOP)
+                .border_type(BorderType::Rounded)
+                .border_style(Style::default().fg(Color::DarkGray)),
+        );
+    let height = paragraph.line_count(width) as u16;
+
+    (paragraph, height)
+}
+
 pub fn create_popup_block(title: &str) -> Block<'_> {
     POPUP_BLOCK
         .clone()
         .title(Span::styled(format!(" {title} "), *POPUP_BLOCK_TITLE_STYLE))
         .title_alignment(Alignment::Center)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_refusal_is_as_tall_as_it_takes_at_the_width_it_gets() {
+        // Three lines of ten, plus the row the border is on.
+        let (_, height) = refusal("aaaa bbbb cccc dddd eeee ffff", 10);
+
+        assert_eq!(height, 4);
+    }
 }


### PR DESCRIPTION
The describe popup and the set-bookmark dialog take themselves down as
they hand what was typed over, so jj's answer arrives in place of a
field that is already gone: the description or the bookmark name is
lost and has to be written again from scratch. The bookmark name popup
already does the right thing and puts the question back with the answer
under it, so we do the same for the other two.

That answer is laid out without wrapping and without room for the rows
wrapping would take, so a long one is cut off at the right edge. Fix
that first, in a helper the three popups share.