### PR TITLE
ui: Copy details panel text with the mouse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Text in the details panel can be marked by dragging the mouse over it,
+  by double clicking a word or by triple clicking a line, and goes to the
+  system clipboard when the button comes up. A line the panel wrapped or
+  cut off to show is copied as the one whole line it is
 - Diff format rendering the Git format with a pager like
   [delta](https://github.com/dandavison/delta), configured as
   `blazingjj.diff-pager` and toggled through with `w` like the others

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Built in Rust with Ratatui. Interacts with `jj` CLI.
   - Render the git diff with a pager like delta by configuring
     `blazingjj.diff-pager`
 - Mouse: scroll the panels, click to select, drag the divider to resize, right
-  click for the context menu
+  click for the context menu, drag over the details panel (or double click a
+  word, triple click a line) to copy its text
 - Config: Configure blazingjj with your jj config
 - Command box: Run jj commands directly in blazingjj with `:`
 - Help: See all key mappings with `?`

--- a/src/app.rs
+++ b/src/app.rs
@@ -35,6 +35,7 @@ use crate::commander::ids::OperationId;
 use crate::commander::new_commander;
 use crate::env::get_env;
 use crate::event::AppEvent;
+use crate::event::Clicks;
 use crate::event::EventSource;
 use crate::event::Mouse;
 use crate::keybinds::GlobalEvent;
@@ -119,6 +120,9 @@ pub struct App<'a> {
 
     // event handling
     running: Arc<AtomicBool>,
+    /// Counts the clicks of the mouse events on their way to the
+    /// components
+    clicks: Clicks,
     event_source: EventSource,
     background_tasks: BackgroundTasks,
 }
@@ -153,6 +157,7 @@ impl<'a> App<'a> {
             pending_interactive: None,
 
             running,
+            clicks: Clicks::default(),
             event_source,
             background_tasks,
         })
@@ -545,7 +550,7 @@ impl<'a> App<'a> {
     /// Whether something on screen counts up on its own, so that the main
     /// loop has to come back on a timer rather than only on an event.
     pub fn needs_periodic_redraw(&mut self) -> bool {
-        self.popup.is_some() || self.get_current_tab().is_waiting()
+        self.popup.is_some() || self.get_current_tab().needs_periodic_redraw()
     }
 
     /// Hand the output of a finished task to whoever asked for it
@@ -630,8 +635,8 @@ impl<'a> App<'a> {
         trace!("Processing user input");
 
         if let TermEvent::Mouse(mouse) = event {
-            let position = Position::new(mouse.column, mouse.row);
-            return self.input_mouse(Mouse::new(mouse.kind, position));
+            let mouse = self.clicks.count(mouse);
+            return self.input_mouse(mouse);
         }
 
         match event {

--- a/src/app.rs
+++ b/src/app.rs
@@ -36,6 +36,7 @@ use crate::commander::new_commander;
 use crate::env::get_env;
 use crate::event::AppEvent;
 use crate::event::EventSource;
+use crate::event::Mouse;
 use crate::keybinds::GlobalEvent;
 use crate::keybinds::GlobalKeybinds;
 use crate::keybinds::HelpSection;
@@ -495,9 +496,9 @@ impl<'a> App<'a> {
     }
 
     /// Whether the mouse event went to the tabs overview.
-    fn input_tabs(&mut self, mouse: event::MouseEvent) -> bool {
-        let position = Position::new(mouse.column, mouse.row);
-        match mouse.kind {
+    fn input_tabs(&mut self, mouse: Mouse) -> bool {
+        let position = mouse.position();
+        match mouse.kind() {
             event::MouseEventKind::Down(event::MouseButton::Left) => {
                 let Some((_, tab)) = self
                     .tab_hits
@@ -579,6 +580,43 @@ impl<'a> App<'a> {
         Ok(Handled::Redraw)
     }
 
+    /// Offer what the mouse did to whatever is on screen, from the top
+    /// down.
+    fn input_mouse(&mut self, mouse: Mouse) -> Result<Handled> {
+        let mut to_tab = self.popup.is_none();
+        if let Some(popup) = self.popup.as_mut() {
+            match popup.input_mouse(mouse)? {
+                ComponentInputResult::HandledAction(app_action) => {
+                    self.handle_action(app_action)?
+                }
+                ComponentInputResult::Handled | ComponentInputResult::NotHandled => {}
+                ComponentInputResult::Dismissed => {
+                    self.popup = None;
+                    to_tab = true;
+                }
+            }
+        }
+
+        if !to_tab {
+            return Ok(Handled::Redraw);
+        }
+
+        if self.input_tabs(mouse) {
+            return Ok(Handled::Redraw);
+        }
+
+        match self.get_current_tab().input_mouse(mouse)? {
+            ComponentInputResult::HandledAction(app_action) => self.handle_action(app_action)?,
+            // A tab is never on top of anything, so it has nothing to
+            // dismiss itself in favour of.
+            ComponentInputResult::Handled
+            | ComponentInputResult::Dismissed
+            | ComponentInputResult::NotHandled => {}
+        }
+
+        Ok(Handled::Redraw)
+    }
+
     /// Process an AppEvent
     #[instrument(level = "trace", skip(self))]
     pub fn input(&mut self, event: AppEvent) -> Result<Handled> {
@@ -590,6 +628,11 @@ impl<'a> App<'a> {
             }
         };
         trace!("Processing user input");
+
+        if let TermEvent::Mouse(mouse) = event {
+            let position = Position::new(mouse.column, mouse.row);
+            return self.input_mouse(Mouse::new(mouse.kind, position));
+        }
 
         match event {
             // Coming back to the window is worth a check, as the repo
@@ -632,13 +675,6 @@ impl<'a> App<'a> {
                     }
                 }
             };
-        }
-
-        if to_tab
-            && let TermEvent::Mouse(mouse) = event
-            && self.input_tabs(mouse)
-        {
-            return Ok(Handled::Redraw);
         }
 
         if to_tab {

--- a/src/event.rs
+++ b/src/event.rs
@@ -3,6 +3,8 @@
 //! for file system notifications in case somebody used jj on this
 //! repository.
 
+mod mouse;
+
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
@@ -11,6 +13,7 @@ use std::thread;
 use std::thread::JoinHandle;
 use std::time::Duration;
 
+pub use mouse::Mouse;
 use ratatui::crossterm;
 use tracing::error;
 use tracing::trace;

--- a/src/event.rs
+++ b/src/event.rs
@@ -13,6 +13,8 @@ use std::thread;
 use std::thread::JoinHandle;
 use std::time::Duration;
 
+pub use mouse::CLICK_PAUSE;
+pub use mouse::Clicks;
 pub use mouse::Mouse;
 use ratatui::crossterm;
 use tracing::error;

--- a/src/event/mouse.rs
+++ b/src/event/mouse.rs
@@ -1,0 +1,25 @@
+//! The mouse as the app takes it, rather than as the terminal reports it.
+
+use ratatui::crossterm::event::MouseEventKind;
+use ratatui::layout::Position;
+
+/// What the mouse did, and the cell it did it on.
+#[derive(Clone, Copy, Debug)]
+pub struct Mouse {
+    kind: MouseEventKind,
+    position: Position,
+}
+
+impl Mouse {
+    pub fn new(kind: MouseEventKind, position: Position) -> Self {
+        Self { kind, position }
+    }
+
+    pub fn kind(&self) -> MouseEventKind {
+        self.kind
+    }
+
+    pub fn position(&self) -> Position {
+        self.position
+    }
+}

--- a/src/event/mouse.rs
+++ b/src/event/mouse.rs
@@ -1,18 +1,68 @@
-//! The mouse as the app takes it, rather than as the terminal reports it.
+/*! What the terminal says about the mouse, and what it does not.
 
+A terminal reports every press on its own, so telling a double or a
+triple click from the clicks it is made of is up to us. [Clicks] does
+that counting, once, for every event on its way into the app, and hands
+on a [Mouse] that says how many presses in a row it belongs to.
+*/
+
+use std::time::Duration;
+use std::time::Instant;
+
+use ratatui::crossterm::event::MouseButton;
+use ratatui::crossterm::event::MouseEvent;
 use ratatui::crossterm::event::MouseEventKind;
 use ratatui::layout::Position;
 
-/// What the mouse did, and the cell it did it on.
+/// How long apart two presses are still one double click. Whoever acts
+/// on a click rather than on the drag that may follow it has to let this
+/// much go by before it can tell that no further click widens it.
+pub const CLICK_PAUSE: Duration = Duration::from_millis(400);
+
+/// What the mouse did, with the presses before it counted.
 #[derive(Clone, Copy, Debug)]
 pub struct Mouse {
     kind: MouseEventKind,
     position: Position,
+    /// How many presses in a row the button is on: 1 for a click of its
+    /// own, 2 for a double click, 3 for a triple click, and 0 for an
+    /// event that is not about a button at all
+    clicks: u8,
+}
+
+/// The press a mouse event belongs to, as far as counting goes.
+#[derive(Clone, Copy)]
+struct Press {
+    /// Cell the button went down on
+    at: Position,
+    /// Button that went down
+    button: MouseButton,
+    /// When it went down
+    when: Instant,
+    /// How many presses in a row it was
+    count: u8,
+    /// Whether the mouse moved with the button down, which ends the run
+    /// of clicks: what follows a drag is a press of its own
+    dragged: bool,
+}
+
+/// Counts the presses that come on one cell, close enough together in
+/// time, to be one double or triple click. A fourth press starts over.
+#[derive(Default)]
+pub struct Clicks {
+    press: Option<Press>,
 }
 
 impl Mouse {
-    pub fn new(kind: MouseEventKind, position: Position) -> Self {
-        Self { kind, position }
+    /// A mouse event of a kind on a cell, as the `clicks`th press in a
+    /// row, for a test that has no terminal event to hand.
+    #[cfg(test)]
+    pub fn new(kind: MouseEventKind, position: Position, clicks: u8) -> Self {
+        Self {
+            kind,
+            position,
+            clicks,
+        }
     }
 
     pub fn kind(&self) -> MouseEventKind {
@@ -21,5 +71,194 @@ impl Mouse {
 
     pub fn position(&self) -> Position {
         self.position
+    }
+
+    /// How many presses in a row the button this event is about is on.
+    /// An event about no button, like the wheel turning, is on none.
+    pub fn clicks(&self) -> u8 {
+        self.clicks
+    }
+
+    /// What `event` says the mouse did, as the `clicks`th press in a row.
+    fn of(event: MouseEvent, clicks: u8) -> Self {
+        Self {
+            kind: event.kind,
+            position: Position::new(event.column, event.row),
+            clicks,
+        }
+    }
+}
+
+impl Clicks {
+    /// The event with the presses before it counted. What a press is the
+    /// second or third of counts for the release and the drag that
+    /// follow it as well, so that whoever acts on those knows what they
+    /// are part of.
+    pub fn count(&mut self, event: MouseEvent) -> Mouse {
+        self.count_at(event, Instant::now())
+    }
+
+    /// The same, for a caller that says when the event came in.
+    fn count_at(&mut self, event: MouseEvent, now: Instant) -> Mouse {
+        let at = Position::new(event.column, event.row);
+        let clicks = match event.kind {
+            MouseEventKind::Down(button) => {
+                let count = match self.press {
+                    Some(press)
+                        if press.button == button
+                            && press.at == at
+                            && now.duration_since(press.when) < CLICK_PAUSE
+                            && press.count < 3
+                            && !press.dragged =>
+                    {
+                        press.count + 1
+                    }
+                    _ => 1,
+                };
+                self.press = Some(Press {
+                    at,
+                    button,
+                    when: now,
+                    count,
+                    dragged: false,
+                });
+                count
+            }
+            MouseEventKind::Drag(button) => {
+                let Some(press) = self.press.filter(|press| press.button == button) else {
+                    return Mouse::of(event, 0);
+                };
+                self.press = Some(Press {
+                    dragged: true,
+                    ..press
+                });
+                press.count
+            }
+            MouseEventKind::Up(button) => self
+                .press
+                .filter(|press| press.button == button)
+                .map_or(0, |press| press.count),
+            _ => 0,
+        };
+
+        Mouse::of(event, clicks)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::crossterm::event::KeyModifiers;
+
+    use super::*;
+
+    const AT: Position = Position { x: 4, y: 2 };
+
+    fn event(kind: MouseEventKind, at: Position) -> MouseEvent {
+        MouseEvent {
+            kind,
+            column: at.x,
+            row: at.y,
+            modifiers: KeyModifiers::NONE,
+        }
+    }
+
+    fn press(clicks: &mut Clicks, at: Position) -> u8 {
+        let down = clicks.count(event(MouseEventKind::Down(MouseButton::Left), at));
+        clicks.count(event(MouseEventKind::Up(MouseButton::Left), at));
+        down.clicks()
+    }
+
+    #[test]
+    fn presses_in_a_row_on_a_cell_are_one_click_after_another() {
+        let mut clicks = Clicks::default();
+
+        assert_eq!(press(&mut clicks, AT), 1);
+        assert_eq!(press(&mut clicks, AT), 2);
+        assert_eq!(press(&mut clicks, AT), 3);
+    }
+
+    /// Three clicks is as much as anything asks for, so the fourth is a
+    /// new click rather than a fourth of a kind.
+    #[test]
+    fn a_fourth_press_starts_over() {
+        let mut clicks = Clicks::default();
+
+        for _ in 0..3 {
+            press(&mut clicks, AT);
+        }
+
+        assert_eq!(press(&mut clicks, AT), 1);
+    }
+
+    /// Two presses with a pause between them are two clicks, however
+    /// little the mouse moved between them.
+    #[test]
+    fn a_press_after_the_pause_is_a_click_of_its_own() {
+        let mut clicks = Clicks::default();
+        let when = Instant::now();
+        clicks.count_at(event(MouseEventKind::Down(MouseButton::Left), AT), when);
+        clicks.count_at(event(MouseEventKind::Up(MouseButton::Left), AT), when);
+
+        let later = when + CLICK_PAUSE;
+        let down = clicks.count_at(event(MouseEventKind::Down(MouseButton::Left), AT), later);
+
+        assert_eq!(down.clicks(), 1);
+    }
+
+    #[test]
+    fn a_press_elsewhere_is_a_click_of_its_own() {
+        let mut clicks = Clicks::default();
+        press(&mut clicks, AT);
+
+        assert_eq!(press(&mut clicks, Position { x: 5, y: 2 }), 1);
+    }
+
+    #[test]
+    fn a_press_of_another_button_is_a_click_of_its_own() {
+        let mut clicks = Clicks::default();
+        press(&mut clicks, AT);
+
+        let right = clicks.count(event(MouseEventKind::Down(MouseButton::Right), AT));
+
+        assert_eq!(right.clicks(), 1);
+    }
+
+    /// A drag is a gesture of its own, so what comes after it is the
+    /// first press of whatever comes next rather than the third of what
+    /// went before.
+    #[test]
+    fn a_press_after_a_drag_is_a_click_of_its_own() {
+        let mut clicks = Clicks::default();
+        press(&mut clicks, AT);
+        clicks.count(event(MouseEventKind::Down(MouseButton::Left), AT));
+        clicks.count(event(MouseEventKind::Drag(MouseButton::Left), AT));
+        clicks.count(event(MouseEventKind::Up(MouseButton::Left), AT));
+
+        assert_eq!(press(&mut clicks, AT), 1);
+    }
+
+    /// The release belongs to the press it ends, so what acts on it
+    /// knows whether it ends a double click.
+    #[test]
+    fn a_release_is_part_of_the_press_it_ends() {
+        let mut clicks = Clicks::default();
+        press(&mut clicks, AT);
+        clicks.count(event(MouseEventKind::Down(MouseButton::Left), AT));
+
+        let up = clicks.count(event(MouseEventKind::Up(MouseButton::Left), AT));
+        let drag = clicks.count(event(MouseEventKind::Drag(MouseButton::Left), AT));
+
+        assert_eq!(up.clicks(), 2);
+        assert_eq!(drag.clicks(), 2);
+    }
+
+    #[test]
+    fn the_wheel_is_about_no_button() {
+        let mut clicks = Clicks::default();
+        press(&mut clicks, AT);
+
+        let wheel = clicks.count(event(MouseEventKind::ScrollDown, AT));
+
+        assert_eq!(wheel.clicks(), 0);
     }
 }

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -22,6 +22,7 @@ use crate::commander::new_commander;
 use crate::commander::revset::Revset;
 use crate::env::JjConfig;
 use crate::env::get_env;
+use crate::event::Mouse;
 use crate::keybinds::BookmarksTabEvent;
 use crate::keybinds::BookmarksTabKeybinds;
 use crate::keybinds::DetailsPanelEvent;
@@ -579,39 +580,38 @@ impl Component for BookmarksTab {
             };
         }
 
-        if let Event::Mouse(mouse) = event {
-            if self.pane_divider.handle_mouse(mouse, self.config.layout()) {
-                return Ok(ComponentInputResult::Handled);
-            }
-            match route_mouse(
-                mouse,
-                &mut [&mut self.bookmarks_pane, &mut self.bookmark_panel],
-            ) {
-                MouseInput::Scroll(delta) => self.scroll_bookmarks(delta),
-                MouseInput::Select(index) => {
-                    let bookmarks = self.bookmarks_output.as_deref().unwrap_or_default();
-                    if let Some(bookmark) = bookmarks.get(index).cloned() {
-                        self.bookmark = Some(bookmark);
-                        self.show_bookmark();
-                    }
-                }
-                // The bookmarks that cannot be parsed are listed as they
-                // are, and name none for a menu to act on.
-                MouseInput::Context(index) => {
-                    let bookmarks = self.bookmarks_output.as_deref().unwrap_or_default();
-                    if let Some(bookmark) = bookmarks.get(index).cloned() {
-                        self.bookmark = Some(bookmark);
-                        self.show_bookmark();
-                        let anchor = Position::new(mouse.column, mouse.row);
-                        return Ok(self.context_menu(Some(anchor)).into());
-                    }
-                }
-                MouseInput::Handled => {}
-                MouseInput::NotHandled => return Ok(ComponentInputResult::NotHandled),
-            }
+        Ok(ComponentInputResult::Handled)
+    }
+
+    fn input_mouse(&mut self, mouse: Mouse) -> Result<ComponentInputResult> {
+        if self.pane_divider.handle_mouse(mouse, self.config.layout()) {
             return Ok(ComponentInputResult::Handled);
         }
-
+        match route_mouse(
+            mouse,
+            &mut [&mut self.bookmarks_pane, &mut self.bookmark_panel],
+        ) {
+            MouseInput::Scroll(delta) => self.scroll_bookmarks(delta),
+            MouseInput::Select(index) => {
+                let bookmarks = self.bookmarks_output.as_deref().unwrap_or_default();
+                if let Some(bookmark) = bookmarks.get(index).cloned() {
+                    self.bookmark = Some(bookmark);
+                    self.show_bookmark();
+                }
+            }
+            // The bookmarks that cannot be parsed are listed as they
+            // are, and name none for a menu to act on.
+            MouseInput::Context(index) => {
+                let bookmarks = self.bookmarks_output.as_deref().unwrap_or_default();
+                if let Some(bookmark) = bookmarks.get(index).cloned() {
+                    self.bookmark = Some(bookmark);
+                    self.show_bookmark();
+                    return Ok(self.context_menu(Some(mouse.position())).into());
+                }
+            }
+            MouseInput::Handled => {}
+            MouseInput::NotHandled => return Ok(ComponentInputResult::NotHandled),
+        }
         Ok(ComponentInputResult::Handled)
     }
 }

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -38,6 +38,7 @@ use crate::ui::dialog::bookmarks_context_menu;
 use crate::ui::panel::CommitShowPanel;
 use crate::ui::panel::ListPane;
 use crate::ui::panel::MouseInput;
+use crate::ui::panel::copy_marked;
 use crate::ui::panel::route_mouse;
 use crate::ui::utils::PaneDivider;
 
@@ -460,8 +461,8 @@ impl Component for BookmarksTab {
         Ok(None)
     }
 
-    fn is_waiting(&self) -> bool {
-        self.bookmark_panel.is_waiting()
+    fn needs_periodic_redraw(&self) -> bool {
+        self.bookmark_panel.needs_periodic_redraw()
     }
 
     fn draw(
@@ -609,6 +610,7 @@ impl Component for BookmarksTab {
                     return Ok(self.context_menu(Some(mouse.position())).into());
                 }
             }
+            MouseInput::Copy(text) => return Ok(copy_marked(text)),
             MouseInput::Handled => {}
             MouseInput::NotHandled => return Ok(ComponentInputResult::NotHandled),
         }

--- a/src/ui/dialog/choice.rs
+++ b/src/ui/dialog/choice.rs
@@ -26,6 +26,7 @@ use ratatui::widgets::ListState;
 use ratatui::widgets::Paragraph;
 
 use crate::env::JjConfig;
+use crate::event::Mouse;
 use crate::keybinds::PopupEvent;
 use crate::keybinds::PopupKeybinds;
 use crate::ui::AppAction;
@@ -198,8 +199,8 @@ impl Component for ChoicePopup {
     }
 
     fn input(&mut self, event: Event) -> Result<ComponentInputResult> {
-        match event {
-            Event::Key(key) => match self.keybinds.match_event(key) {
+        if let Event::Key(key) = event {
+            match self.keybinds.match_event(key) {
                 PopupEvent::ScrollDown => self.scroll(1),
                 PopupEvent::ScrollUp => self.scroll(-1),
                 PopupEvent::ScrollDownHalf => self.scroll(self.list_area.height as isize / 2),
@@ -213,35 +214,39 @@ impl Component for ChoicePopup {
                 PopupEvent::Accept => return self.confirm(),
                 PopupEvent::Cancel => return Self::close(),
                 PopupEvent::Unbound => {}
-            },
-            // Where the popup sits is only known once it has been drawn,
-            // and events are handled in batches without a draw between
-            // them, so the one that opened us may be in this very batch.
-            Event::Mouse(mouse) if !self.popup_area.is_empty() => {
-                let pos = Position::new(mouse.column, mouse.row);
-                match mouse.kind {
-                    MouseEventKind::ScrollUp => self.scroll(-1),
-                    MouseEventKind::ScrollDown => self.scroll(1),
-                    MouseEventKind::Down(MouseButton::Left) => {
-                        if !self.popup_area.contains(pos) {
-                            return Self::close();
-                        }
-                        if let Some(index) = self.item_at(pos) {
-                            self.list_state.select(Some(index));
-                            return self.confirm();
-                        }
-                    }
-                    // A right click outside still names what it hit, so
-                    // we let it through rather than only taking it as a
-                    // dismissal.
-                    MouseEventKind::Down(MouseButton::Right) => {
-                        if self.popup_area.contains(pos) {
-                            return Self::close();
-                        }
-                        return Ok(ComponentInputResult::Dismissed);
-                    }
-                    _ => {}
+            }
+        }
+        Ok(ComponentInputResult::Handled)
+    }
+
+    fn input_mouse(&mut self, mouse: Mouse) -> Result<ComponentInputResult> {
+        // Where the popup sits is only known once it has been drawn, and
+        // events are handled in batches without a draw between them, so
+        // the one that opened us may be in this very batch.
+        if self.popup_area.is_empty() {
+            return Ok(ComponentInputResult::Handled);
+        }
+
+        let pos = mouse.position();
+        match mouse.kind() {
+            MouseEventKind::ScrollUp => self.scroll(-1),
+            MouseEventKind::ScrollDown => self.scroll(1),
+            MouseEventKind::Down(MouseButton::Left) => {
+                if !self.popup_area.contains(pos) {
+                    return Self::close();
                 }
+                if let Some(index) = self.item_at(pos) {
+                    self.list_state.select(Some(index));
+                    return self.confirm();
+                }
+            }
+            // A right click outside still names what it hit, so we let
+            // it through rather than only taking it as a dismissal.
+            MouseEventKind::Down(MouseButton::Right) => {
+                if self.popup_area.contains(pos) {
+                    return Self::close();
+                }
+                return Ok(ComponentInputResult::Dismissed);
             }
             _ => {}
         }
@@ -254,8 +259,6 @@ pub(super) mod tests {
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
     use ratatui::crossterm::event::KeyCode;
-    use ratatui::crossterm::event::KeyModifiers;
-    use ratatui::crossterm::event::MouseEvent;
 
     use super::*;
     use crate::commander::ids::ChangeId;
@@ -340,12 +343,7 @@ pub(super) mod tests {
         row: u16,
     ) -> ComponentInputResult {
         popup
-            .input(Event::Mouse(MouseEvent {
-                kind,
-                column,
-                row,
-                modifiers: KeyModifiers::NONE,
-            }))
+            .input_mouse(Mouse::new(kind, Position::new(column, row)))
             .expect("the popup handles mouse events")
     }
 

--- a/src/ui/dialog/choice.rs
+++ b/src/ui/dialog/choice.rs
@@ -343,7 +343,7 @@ pub(super) mod tests {
         row: u16,
     ) -> ComponentInputResult {
         popup
-            .input_mouse(Mouse::new(kind, Position::new(column, row)))
+            .input_mouse(Mouse::new(kind, Position::new(column, row), 1))
             .expect("the popup handles mouse events")
     }
 

--- a/src/ui/dialog/help.rs
+++ b/src/ui/dialog/help.rs
@@ -18,6 +18,7 @@ use ratatui::widgets::ScrollbarOrientation;
 use ratatui::widgets::ScrollbarState;
 use ratatui::widgets::Table;
 
+use crate::event::Mouse;
 use crate::keybinds::HelpSection;
 use crate::keybinds::PopupEvent;
 use crate::keybinds::PopupKeybinds;
@@ -346,17 +347,20 @@ impl Component for HelpPopup {
                 self.do_scroll(delta);
                 Ok(ComponentInputResult::Handled)
             }
-            Event::Mouse(mouse) => match mouse.kind {
-                MouseEventKind::ScrollDown => {
-                    self.do_scroll(3);
-                    Ok(ComponentInputResult::Handled)
-                }
-                MouseEventKind::ScrollUp => {
-                    self.do_scroll(-3);
-                    Ok(ComponentInputResult::Handled)
-                }
-                _ => Ok(ComponentInputResult::NotHandled),
-            },
+            _ => Ok(ComponentInputResult::NotHandled),
+        }
+    }
+
+    fn input_mouse(&mut self, mouse: Mouse) -> anyhow::Result<ComponentInputResult> {
+        match mouse.kind() {
+            MouseEventKind::ScrollDown => {
+                self.do_scroll(3);
+                Ok(ComponentInputResult::Handled)
+            }
+            MouseEventKind::ScrollUp => {
+                self.do_scroll(-3);
+                Ok(ComponentInputResult::Handled)
+            }
             _ => Ok(ComponentInputResult::NotHandled),
         }
     }
@@ -365,8 +369,7 @@ impl Component for HelpPopup {
 #[cfg(test)]
 mod tests {
     use ratatui::crossterm::event::KeyCode;
-    use ratatui::crossterm::event::KeyModifiers;
-    use ratatui::crossterm::event::MouseEvent;
+    use ratatui::layout::Position;
 
     use super::*;
 
@@ -383,13 +386,8 @@ mod tests {
         vec![("k".repeat(key_width), "d".repeat(description_width)); items]
     }
 
-    fn wheel(kind: MouseEventKind) -> Event {
-        Event::Mouse(MouseEvent {
-            kind,
-            column: 0,
-            row: 0,
-            modifiers: KeyModifiers::empty(),
-        })
+    fn wheel(kind: MouseEventKind) -> Mouse {
+        Mouse::new(kind, Position::ORIGIN)
     }
 
     #[test]
@@ -508,12 +506,12 @@ mod tests {
         popup.max_scroll = 10;
 
         popup
-            .input(wheel(MouseEventKind::ScrollDown))
+            .input_mouse(wheel(MouseEventKind::ScrollDown))
             .expect("scrolling down should be handled");
         assert_eq!(popup.scroll, 3);
 
         popup
-            .input(wheel(MouseEventKind::ScrollUp))
+            .input_mouse(wheel(MouseEventKind::ScrollUp))
             .expect("scrolling up should be handled");
         assert_eq!(popup.scroll, 0);
     }

--- a/src/ui/dialog/help.rs
+++ b/src/ui/dialog/help.rs
@@ -387,7 +387,7 @@ mod tests {
     }
 
     fn wheel(kind: MouseEventKind) -> Mouse {
-        Mouse::new(kind, Position::ORIGIN)
+        Mouse::new(kind, Position::ORIGIN, 0)
     }
 
     #[test]

--- a/src/ui/dialog/message.rs
+++ b/src/ui/dialog/message.rs
@@ -20,6 +20,7 @@ use ratatui::widgets::Scrollbar;
 use ratatui::widgets::ScrollbarOrientation;
 use ratatui::widgets::ScrollbarState;
 
+use crate::event::Mouse;
 use crate::keybinds::PopupEvent;
 use crate::keybinds::PopupKeybinds;
 use crate::ui::Component;
@@ -180,17 +181,20 @@ impl Component for MessagePopup<'_> {
                 self.do_scroll(delta);
                 Ok(ComponentInputResult::Handled)
             }
-            Event::Mouse(mouse) => match mouse.kind {
-                MouseEventKind::ScrollDown => {
-                    self.do_scroll(3);
-                    Ok(ComponentInputResult::Handled)
-                }
-                MouseEventKind::ScrollUp => {
-                    self.do_scroll(-3);
-                    Ok(ComponentInputResult::Handled)
-                }
-                _ => Ok(ComponentInputResult::NotHandled),
-            },
+            _ => Ok(ComponentInputResult::NotHandled),
+        }
+    }
+
+    fn input_mouse(&mut self, mouse: Mouse) -> Result<ComponentInputResult> {
+        match mouse.kind() {
+            MouseEventKind::ScrollDown => {
+                self.do_scroll(3);
+                Ok(ComponentInputResult::Handled)
+            }
+            MouseEventKind::ScrollUp => {
+                self.do_scroll(-3);
+                Ok(ComponentInputResult::Handled)
+            }
             _ => Ok(ComponentInputResult::NotHandled),
         }
     }

--- a/src/ui/evolog_tab.rs
+++ b/src/ui/evolog_tab.rs
@@ -36,6 +36,7 @@ use crate::ui::dialog::evolog_context_menu;
 use crate::ui::panel::EvologShowPanel;
 use crate::ui::panel::LogPanel;
 use crate::ui::panel::MouseInput;
+use crate::ui::panel::copy_marked;
 use crate::ui::panel::route_mouse;
 use crate::ui::utils::PaneDivider;
 
@@ -219,8 +220,8 @@ impl Component for EvologTab<'_> {
         Ok(None)
     }
 
-    fn is_waiting(&self) -> bool {
-        self.patch_panel.is_waiting()
+    fn needs_periodic_redraw(&self) -> bool {
+        self.patch_panel.needs_periodic_redraw()
     }
 
     fn draw(&mut self, f: &mut Frame<'_>, area: Rect) -> Result<()> {
@@ -278,6 +279,7 @@ impl Component for EvologTab<'_> {
                     return Ok(self.context_menu(Some(mouse.position())).into());
                 }
             }
+            MouseInput::Copy(text) => return Ok(copy_marked(text)),
             MouseInput::Handled => {}
             MouseInput::NotHandled => return Ok(ComponentInputResult::NotHandled),
         }

--- a/src/ui/evolog_tab.rs
+++ b/src/ui/evolog_tab.rs
@@ -21,6 +21,7 @@ use crate::commander::new_commander;
 use crate::commander::revset::Revset;
 use crate::env::JjConfig;
 use crate::env::get_env;
+use crate::event::Mouse;
 use crate::keybinds::DetailsPanelEvent;
 use crate::keybinds::DetailsPanelKeybinds;
 use crate::keybinds::EvologTabEvent;
@@ -253,34 +254,33 @@ impl Component for EvologTab<'_> {
             };
         }
 
-        if let Event::Mouse(mouse) = event {
-            if self.pane_divider.handle_mouse(mouse, self.config.layout()) {
-                return Ok(ComponentInputResult::Handled);
-            }
-            match route_mouse(mouse, &mut [&mut self.entry_panel, &mut self.patch_panel]) {
-                MouseInput::Scroll(delta) => self.scroll_entries(delta),
-                MouseInput::Select(index) => {
-                    if let Some(entry) = self.entry_panel.head_at_log_line(index) {
-                        self.entry_panel.set_head(entry);
-                        self.sync_entry_output();
-                    }
-                }
-                // The graph takes lines of its own, which name no version
-                // for a menu to act on.
-                MouseInput::Context(index) => {
-                    if let Some(entry) = self.entry_panel.head_at_log_line(index) {
-                        self.entry_panel.set_head_in_place(entry);
-                        self.sync_entry_output();
-                        let anchor = Position::new(mouse.column, mouse.row);
-                        return Ok(self.context_menu(Some(anchor)).into());
-                    }
-                }
-                MouseInput::Handled => {}
-                MouseInput::NotHandled => return Ok(ComponentInputResult::NotHandled),
-            }
+        Ok(ComponentInputResult::Handled)
+    }
+
+    fn input_mouse(&mut self, mouse: Mouse) -> Result<ComponentInputResult> {
+        if self.pane_divider.handle_mouse(mouse, self.config.layout()) {
             return Ok(ComponentInputResult::Handled);
         }
-
+        match route_mouse(mouse, &mut [&mut self.entry_panel, &mut self.patch_panel]) {
+            MouseInput::Scroll(delta) => self.scroll_entries(delta),
+            MouseInput::Select(index) => {
+                if let Some(entry) = self.entry_panel.head_at_log_line(index) {
+                    self.entry_panel.set_head(entry);
+                    self.sync_entry_output();
+                }
+            }
+            // The graph takes lines of its own, which name no version
+            // for a menu to act on.
+            MouseInput::Context(index) => {
+                if let Some(entry) = self.entry_panel.head_at_log_line(index) {
+                    self.entry_panel.set_head_in_place(entry);
+                    self.sync_entry_output();
+                    return Ok(self.context_menu(Some(mouse.position())).into());
+                }
+            }
+            MouseInput::Handled => {}
+            MouseInput::NotHandled => return Ok(ComponentInputResult::NotHandled),
+        }
         Ok(ComponentInputResult::Handled)
     }
 }

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -41,6 +41,7 @@ use crate::ui::panel::MouseInput;
 use crate::ui::panel::OutputKey;
 use crate::ui::panel::OutputPanel;
 use crate::ui::panel::OutputRequest;
+use crate::ui::panel::copy_marked;
 use crate::ui::panel::route_mouse;
 use crate::ui::utils::PaneDivider;
 use crate::ui::utils::error_text;
@@ -348,8 +349,8 @@ impl Component for FilesTab {
         Ok(None)
     }
 
-    fn is_waiting(&self) -> bool {
-        self.diff_panel.is_waiting()
+    fn needs_periodic_redraw(&self) -> bool {
+        self.diff_panel.needs_periodic_redraw()
     }
 
     fn draw(
@@ -499,6 +500,7 @@ impl Component for FilesTab {
                     return Ok(self.context_menu(Some(mouse.position())).into());
                 }
             }
+            MouseInput::Copy(text) => return Ok(copy_marked(text)),
             MouseInput::Handled => {}
             MouseInput::NotHandled => return Ok(ComponentInputResult::NotHandled),
         }

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -24,6 +24,7 @@ use crate::commander::new_commander;
 use crate::env::DiffFormat;
 use crate::env::JjConfig;
 use crate::env::get_env;
+use crate::event::Mouse;
 use crate::keybinds::DetailsPanelEvent;
 use crate::keybinds::DetailsPanelKeybinds;
 use crate::keybinds::FilesTabEvent;
@@ -470,38 +471,37 @@ impl Component for FilesTab {
             };
         }
 
-        if let Event::Mouse(mouse) = event {
-            if self.pane_divider.handle_mouse(mouse, self.config.layout()) {
-                return Ok(ComponentInputResult::Handled);
-            }
-            match route_mouse(mouse, &mut [&mut self.files_pane, &mut self.diff_panel]) {
-                MouseInput::Scroll(delta) => self.scroll_files(delta),
-                MouseInput::Select(index) => {
-                    if let Ok(files) = self.files_output.as_ref()
-                        && let Some(file) = files.get(index).cloned()
-                    {
-                        self.file = Some(file);
-                        self.show_diff();
-                    }
-                }
-                // The conflicts are listed below the files, and name no
-                // file for a menu to act on.
-                MouseInput::Context(index) => {
-                    if let Ok(files) = self.files_output.as_ref()
-                        && let Some(file) = files.get(index).cloned()
-                    {
-                        self.file = Some(file);
-                        self.show_diff();
-                        let anchor = Position::new(mouse.column, mouse.row);
-                        return Ok(self.context_menu(Some(anchor)).into());
-                    }
-                }
-                MouseInput::Handled => {}
-                MouseInput::NotHandled => return Ok(ComponentInputResult::NotHandled),
-            }
+        Ok(ComponentInputResult::Handled)
+    }
+
+    fn input_mouse(&mut self, mouse: Mouse) -> Result<ComponentInputResult> {
+        if self.pane_divider.handle_mouse(mouse, self.config.layout()) {
             return Ok(ComponentInputResult::Handled);
         }
-
+        match route_mouse(mouse, &mut [&mut self.files_pane, &mut self.diff_panel]) {
+            MouseInput::Scroll(delta) => self.scroll_files(delta),
+            MouseInput::Select(index) => {
+                if let Ok(files) = self.files_output.as_ref()
+                    && let Some(file) = files.get(index).cloned()
+                {
+                    self.file = Some(file);
+                    self.show_diff();
+                }
+            }
+            // The conflicts are listed below the files, and name no
+            // file for a menu to act on.
+            MouseInput::Context(index) => {
+                if let Ok(files) = self.files_output.as_ref()
+                    && let Some(file) = files.get(index).cloned()
+                {
+                    self.file = Some(file);
+                    self.show_diff();
+                    return Ok(self.context_menu(Some(mouse.position())).into());
+                }
+            }
+            MouseInput::Handled => {}
+            MouseInput::NotHandled => return Ok(ComponentInputResult::NotHandled),
+        }
         Ok(ComponentInputResult::Handled)
     }
 }

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -41,6 +41,7 @@ use crate::ui::dialog::parent_select;
 use crate::ui::panel::CommitShowPanel;
 use crate::ui::panel::LogPanel;
 use crate::ui::panel::MouseInput;
+use crate::ui::panel::copy_marked;
 use crate::ui::panel::route_mouse;
 use crate::ui::utils::PaneDivider;
 use crate::ui::utils::centered_rect_line_height;
@@ -413,8 +414,8 @@ impl Component for LogTab<'_> {
         Ok(None)
     }
 
-    fn is_waiting(&self) -> bool {
-        self.head_panel.is_waiting()
+    fn needs_periodic_redraw(&self) -> bool {
+        self.head_panel.needs_periodic_redraw()
     }
 
     fn draw(
@@ -537,6 +538,7 @@ impl Component for LogTab<'_> {
                     return Ok(self.context_menu(Some(mouse.position()))?.into());
                 }
             }
+            MouseInput::Copy(text) => return Ok(copy_marked(text)),
             MouseInput::Handled => {}
             MouseInput::NotHandled => return Ok(ComponentInputResult::NotHandled),
         }

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -21,6 +21,7 @@ use crate::commander::new_commander;
 use crate::commander::revset::Revset;
 use crate::env::JjConfig;
 use crate::env::get_env;
+use crate::event::Mouse;
 use crate::keybinds::DetailsPanelEvent;
 use crate::keybinds::DetailsPanelKeybinds;
 use crate::keybinds::HelpItem;
@@ -513,40 +514,33 @@ impl Component for LogTab<'_> {
             };
         }
 
-        if let Event::Mouse(mouse_event) = event {
-            if self
-                .pane_divider
-                .handle_mouse(mouse_event, self.config.layout())
-            {
-                return Ok(ComponentInputResult::Handled);
-            }
-            match route_mouse(
-                mouse_event,
-                &mut [&mut self.log_panel, &mut self.head_panel],
-            ) {
-                MouseInput::Scroll(delta) => self.log_panel.scroll_relative(delta),
-                MouseInput::Select(index) => {
-                    if let Some(head) = self.log_panel.head_at_log_line(index) {
-                        self.log_panel.set_head(head);
-                    }
-                }
-                // The graph takes lines of its own, which name no change
-                // for a menu to act on.
-                MouseInput::Context(index) => {
-                    if let Some(head) = self.log_panel.head_at_log_line(index) {
-                        self.log_panel.set_head_in_place(head);
-                        self.sync_head_output();
-                        let anchor = Position::new(mouse_event.column, mouse_event.row);
-                        return Ok(self.context_menu(Some(anchor))?.into());
-                    }
-                }
-                MouseInput::Handled => {}
-                MouseInput::NotHandled => return Ok(ComponentInputResult::NotHandled),
-            }
-            self.sync_head_output();
+        Ok(ComponentInputResult::Handled)
+    }
+
+    fn input_mouse(&mut self, mouse: Mouse) -> Result<ComponentInputResult> {
+        if self.pane_divider.handle_mouse(mouse, self.config.layout()) {
             return Ok(ComponentInputResult::Handled);
         }
-
+        match route_mouse(mouse, &mut [&mut self.log_panel, &mut self.head_panel]) {
+            MouseInput::Scroll(delta) => self.log_panel.scroll_relative(delta),
+            MouseInput::Select(index) => {
+                if let Some(head) = self.log_panel.head_at_log_line(index) {
+                    self.log_panel.set_head(head);
+                }
+            }
+            // The graph takes lines of its own, which name no change
+            // for a menu to act on.
+            MouseInput::Context(index) => {
+                if let Some(head) = self.log_panel.head_at_log_line(index) {
+                    self.log_panel.set_head_in_place(head);
+                    self.sync_head_output();
+                    return Ok(self.context_menu(Some(mouse.position()))?.into());
+                }
+            }
+            MouseInput::Handled => {}
+            MouseInput::NotHandled => return Ok(ComponentInputResult::NotHandled),
+        }
+        self.sync_head_output();
         Ok(ComponentInputResult::Handled)
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -17,6 +17,7 @@ use crate::app::command::Command;
 use crate::background_tasks::TaskResult;
 use crate::commander::JjCommand;
 use crate::commander::log::Head;
+use crate::event::Mouse;
 use crate::keybinds::HelpItem;
 
 /// Action commmands from component to application
@@ -129,6 +130,12 @@ pub trait Component {
     fn draw(&mut self, f: &mut Frame<'_>, area: Rect) -> Result<()>;
 
     fn input(&mut self, _event: Event) -> Result<ComponentInputResult> {
+        Ok(ComponentInputResult::NotHandled)
+    }
+
+    /// Called with what the mouse did, in z-order from the top down,
+    /// until a component takes it.
+    fn input_mouse(&mut self, _mouse: Mouse) -> Result<ComponentInputResult> {
         Ok(ComponentInputResult::NotHandled)
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -121,9 +121,10 @@ pub trait Component {
         Ok(None)
     }
 
-    /// Whether the component is still waiting for a task result it wants.
-    /// While it is, the main loop keeps calling [Self::update].
-    fn is_waiting(&self) -> bool {
+    /// Whether what the component shows changes without anything
+    /// happening. While it does, the main loop draws on a timer rather
+    /// than only on an event.
+    fn needs_periodic_redraw(&self) -> bool {
         false
     }
 

--- a/src/ui/panel/details_panel.rs
+++ b/src/ui/panel/details_panel.rs
@@ -12,9 +12,18 @@ To make this efficient there are two implementations of DetailContent.
 
 */
 
+use std::time::Duration;
+use std::time::Instant;
+
+use ratatui::buffer::Buffer;
+use ratatui::crossterm::event::MouseButton;
 use ratatui::crossterm::event::MouseEventKind;
 use ratatui::layout::Margin;
+use ratatui::layout::Position;
 use ratatui::layout::Rect;
+use ratatui::style::Color;
+use ratatui::style::Modifier;
+use ratatui::style::Style;
 use ratatui::text::Line;
 use ratatui::text::Text;
 use ratatui::widgets::Block;
@@ -29,6 +38,7 @@ use tracing::trace;
 
 use super::MouseInput;
 use super::PanelMouseInput;
+use crate::event::CLICK_PAUSE;
 use crate::event::Mouse;
 use crate::keybinds::DetailsPanelEvent;
 use crate::ui::utils::LargeString;
@@ -42,16 +52,109 @@ pub struct DetailsPanel {
     content_rect: Rect,
     /// First line of content that is visible
     scroll: u16,
-    /// Total number of lines in content, including extra lines for wrapped lines.
+    /// Total number of lines in content, however many rows they take to
+    /// show.
     lines: u16,
     /// Wrap long lines of content into multiple lines
     wrap: bool,
+    /// What the mouse has marked to be copied
+    selection: Option<Selection>,
+    /// The symbol of each cell of `content_rect` in the last frame, by row
+    /// and column, which is where a marked column falls in its line
+    screen: Vec<Vec<String>>,
+    /// The lines of content the last frame showed, from the top of the
+    /// panel, as marking them copies them
+    source: Vec<String>,
+    /// What each row of the last frame shows of `source`
+    origins: Vec<RowOrigin>,
+    /// When text was last copied out of the panel, which it says for a
+    /// moment
+    copied: Option<Instant>,
+    /// When a click marked the cell it landed on, which stands only as
+    /// long as a further click could still widen it
+    marked: Option<Instant>,
+}
+
+/// What a row on screen shows of the line of content it is part of. A
+/// line the panel wraps takes several rows, and one it cuts off has more
+/// to it than the row shows.
+struct RowOrigin {
+    /// Index into the content on screen
+    line: usize,
+    /// Byte offset in that line where the row picks it up
+    start: usize,
+    /// Byte offset in that line where the row leaves off
+    end: usize,
+}
+
+/// A place in the content on screen.
+struct Spot {
+    /// Index into the content on screen
+    line: usize,
+    /// Byte offset in that line
+    at: usize,
+}
+
+/// Text marked with the mouse, to be copied when the button comes up.
+///
+/// What is marked are the cells on screen, so that marking follows the
+/// mouse. What is copied is the content behind them, so that a line the
+/// panel wrapped or cut off to show is not copied the way it looks.
+struct Selection {
+    /// Cell the button went down on
+    press: Position,
+    /// How much of what it is on a cell stands for
+    mode: Mode,
+    /// End the mark is anchored at, which is the press taken as `mode`
+    /// has it
+    anchor: Position,
+    /// End the drag has reached, taken as `mode` has it
+    cursor: Position,
+    /// Whether the mouse moved with the button down, so that no further
+    /// click can be part of this mark
+    dragged: bool,
+    /// Whether the button that made the mark is still down, so that the
+    /// drag and the release still to come belong to it
+    held: bool,
+}
+
+/// How much of the content a cell of a mark stands for, which is what
+/// the number of presses that began the mark asked for.
+#[derive(Clone, Copy)]
+enum Mode {
+    /// The cell itself
+    Cell,
+    /// The word it is on
+    Word,
+    /// The line it is on
+    Line,
+}
+
+/// How marked text is set apart from the rest.
+const SELECTED: Style = Style::new().add_modifier(Modifier::REVERSED);
+
+/// How long the panel says that it has copied something.
+const COPIED_SHOWN: Duration = Duration::from_millis(1500);
+
+/// What a double click takes to be part of a word. Change ids, revsets
+/// and paths are worth taking whole, so the punctuation inside them
+/// counts.
+fn is_word(symbol: &str) -> bool {
+    !symbol.is_empty()
+        && symbol
+            .chars()
+            .all(|c| c.is_alphanumeric() || "_-./".contains(c))
 }
 
 /// Content of the detail panel must be able to render as a paragraph
 pub trait DetailContent<'a> {
     /// Render content as a paragraph, and update panel total lines
     fn render_as_paragraph(&self, panel: &mut DetailsPanel, area: Rect) -> Paragraph<'_>;
+
+    /// `count` lines of the content from `top`, as the plain text they
+    /// read as. This is what marking them copies, so that a line the
+    /// panel has to wrap or cut off to show is still copied whole.
+    fn source_lines(&self, top: usize, count: usize) -> Vec<String>;
 }
 
 /// Content is preformatted ratatui Text
@@ -105,20 +208,48 @@ impl<'a> DetailContent<'a> for LargeStringContent<'a> {
         let content_text = self.large_string.render(top_line, line_count);
         Paragraph::new(content_text)
     }
+
+    fn source_lines(&self, top: usize, count: usize) -> Vec<String> {
+        self.large_string.plain_lines(top, count)
+    }
 }
 
 impl<'a> DetailContent<'a> for TextContent<'a> {
     fn render_as_paragraph(&self, panel: &mut DetailsPanel, area: Rect) -> Paragraph<'_> {
-        let content_text = &self.text;
-        let mut paragraph = Paragraph::new(content_text.clone());
-
         panel.content_rect = area;
-        panel.lines = paragraph.line_count(area.width) as u16;
+        panel.lines = self.text.lines.len() as u16;
         panel.clamp_scroll();
 
-        paragraph = paragraph.scroll((panel.scroll, 0));
+        // Cut the visible lines out rather than letting the paragraph
+        // scroll, which counts the rows a wrapped line takes and would
+        // leave the scroll position naming another line than it does for
+        // the scrollbar and for what marking copies
+        Paragraph::new(self.visible_lines(panel.scroll as usize, area.height as usize))
+    }
 
-        paragraph
+    fn source_lines(&self, top: usize, count: usize) -> Vec<String> {
+        self.text
+            .lines
+            .iter()
+            .skip(top)
+            .take(count)
+            .map(ToString::to_string)
+            .collect()
+    }
+}
+
+impl TextContent<'_> {
+    /// `count` lines of the content from `top`.
+    fn visible_lines(&self, top: usize, count: usize) -> Text<'_> {
+        Text::from(
+            self.text
+                .lines
+                .iter()
+                .skip(top)
+                .take(count)
+                .cloned()
+                .collect::<Vec<_>>(),
+        )
     }
 }
 
@@ -155,6 +286,7 @@ where
     pub fn draw(&mut self, f: &mut ratatui::prelude::Frame<'_>, area: ratatui::prelude::Rect) {
         // Remember last rendered rect for mouse event handling
         self.panel.panel_rect = area;
+        self.panel.fade();
 
         // Define border block
         let mut border = Block::bordered()
@@ -164,8 +296,14 @@ where
         if let Some(title) = &self.title {
             border = border.title_top(title.clone());
         }
-        if let Some(title) = &self.title_right {
-            border = border.title_top(title.clone().right_aligned());
+        // What was just copied is worth saying more than whatever the
+        // corner says the rest of the time
+        let title_right = self
+            .panel
+            .copied_note()
+            .or_else(|| self.title_right.clone());
+        if let Some(title) = title_right {
+            border = border.title_top(title.right_aligned());
         }
 
         // Create content widget that uses border
@@ -198,6 +336,55 @@ where
                 &mut scrollbar_state,
             );
         }
+
+        let source = self
+            .content
+            .source_lines(self.panel.scroll as usize, paragraph_area.height as usize);
+        self.panel.paint_selection(f.buffer_mut(), source);
+    }
+}
+
+impl Selection {
+    /// The mark a press on `at` begins, before any drag widens it.
+    fn new(at: Position, mode: Mode, ends: Option<(Position, Position)>) -> Self {
+        Self {
+            press: at,
+            mode,
+            anchor: ends.map_or(at, |(anchor, _)| anchor),
+            cursor: ends.map_or(at, |(_, cursor)| cursor),
+            dragged: false,
+            held: true,
+        }
+    }
+
+    /// Whether the mark stands for text rather than for the cell a press
+    /// landed on, which marks where a mark may come to be.
+    fn marks_text(&self) -> bool {
+        self.dragged || !matches!(self.mode, Mode::Cell)
+    }
+
+    /// The marked cells of each row, from the first to the last one, as
+    /// the row and the columns it is marked from and up to, both ends
+    /// included. Rows between the ends of the selection are marked all the
+    /// way across `area`, so that marking reads like it does in a
+    /// terminal rather than cutting out a rectangle.
+    fn rows(&self, area: Rect) -> impl Iterator<Item = (u16, u16, u16)> {
+        let cursor = self.cursor;
+        let (start, end) = if (self.anchor.y, self.anchor.x) <= (cursor.y, cursor.x) {
+            (self.anchor, cursor)
+        } else {
+            (cursor, self.anchor)
+        };
+
+        (start.y..=end.y).map(move |y| {
+            let from = if y == start.y { start.x } else { area.left() };
+            let to = if y == end.y {
+                end.x
+            } else {
+                area.right().saturating_sub(1)
+            };
+            (y, from, to)
+        })
     }
 }
 
@@ -209,7 +396,354 @@ impl DetailsPanel {
             scroll: 0,
             lines: 0,
             wrap: true,
+            selection: None,
+            screen: Vec::new(),
+            source: Vec::new(),
+            origins: Vec::new(),
+            copied: None,
+            marked: None,
         }
+    }
+
+    /// Whether the panel has something on screen that goes away on its
+    /// own.
+    pub fn is_flashing(&self) -> bool {
+        self.marked.is_some() || self.copied.is_some()
+    }
+
+    /// Take what has been on screen long enough off it. Only drawing may
+    /// do so, as being asked whether anything fades must not be what
+    /// makes it fade.
+    fn fade(&mut self) {
+        if self
+            .marked
+            .is_some_and(|marked| marked.elapsed() >= CLICK_PAUSE)
+        {
+            self.marked = None;
+            self.selection = None;
+        }
+        if self
+            .copied
+            .is_some_and(|copied| copied.elapsed() >= COPIED_SHOWN)
+        {
+            self.copied = None;
+        }
+    }
+
+    /// What the panel says in its corner just after copying, until the
+    /// news is stale.
+    fn copied_note(&self) -> Option<Line<'static>> {
+        self.copied
+            .is_some()
+            .then(|| Line::styled(" Copied ", Style::new().fg(Color::Green)))
+    }
+
+    /// Take down where each row on screen picks up the content it shows,
+    /// so that marking it copies the content rather than the display, and
+    /// set the marked cells apart from the rest.
+    fn paint_selection(&mut self, buffer: &mut Buffer, source: Vec<String>) {
+        let area = self.content_rect;
+        // Taken down cell by cell into what the last frame left behind
+        self.screen.resize_with(area.height as usize, Vec::new);
+        for (row, y) in self.screen.iter_mut().zip(area.top()..area.bottom()) {
+            row.resize_with(area.width as usize, String::new);
+            for (cell, x) in row.iter_mut().zip(area.left()..area.right()) {
+                cell.clear();
+                if let Some(drawn) = buffer.cell(Position::new(x, y)) {
+                    cell.push_str(drawn.symbol());
+                }
+            }
+        }
+        // Where the rows pick up the content is worked out only once the
+        // mouse asks for it
+        self.origins.clear();
+        self.source = source;
+
+        let Some(selection) = self.mark() else {
+            return;
+        };
+        for (y, from, to) in selection.rows(area) {
+            for x in from..=to {
+                if let Some(cell) = buffer.cell_mut(Position::new(x, y)) {
+                    cell.set_style(SELECTED);
+                }
+            }
+        }
+    }
+
+    /// What is marked on screen, which a press that has yet to be
+    /// widened or dragged into a mark is not.
+    fn mark(&self) -> Option<&Selection> {
+        self.selection.as_ref().filter(|mark| mark.marks_text())
+    }
+
+    /// Work out where the rows of the last frame pick up the content, if
+    /// nothing has asked since it was drawn.
+    fn locate_rows(&mut self) {
+        if self.origins.is_empty() {
+            self.origins = self.map_rows();
+        }
+    }
+
+    /// Where each row on screen picks up the line of the content it
+    /// shows. The row a wrapped line goes on with reads on from where the
+    /// row before it left off, which is where that row's text is found
+    /// again in the line.
+    fn map_rows(&self) -> Vec<RowOrigin> {
+        let mut rows: Vec<RowOrigin> = Vec::new();
+        for (line, text) in self.source.iter().enumerate() {
+            let mut start = 0;
+            for row in 0..self.rows_of(text) {
+                if rows.len() >= self.screen.len() {
+                    return rows;
+                }
+                let shown = self.row_text(rows.len());
+                if row > 0 {
+                    // A row we cannot find again in its line leaves us
+                    // nowhere to pick it up from, so it stands for
+                    // whatever the line has left and the rows after it
+                    // for nothing.
+                    let Some(found) = text[start..].find(&shown) else {
+                        rows.push(RowOrigin {
+                            line,
+                            start,
+                            end: text.len(),
+                        });
+                        start = text.len();
+                        continue;
+                    };
+                    start += found;
+                }
+                let end = (start + shown.len()).min(text.len());
+                rows.push(RowOrigin { line, start, end });
+                start = end;
+            }
+        }
+        rows
+    }
+
+    /// How many rows a line of content takes on screen.
+    fn rows_of(&self, line: &str) -> usize {
+        if !self.wrap {
+            return 1;
+        }
+        Paragraph::new(line)
+            .wrap(Wrap { trim: false })
+            .line_count(self.content_rect.width)
+            .max(1)
+    }
+
+    /// What the row at `index` of the panel showed in the last frame,
+    /// without the blanks it was padded with.
+    fn row_text(&self, index: usize) -> String {
+        let Some(row) = self.screen.get(index) else {
+            return String::new();
+        };
+        row.concat().trim_end().to_owned()
+    }
+
+    /// What a press on `position` marks: the word under it when it is the
+    /// second in a row, the line it is on when it is the third, and
+    /// nothing yet when it stands on its own, as the mark is then the
+    /// drag that may follow.
+    fn press(&self, position: Position, clicks: u8) -> Selection {
+        let mode = match clicks {
+            2 => Mode::Word,
+            3 => Mode::Line,
+            _ => Mode::Cell,
+        };
+        match self.extent(position, mode) {
+            // Nothing to widen the press to leaves the cell it landed on
+            // standing for itself
+            None => Selection::new(position, Mode::Cell, None),
+            ends => Selection::new(position, mode, ends),
+        }
+    }
+
+    /// Widen the mark to where the drag has taken it, both of its ends
+    /// standing for as much as the presses that began it asked for.
+    fn extend(&mut self, to: Position) {
+        let Some(selection) = self.selection.take() else {
+            return;
+        };
+        let cell = |at: Position| (at, at);
+        let from = self
+            .extent(selection.press, selection.mode)
+            .unwrap_or_else(|| cell(selection.press));
+        let onto = self.extent(to, selection.mode).unwrap_or_else(|| cell(to));
+
+        // Which end of each is the outer one depends on which way the
+        // drag went
+        let (anchor, cursor) = if (onto.0.y, onto.0.x) >= (from.0.y, from.0.x) {
+            (from.0, onto.1)
+        } else {
+            (from.1, onto.0)
+        };
+
+        self.selection = Some(Selection {
+            anchor,
+            cursor,
+            dragged: true,
+            ..selection
+        });
+    }
+
+    /// The cells the mark takes `position` to stand for. A cell stands
+    /// for itself, so a mark of cells has nothing to widen it to.
+    fn extent(&self, position: Position, mode: Mode) -> Option<(Position, Position)> {
+        match mode {
+            Mode::Cell => None,
+            Mode::Word => self.word_at(position),
+            Mode::Line => self.line_at(position),
+        }
+    }
+
+    /// The cells the word at `position` covers, if there is one there.
+    fn word_at(&self, position: Position) -> Option<(Position, Position)> {
+        let row = self.screen_row(position.y)?;
+        let column = position.x.checked_sub(self.content_rect.left())? as usize;
+        if !is_word(row.get(column)?) {
+            return None;
+        }
+
+        let from = row[..column]
+            .iter()
+            .rposition(|symbol| !is_word(symbol))
+            .map_or(0, |before| before + 1);
+        let to = row[column..]
+            .iter()
+            .position(|symbol| !is_word(symbol))
+            .map_or(row.len() - 1, |behind| column + behind - 1);
+
+        let left = self.content_rect.left();
+        Some((
+            Position::new(left + from as u16, position.y),
+            Position::new(left + to as u16, position.y),
+        ))
+    }
+
+    /// The cells the line at `position` covers, which are all of the rows
+    /// it took to show it.
+    fn line_at(&self, position: Position) -> Option<(Position, Position)> {
+        let top = self.content_rect.top();
+        let row = position.y.checked_sub(top)? as usize;
+        let line = self.origins.get(row)?.line;
+        let same_line = |row: &usize| self.origins.get(*row).is_some_and(|at| at.line == line);
+
+        let first = (0..=row).rev().take_while(same_line).last()?;
+        let last = (row..self.origins.len()).take_while(same_line).last()?;
+
+        Some((
+            Position::new(self.content_rect.left(), top + first as u16),
+            Position::new(
+                self.content_rect.right().saturating_sub(1),
+                top + last as u16,
+            ),
+        ))
+    }
+
+    /// The cells of the row at `y` as the last frame drew them.
+    fn screen_row(&self, y: u16) -> Option<&Vec<String>> {
+        let row = y.checked_sub(self.content_rect.top())?;
+        self.screen.get(row as usize)
+    }
+
+    /// The content the marked cells of the last frame show. A line the
+    /// panel wrapped comes out as the one line it is, and one it cut off
+    /// comes out whole.
+    fn marked_text(&self, selection: &Selection) -> String {
+        let marked: Vec<_> = selection.rows(self.content_rect).collect();
+        let (Some(&(first, from, _)), Some(&(last, _, to))) = (marked.first(), marked.last())
+        else {
+            return String::new();
+        };
+        // A word is marked as far as it goes, while a mark that is not
+        // bounded by what it is on takes what its last row leaves off
+        // showing of the line it ends in
+        let whole_line = !matches!(selection.mode, Mode::Word);
+        let (Some(start), Some(end)) = (
+            self.mark_start(first, from),
+            self.mark_end(last, to, whole_line),
+        ) else {
+            return String::new();
+        };
+
+        if start.line == end.line {
+            return self.source[start.line][start.at..end.at].to_owned();
+        }
+
+        let mut text = self.source[start.line][start.at..].to_owned();
+        for line in &self.source[start.line + 1..end.line] {
+            text.push('\n');
+            text.push_str(line);
+        }
+        text.push('\n');
+        text.push_str(&self.source[end.line][..end.at]);
+        text
+    }
+
+    /// Where the content picks up what the mark begins at, which is the
+    /// column it was drawn from on the row it is on.
+    fn mark_start(&self, y: u16, column: u16) -> Option<Spot> {
+        let origin = self.origin_of(y)?;
+        let line = self.source.get(origin.line)?;
+        let at = origin.start + self.row_prefix(y, column).len();
+        Some(Spot {
+            line: origin.line,
+            at: char_boundary(line, at.min(origin.end)),
+        })
+    }
+
+    /// Where the content leaves off what the mark ends at. With
+    /// `whole_line`, a mark that reaches the end of a row takes the rest
+    /// of the line the row shows, which is what a line the panel wrapped
+    /// or cut off has more of.
+    fn mark_end(&self, y: u16, column: u16, whole_line: bool) -> Option<Spot> {
+        let origin = self.origin_of(y)?;
+        let line = self.source.get(origin.line)?;
+        let at = origin.start + self.row_prefix(y, column.saturating_add(1)).len();
+        let at = if whole_line && at >= origin.end && self.ends_its_line(y) {
+            line.len()
+        } else {
+            at.min(origin.end)
+        };
+        Some(Spot {
+            line: origin.line,
+            at: char_boundary(line, at),
+        })
+    }
+
+    /// Where the row at `y` picks up the content it shows. Rows past the
+    /// content show nothing, and end up at the last one that does.
+    fn origin_of(&self, y: u16) -> Option<&RowOrigin> {
+        let row = y.checked_sub(self.content_rect.top())? as usize;
+        self.origins.get(row).or_else(|| self.origins.last())
+    }
+
+    /// Whether the row at `y` is the last one on screen showing its line,
+    /// so that whatever the line has past it is not marked elsewhere.
+    fn ends_its_line(&self, y: u16) -> bool {
+        let Some(origin) = self.origin_of(y) else {
+            return false;
+        };
+        let Some(row) = y.checked_sub(self.content_rect.top()) else {
+            return false;
+        };
+        self.origins
+            .get(row as usize + 1)
+            .is_none_or(|next| next.line != origin.line)
+    }
+
+    /// What the row at `y` shows left of `column`.
+    fn row_prefix(&self, y: u16, column: u16) -> String {
+        let Some(row) = y
+            .checked_sub(self.content_rect.top())
+            .and_then(|row| self.screen.get(row as usize))
+        else {
+            return String::new();
+        };
+        let columns = column.saturating_sub(self.content_rect.left()) as usize;
+        row.iter().take(columns).map(String::as_str).collect()
     }
 
     /// Create a RenderContext that can render the provided content
@@ -251,6 +785,9 @@ impl DetailsPanel {
     }
 
     pub fn scroll(&mut self, scroll: isize) {
+        // What was marked is gone from where it was marked.
+        self.selection = None;
+        self.marked = None;
         self.scroll_to(self.scroll.saturating_add_signed(scroll as i16))
     }
 
@@ -264,7 +801,13 @@ impl DetailsPanel {
             }
             DetailsPanelEvent::ScrollDownPage => self.scroll(self.rows() as isize),
             DetailsPanelEvent::ScrollUpPage => self.scroll((self.rows() as isize).saturating_neg()),
-            DetailsPanelEvent::ToggleWrap => self.wrap = !self.wrap,
+            DetailsPanelEvent::ToggleWrap => {
+                // Every row comes to show something else, so the marked
+                // cells no longer stand for what was marked
+                self.selection = None;
+                self.marked = None;
+                self.wrap = !self.wrap;
+            }
             DetailsPanelEvent::ToggleDiffFormat | DetailsPanelEvent::Unbound => {}
         }
     }
@@ -272,7 +815,49 @@ impl DetailsPanel {
 
 impl PanelMouseInput for DetailsPanel {
     fn input_mouse(&mut self, mouse: Mouse) -> MouseInput {
-        if !self.panel_rect.contains(mouse.position()) {
+        let position = mouse.position();
+
+        // A drag that started in the panel goes on wherever it leads, so
+        // marking text does not end at the edge of the panel. A mark the
+        // button is no longer down on is done with, so what the mouse
+        // does next is nothing to do with it.
+        match mouse.kind() {
+            MouseEventKind::Drag(MouseButton::Left)
+                if self.selection.as_ref().is_some_and(|mark| mark.held) =>
+            {
+                self.locate_rows();
+                self.extend(clamp(position, self.content_rect));
+                return MouseInput::Handled;
+            }
+            MouseEventKind::Up(MouseButton::Left) => {
+                if let Some(mut selection) = self.selection.take_if(|mark| mark.held) {
+                    self.locate_rows();
+                    selection.held = false;
+                    // A press of its own is only where a drag or a
+                    // further click may come to mark something, so it
+                    // leaves nothing behind.
+                    if !selection.marks_text() {
+                        return MouseInput::Handled;
+                    }
+                    let text = self.marked_text(&selection);
+                    if text.is_empty() {
+                        return MouseInput::Handled;
+                    }
+                    // A drag is over once the button comes up, while a
+                    // click may still be widened by the next one, so its
+                    // mark stands until no further click can come.
+                    if !selection.dragged {
+                        self.selection = Some(selection);
+                        self.marked = Some(Instant::now());
+                    }
+                    self.copied = Some(Instant::now());
+                    return MouseInput::Copy(text);
+                }
+            }
+            _ => {}
+        }
+
+        if !self.panel_rect.contains(position) {
             trace!("mouse {:?} not in rect {:?}", &mouse, &self.panel_rect);
             return MouseInput::NotHandled;
         }
@@ -288,14 +873,49 @@ impl PanelMouseInput for DetailsPanel {
                 self.handle_event(DetailsPanelEvent::ScrollDown);
                 self.handle_event(DetailsPanelEvent::ScrollDown);
             }
+            MouseEventKind::Down(MouseButton::Left) => {
+                // The mark this press makes stands on its own terms,
+                // however the one it replaces was to go
+                self.marked = None;
+                self.selection = if self.content_rect.contains(position) {
+                    self.locate_rows();
+                    Some(self.press(position, mouse.clicks()))
+                } else {
+                    None
+                };
+            }
             _ => return MouseInput::NotHandled,
         }
         MouseInput::Handled
     }
 }
 
+/// `at` pulled back to where a character of `line` begins, so that a row
+/// whose text is not found where it was looked for cannot cut one in two.
+fn char_boundary(line: &str, at: usize) -> usize {
+    let mut at = at.min(line.len());
+    while !line.is_char_boundary(at) {
+        at -= 1;
+    }
+    at
+}
+
+/// The cell of `area` closest to `position`.
+fn clamp(position: Position, area: Rect) -> Position {
+    Position::new(
+        position
+            .x
+            .clamp(area.left(), area.right().saturating_sub(1).max(area.left())),
+        position
+            .y
+            .clamp(area.top(), area.bottom().saturating_sub(1).max(area.top())),
+    )
+}
+
 #[cfg(test)]
 mod tests {
+    use ratatui::widgets::Widget;
+
     use super::*;
 
     const AREA: Rect = Rect {
@@ -304,6 +924,10 @@ mod tests {
         width: 40,
         height: 10,
     };
+
+    fn mouse(kind: MouseEventKind, column: u16, row: u16) -> Mouse {
+        Mouse::new(kind, Position::new(column, row), 1)
+    }
 
     /// A panel that has rendered `lines` of unwrapped content into [AREA]
     fn panel_showing(lines: u16) -> DetailsPanel {
@@ -316,6 +940,395 @@ mod tests {
 
     fn render(panel: &mut DetailsPanel, content: &LargeString) {
         LargeStringContent::from(content).render_as_paragraph(panel, AREA);
+    }
+
+    /// A panel of [AREA] that has drawn `content` the way a frame does,
+    /// and the frame it drew it on.
+    fn drawn(content: &str, wrap: bool) -> (DetailsPanel, Buffer) {
+        let content = LargeString::new(content.to_owned());
+        let content = LargeStringContent::from(&content);
+        let mut panel = DetailsPanel::new();
+        panel.panel_rect = AREA;
+        panel.wrap = wrap;
+
+        let mut paragraph = content.render_as_paragraph(&mut panel, AREA);
+        if wrap {
+            paragraph = paragraph.wrap(Wrap { trim: false });
+        }
+        let mut buffer = Buffer::empty(AREA);
+        paragraph.render(AREA, &mut buffer);
+        let source = content.source_lines(panel.scroll as usize, AREA.height as usize);
+        panel.paint_selection(&mut buffer, source);
+
+        (panel, buffer)
+    }
+
+    /// A panel of [AREA] that has drawn `text` wrapped, scrolled down by
+    /// `scroll` lines, the way a frame does.
+    fn drawn_text(text: &str, scroll: u16) -> DetailsPanel {
+        let content = TextContent::from(text.to_owned());
+        let mut panel = DetailsPanel::new();
+        panel.panel_rect = AREA;
+        panel.wrap = true;
+        panel.scroll = scroll;
+
+        let paragraph = content
+            .render_as_paragraph(&mut panel, AREA)
+            .wrap(Wrap { trim: false });
+        let mut buffer = Buffer::empty(AREA);
+        paragraph.render(AREA, &mut buffer);
+        let source = content.source_lines(panel.scroll as usize, AREA.height as usize);
+        panel.paint_selection(&mut buffer, source);
+
+        panel
+    }
+
+    /// A paragraph of its own scrolls by the rows a wrapped line takes,
+    /// while the scroll position names a line of content everywhere else,
+    /// so what is on the top row is the line it names.
+    #[test]
+    fn scrolled_wrapped_text_is_read_from_the_lines_it_shows() {
+        let long = "one two three four five six seven eight nine ten eleven twelve";
+        let lines: Vec<String> = (1..20).map(|n| format!("line {n}")).collect();
+        let mut panel = drawn_text(&format!("{long}\n{}\n", lines.join("\n")), 1);
+
+        assert_eq!(marked(&mut panel, (0, 0), (39, 0)), "line 1");
+    }
+
+    /// What `panel` reads with `anchor` up to `cursor` dragged over in it.
+    fn marked(panel: &mut DetailsPanel, anchor: (u16, u16), cursor: (u16, u16)) -> String {
+        panel.locate_rows();
+        let anchor = Position::new(anchor.0, anchor.1);
+        panel.selection = Some(Selection {
+            dragged: true,
+            ..Selection::new(
+                anchor,
+                Mode::Cell,
+                Some((anchor, Position::new(cursor.0, cursor.1))),
+            )
+        });
+        panel.marked_text(panel.selection.as_ref().unwrap())
+    }
+
+    #[test]
+    fn marking_within_a_line_reads_what_is_between_its_ends() {
+        let (mut panel, _) = drawn("hello world\n", false);
+
+        assert_eq!(marked(&mut panel, (6, 0), (10, 0)), "world");
+    }
+
+    /// What a panel shows is coloured by escape sequences that take up
+    /// no cell, so where a mark falls in the content is not where it
+    /// falls in the line as it is stored.
+    #[test]
+    fn marking_coloured_content_reads_what_is_on_screen() {
+        let (mut panel, _) = drawn("\x1b[1;31mhello\x1b[0m world\n", false);
+
+        assert_eq!(marked(&mut panel, (6, 0), (10, 0)), "world");
+        assert_eq!(click(&mut panel, (2, 0), 2).as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn marking_backwards_reads_the_same_text() {
+        let (mut panel, _) = drawn("hello world\n", false);
+
+        assert_eq!(marked(&mut panel, (10, 0), (6, 0)), "world");
+    }
+
+    #[test]
+    fn marking_across_lines_takes_the_ones_between_whole() {
+        let (mut panel, _) = drawn("first line\nsecond line\nthird line\n", false);
+
+        assert_eq!(
+            marked(&mut panel, (6, 0), (4, 2)),
+            "line\nsecond line\nthird"
+        );
+    }
+
+    /// The panel shows what fits, but a mark reaching the edge is for the
+    /// line, not for the part of it that got drawn.
+    #[test]
+    fn marking_a_line_that_is_cut_off_takes_all_of_it() {
+        let line = "0123456789".repeat(6);
+        let (mut panel, _) = drawn(&format!("{line}\n"), false);
+
+        assert_eq!(marked(&mut panel, (0, 0), (39, 0)), line);
+    }
+
+    #[test]
+    fn marking_a_wrapped_line_takes_it_as_the_one_line_it_is() {
+        let line = "one two three four five six seven eight nine ten eleven";
+        let (mut panel, _) = drawn(&format!("{line}\n"), true);
+
+        assert_eq!(marked(&mut panel, (0, 0), (39, 1)), line);
+    }
+
+    /// Marking one row of a wrapped line is for that much of the line,
+    /// which reads on where the row before it left off.
+    #[test]
+    fn marking_a_row_of_a_wrapped_line_takes_what_it_shows_of_it() {
+        let line = "one two three four five six seven eight nine ten eleven";
+        let (mut panel, _) = drawn(&format!("{line}\n"), true);
+
+        assert_eq!(marked(&mut panel, (0, 1), (39, 1)), "nine ten eleven");
+    }
+
+    #[test]
+    fn releasing_the_button_copies_what_was_marked_and_lets_go_of_it() {
+        let (mut panel, mut buffer) = drawn("hello world\n", false);
+
+        panel.input_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 6, 0));
+        panel.input_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 10, 0));
+        panel.paint_selection(&mut buffer, panel.source.clone());
+        let copied = panel.input_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 10, 0));
+
+        assert!(matches!(copied, MouseInput::Copy(text) if text == "world"));
+        assert!(panel.selection.is_none());
+        assert!(panel.copied_note().is_some());
+    }
+
+    /// Press and release the left button `times` in a row on a cell, and
+    /// report what each release did.
+    fn press_release(panel: &mut DetailsPanel, at: (u16, u16), times: usize) -> Vec<MouseInput> {
+        (1..=times)
+            .map(|clicks| {
+                panel.input_mouse(clicked(MouseButton::Left, at, clicks as u8));
+                panel.input_mouse(released(MouseButton::Left, at, clicks as u8))
+            })
+            .collect()
+    }
+
+    /// The press that a click on `at` is the `clicks`th of, as the app
+    /// counts them before the panel is told.
+    fn clicked(button: MouseButton, at: (u16, u16), clicks: u8) -> Mouse {
+        Mouse::new(
+            MouseEventKind::Down(button),
+            Position::new(at.0, at.1),
+            clicks,
+        )
+    }
+
+    /// The release that ends such a press.
+    fn released(button: MouseButton, at: (u16, u16), clicks: u8) -> Mouse {
+        Mouse::new(
+            MouseEventKind::Up(button),
+            Position::new(at.0, at.1),
+            clicks,
+        )
+    }
+
+    /// Click `times` in a row on a cell and report what the last of them
+    /// copied.
+    fn click(panel: &mut DetailsPanel, at: (u16, u16), times: usize) -> Option<String> {
+        match press_release(panel, at, times).pop() {
+            Some(MouseInput::Copy(text)) => Some(text),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn a_double_click_copies_the_word_it_is_on() {
+        let (mut panel, _) = drawn("show 5b41ab5f in src/ui/mod.rs\n", false);
+
+        assert_eq!(click(&mut panel, (7, 0), 2).as_deref(), Some("5b41ab5f"));
+    }
+
+    /// What a change id or a path is made of holds together, or a double
+    /// click would leave most of one behind.
+    #[test]
+    fn a_double_click_takes_a_path_whole() {
+        let (mut panel, _) = drawn("show 5b41ab5f in src/ui/mod.rs\n", false);
+
+        assert_eq!(
+            click(&mut panel, (22, 0), 2).as_deref(),
+            Some("src/ui/mod.rs")
+        );
+    }
+
+    /// Press `times` in a row on `at`, then drag to `to` and let go.
+    fn click_and_drag(
+        panel: &mut DetailsPanel,
+        at: (u16, u16),
+        times: usize,
+        to: (u16, u16),
+    ) -> MouseInput {
+        press_release(panel, at, times - 1);
+        let clicks = times as u8;
+        panel.input_mouse(clicked(MouseButton::Left, at, clicks));
+        panel.input_mouse(Mouse::new(
+            MouseEventKind::Drag(MouseButton::Left),
+            Position::new(to.0, to.1),
+            clicks,
+        ));
+        panel.input_mouse(released(MouseButton::Left, to, clicks))
+    }
+
+    #[test]
+    fn dragging_from_a_double_click_takes_whole_words() {
+        let (mut panel, _) = drawn("show 5b41ab5f in src/ui/mod.rs\n", false);
+
+        // From the middle of the first word to the middle of the last
+        let copied = click_and_drag(&mut panel, (7, 0), 2, (22, 0));
+
+        assert!(matches!(copied, MouseInput::Copy(text) if text == "5b41ab5f in src/ui/mod.rs"));
+    }
+
+    #[test]
+    fn dragging_from_a_double_click_backwards_takes_whole_words() {
+        let (mut panel, _) = drawn("show 5b41ab5f in src/ui/mod.rs\n", false);
+
+        let copied = click_and_drag(&mut panel, (22, 0), 2, (7, 0));
+
+        assert!(matches!(copied, MouseInput::Copy(text) if text == "5b41ab5f in src/ui/mod.rs"));
+    }
+
+    #[test]
+    fn dragging_from_a_triple_click_takes_whole_lines() {
+        let (mut panel, _) = drawn("first line\nsecond line\nthird line\n", false);
+
+        let copied = click_and_drag(&mut panel, (4, 0), 3, (2, 1));
+
+        assert!(matches!(copied, MouseInput::Copy(text) if text == "first line\nsecond line"));
+    }
+
+    /// How many cells the panel has marked.
+    fn marked_cells(panel: &DetailsPanel) -> usize {
+        panel.mark().map_or(0, |selection| {
+            selection
+                .rows(panel.content_rect)
+                .map(|(_, from, to)| (to - from + 1) as usize)
+                .sum()
+        })
+    }
+
+    /// A click of its own picks nothing, so it marks nothing; what the
+    /// clicks after it mark grows from the cell it landed on.
+    #[test]
+    fn the_clicks_that_widen_a_mark_grow_it_from_the_cell_pressed() {
+        let (mut panel, _) = drawn("first line\nsecond line\n", false);
+
+        let mut marked = Vec::new();
+        for clicks in 1..=3 {
+            panel.input_mouse(clicked(MouseButton::Left, (2, 0), clicks));
+            marked.push(marked_cells(&panel));
+            panel.input_mouse(released(MouseButton::Left, (2, 0), clicks));
+            marked.push(marked_cells(&panel));
+        }
+
+        // Nothing, then the word the cell is on, then its line
+        assert_eq!(marked, [0, 0, 5, 5, 40, 40]);
+    }
+
+    /// A click stands for nothing anyone can act on, so the panel is
+    /// left as it was and has nothing to take off screen later.
+    #[test]
+    fn a_click_leaves_no_mark_behind() {
+        let (mut panel, _) = drawn("hello world\n", false);
+        press_release(&mut panel, (6, 0), 1);
+
+        assert_eq!(marked_cells(&panel), 0);
+        assert!(!panel.is_flashing());
+    }
+
+    /// What a double click marks is copied, and stands as long as a
+    /// third click could still widen it to the line.
+    #[test]
+    fn the_mark_a_double_click_makes_stays_for_a_further_click() {
+        let (mut panel, _) = drawn("hello world\n", false);
+        press_release(&mut panel, (6, 0), 2);
+
+        assert_eq!(marked_cells(&panel), 5);
+
+        panel.marked = Some(Instant::now() - CLICK_PAUSE);
+        panel.fade();
+
+        assert_eq!(marked_cells(&panel), 0);
+    }
+
+    /// The button is up once a click is over, so a drag that begins
+    /// elsewhere is somebody else's.
+    #[test]
+    fn a_drag_that_began_outside_marks_nothing() {
+        let (mut panel, _) = drawn("hello world\n", false);
+        press_release(&mut panel, (6, 0), 1);
+
+        let dragged = panel.input_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), 10, 0));
+        let released = panel.input_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 10, 0));
+
+        assert!(matches!(dragged, MouseInput::NotHandled));
+        assert!(matches!(released, MouseInput::NotHandled));
+        assert_eq!(marked_cells(&panel), 0);
+    }
+
+    /// Every row comes to show something else, so keeping the marked
+    /// cells would mark text nobody picked.
+    #[test]
+    fn toggling_the_wrap_drops_the_mark() {
+        let (mut panel, _) = drawn("hello world\n", false);
+        press_release(&mut panel, (6, 0), 2);
+
+        panel.handle_event(DetailsPanelEvent::ToggleWrap);
+
+        assert_eq!(marked_cells(&panel), 0);
+        assert!(panel.marked.is_none());
+    }
+
+    #[test]
+    fn a_double_click_between_words_marks_nothing() {
+        let (mut panel, _) = drawn("hello world\n", false);
+
+        assert_eq!(click(&mut panel, (5, 0), 2), None);
+    }
+
+    #[test]
+    fn a_triple_click_copies_the_line_it_is_on_however_it_was_drawn() {
+        let line = "one two three four five six seven eight nine ten eleven";
+        let (mut panel, _) = drawn(&format!("{line}\n"), true);
+
+        assert_eq!(click(&mut panel, (2, 0), 3).as_deref(), Some(line));
+    }
+
+    #[test]
+    fn a_click_marks_nothing_to_copy() {
+        let (mut panel, _) = drawn("hello world\n", false);
+
+        panel.input_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 6, 0));
+        let copied = panel.input_mouse(mouse(MouseEventKind::Up(MouseButton::Left), 6, 0));
+
+        assert!(matches!(copied, MouseInput::Handled));
+        assert!(panel.copied_note().is_none());
+    }
+
+    #[test]
+    fn the_word_of_a_copy_goes_off_screen_on_its_own() {
+        let mut panel = panel_showing(1);
+        panel.copied = Some(Instant::now());
+
+        assert!(panel.is_flashing());
+        assert!(panel.copied_note().is_some());
+
+        panel.copied = Some(Instant::now() - COPIED_SHOWN);
+
+        // The word is still on screen, so the frame that takes it off is
+        // asked for
+        assert!(panel.is_flashing());
+
+        panel.fade();
+
+        assert!(panel.copied_note().is_none());
+        assert!(!panel.is_flashing());
+    }
+
+    #[test]
+    fn marked_cells_are_set_apart() {
+        let (mut panel, mut buffer) = drawn("hello world\n", false);
+        marked(&mut panel, (6, 0), (10, 0));
+        panel.paint_selection(&mut buffer, panel.source.clone());
+
+        assert!(!buffer[(5, 0)].modifier.contains(Modifier::REVERSED));
+        assert!(buffer[(6, 0)].modifier.contains(Modifier::REVERSED));
+        assert!(buffer[(10, 0)].modifier.contains(Modifier::REVERSED));
+        assert!(!buffer[(11, 0)].modifier.contains(Modifier::REVERSED));
     }
 
     #[test]

--- a/src/ui/panel/details_panel.rs
+++ b/src/ui/panel/details_panel.rs
@@ -12,10 +12,8 @@ To make this efficient there are two implementations of DetailContent.
 
 */
 
-use ratatui::crossterm::event::MouseEvent;
 use ratatui::crossterm::event::MouseEventKind;
 use ratatui::layout::Margin;
-use ratatui::layout::Position;
 use ratatui::layout::Rect;
 use ratatui::text::Line;
 use ratatui::text::Text;
@@ -31,6 +29,7 @@ use tracing::trace;
 
 use super::MouseInput;
 use super::PanelMouseInput;
+use crate::event::Mouse;
 use crate::keybinds::DetailsPanelEvent;
 use crate::ui::utils::LargeString;
 
@@ -272,16 +271,13 @@ impl DetailsPanel {
 }
 
 impl PanelMouseInput for DetailsPanel {
-    fn input_mouse(&mut self, mouse: MouseEvent) -> MouseInput {
-        if !self
-            .panel_rect
-            .contains(Position::new(mouse.column, mouse.row))
-        {
+    fn input_mouse(&mut self, mouse: Mouse) -> MouseInput {
+        if !self.panel_rect.contains(mouse.position()) {
             trace!("mouse {:?} not in rect {:?}", &mouse, &self.panel_rect);
             return MouseInput::NotHandled;
         }
         trace!("mouse {:?} inside  rect {:?}", &mouse, &self.panel_rect);
-        match mouse.kind {
+        match mouse.kind() {
             MouseEventKind::ScrollUp => {
                 self.handle_event(DetailsPanelEvent::ScrollUp);
                 self.handle_event(DetailsPanelEvent::ScrollUp);

--- a/src/ui/panel/list_pane.rs
+++ b/src/ui/panel/list_pane.rs
@@ -1,6 +1,5 @@
 use ratatui::Frame;
 use ratatui::crossterm::event::MouseButton;
-use ratatui::crossterm::event::MouseEvent;
 use ratatui::crossterm::event::MouseEventKind;
 use ratatui::layout::Margin;
 use ratatui::layout::Position;
@@ -14,6 +13,7 @@ use ratatui::widgets::ScrollbarState;
 
 use super::MouseInput;
 use super::PanelMouseInput;
+use crate::event::Mouse;
 
 /// The list a tab shows in its main panel, with a scrollbar and mouse
 /// handling.
@@ -105,12 +105,12 @@ impl ListPane {
 }
 
 impl PanelMouseInput for ListPane {
-    fn input_mouse(&mut self, mouse: MouseEvent) -> MouseInput {
-        let pos = Position::new(mouse.column, mouse.row);
+    fn input_mouse(&mut self, mouse: Mouse) -> MouseInput {
+        let pos = mouse.position();
         if !self.panel_rect.contains(pos) {
             return MouseInput::NotHandled;
         }
-        match mouse.kind {
+        match mouse.kind() {
             MouseEventKind::ScrollDown => MouseInput::Scroll(1),
             MouseEventKind::ScrollUp => MouseInput::Scroll(-1),
             MouseEventKind::Down(MouseButton::Left) => match self.item_at(pos) {

--- a/src/ui/panel/log_panel.rs
+++ b/src/ui/panel/log_panel.rs
@@ -4,7 +4,6 @@ use std::collections::HashSet;
 
 use ansi_to_tui::IntoText;
 use anyhow::Result;
-use ratatui::crossterm::event::MouseEvent;
 use ratatui::layout::Rect;
 use ratatui::prelude::*;
 use ratatui::widgets::*;
@@ -18,6 +17,7 @@ use crate::commander::log::Head;
 use crate::commander::log::LogOutput;
 use crate::env::JjConfig;
 use crate::env::get_env;
+use crate::event::Mouse;
 use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::utils::error_text;
@@ -342,7 +342,7 @@ impl Component for LogPanel<'_> {
 }
 
 impl PanelMouseInput for LogPanel<'_> {
-    fn input_mouse(&mut self, mouse: MouseEvent) -> MouseInput {
+    fn input_mouse(&mut self, mouse: Mouse) -> MouseInput {
         self.list_pane.input_mouse(mouse)
     }
 }

--- a/src/ui/panel/mod.rs
+++ b/src/ui/panel/mod.rs
@@ -18,7 +18,8 @@ pub use log_panel::LogPanel;
 pub use output_cache::OutputKey;
 pub use output_cache::OutputRequest;
 pub use output_panel::OutputPanel;
-use ratatui::crossterm::event::MouseEvent;
+
+use crate::event::Mouse;
 
 /// What a panel did with a mouse event.
 pub(crate) enum MouseInput {
@@ -37,15 +38,12 @@ pub(crate) enum MouseInput {
 }
 
 pub(crate) trait PanelMouseInput {
-    fn input_mouse(&mut self, mouse: MouseEvent) -> MouseInput;
+    fn input_mouse(&mut self, mouse: Mouse) -> MouseInput;
 }
 
 /// Offer `mouse` to each panel in turn and report what the first one that
 /// takes it did with it.
-pub(crate) fn route_mouse(
-    mouse: MouseEvent,
-    panels: &mut [&mut dyn PanelMouseInput],
-) -> MouseInput {
+pub(crate) fn route_mouse(mouse: Mouse, panels: &mut [&mut dyn PanelMouseInput]) -> MouseInput {
     for panel in panels {
         match panel.input_mouse(mouse) {
             MouseInput::NotHandled => {}

--- a/src/ui/panel/mod.rs
+++ b/src/ui/panel/mod.rs
@@ -19,7 +19,10 @@ pub use output_cache::OutputKey;
 pub use output_cache::OutputRequest;
 pub use output_panel::OutputPanel;
 
+use crate::app::command::Command;
 use crate::event::Mouse;
+use crate::ui::AppAction;
+use crate::ui::ComponentInputResult;
 
 /// What a panel did with a mouse event.
 pub(crate) enum MouseInput {
@@ -35,6 +38,14 @@ pub(crate) enum MouseInput {
     /// The item at this index was right-clicked, asking for whatever the
     /// caller offers as a context menu.
     Context(usize),
+    /// This text was marked with the mouse, to be copied.
+    Copy(String),
+}
+
+/// What a tab is to do about text a panel of it had marked, which is the
+/// same wherever the panel sits.
+pub(crate) fn copy_marked(text: String) -> ComponentInputResult {
+    ComponentInputResult::HandledAction(AppAction::Run(Command::Copy(text)))
 }
 
 pub(crate) trait PanelMouseInput {

--- a/src/ui/panel/output_panel.rs
+++ b/src/ui/panel/output_panel.rs
@@ -6,7 +6,6 @@ UI responsive. What it has rendered goes into a
 [cache](super::output_cache), so that coming back to it is instant.
 */
 
-use ratatui::crossterm::event::MouseEvent;
 use ratatui::layout::Rect;
 use ratatui::prelude::Frame;
 use ratatui::style::Color;
@@ -28,6 +27,7 @@ use crate::background_tasks::BackgroundTasks;
 use crate::background_tasks::TaskOutput;
 use crate::env::DiffFormat;
 use crate::env::get_env;
+use crate::event::Mouse;
 use crate::keybinds::DetailsPanelEvent;
 use crate::ui::utils::PanelWait;
 use crate::ui::utils::error_text;
@@ -350,7 +350,7 @@ fn stands_in_for<K: OutputKey>(on_screen: Option<&K>, wanted: &K) -> bool {
 }
 
 impl<K: OutputKey> PanelMouseInput for OutputPanel<K> {
-    fn input_mouse(&mut self, mouse: MouseEvent) -> MouseInput {
+    fn input_mouse(&mut self, mouse: Mouse) -> MouseInput {
         self.panel.input_mouse(mouse)
     }
 }

--- a/src/ui/panel/output_panel.rs
+++ b/src/ui/panel/output_panel.rs
@@ -229,9 +229,11 @@ impl<K: OutputKey> OutputPanel<K> {
         self.cache.insert_document(request.into_value(output));
     }
 
-    /// Whether the panel is still waiting for output it wants.
-    pub fn is_waiting(&self) -> bool {
-        self.wait.is_waiting()
+    /// Whether what the panel shows changes without anything happening,
+    /// because it is waiting for output it wants or is saying something
+    /// that goes away on its own.
+    pub fn needs_periodic_redraw(&self) -> bool {
+        self.wait.is_waiting() || self.panel.is_flashing()
     }
 
     /// Declare what is worth keeping in the cache. Whatever the panel may

--- a/src/ui/utils.rs
+++ b/src/ui/utils.rs
@@ -7,11 +7,11 @@ use std::time::Instant;
 use ansi_to_tui::IntoText;
 pub use large_string::LargeString;
 use ratatui::crossterm::event::MouseButton;
-use ratatui::crossterm::event::MouseEvent;
 use ratatui::crossterm::event::MouseEventKind;
 use ratatui::layout::Constraint;
 use ratatui::layout::Direction;
 use ratatui::layout::Layout;
+use ratatui::layout::Position;
 use ratatui::layout::Rect;
 use ratatui::style::Color;
 use ratatui::style::Stylize;
@@ -20,6 +20,7 @@ use ratatui::text::Text;
 use ratatui::widgets::Block;
 
 use crate::env::JJLayout;
+use crate::event::Mouse;
 use crate::keybinds::Shortcut;
 
 /// Tracks the split position between two panes and handles drag-to-resize mouse events.
@@ -66,20 +67,21 @@ impl PaneDivider {
     }
 
     /// Handle a mouse event. Returns true if the event was consumed.
-    pub fn handle_mouse(&mut self, mouse: MouseEvent, layout: JJLayout) -> bool {
-        match mouse.kind {
+    pub fn handle_mouse(&mut self, mouse: Mouse, layout: JJLayout) -> bool {
+        let position = mouse.position();
+        match mouse.kind() {
             MouseEventKind::Down(MouseButton::Left) => {
                 self.dragging = false;
-                if self.on_border(mouse.column, mouse.row, layout) {
+                if self.on_border(position, layout) {
                     self.dragging = true;
-                    self.update_size(mouse.column, mouse.row, layout);
+                    self.update_size(position, layout);
                     true
                 } else {
                     false
                 }
             }
             MouseEventKind::Drag(MouseButton::Left) if self.dragging => {
-                self.update_size(mouse.column, mouse.row, layout);
+                self.update_size(position, layout);
                 true
             }
             MouseEventKind::Up(MouseButton::Left) if self.dragging => {
@@ -90,32 +92,32 @@ impl PaneDivider {
         }
     }
 
-    fn on_border(&self, col: u16, row: u16, layout: JJLayout) -> bool {
+    fn on_border(&self, position: Position, layout: JJLayout) -> bool {
         let [r0, r1] = self.rects;
         match layout {
             JJLayout::Horizontal => {
-                let in_row = row >= r0.top() && row < r0.bottom();
+                let in_row = position.y >= r0.top() && position.y < r0.bottom();
                 // Right border of r0 and left border of r1 are adjacent columns.
-                let on_col = col == r0.right().saturating_sub(1) || col == r1.left();
+                let on_col = position.x == r0.right().saturating_sub(1) || position.x == r1.left();
                 in_row && on_col
             }
             JJLayout::Vertical => {
-                let in_col = col >= r0.left() && col < r0.right();
-                let on_row = row == r0.bottom().saturating_sub(1) || row == r1.top();
+                let in_col = position.x >= r0.left() && position.x < r0.right();
+                let on_row = position.y == r0.bottom().saturating_sub(1) || position.y == r1.top();
                 in_col && on_row
             }
         }
     }
 
-    fn update_size(&mut self, col: u16, row: u16, layout: JJLayout) {
+    fn update_size(&mut self, position: Position, layout: JJLayout) {
         let [r0, r1] = self.rects;
         let (pos, total) = match layout {
             JJLayout::Horizontal => (
-                col.saturating_sub(r0.left()),
+                position.x.saturating_sub(r0.left()),
                 r1.right().saturating_sub(r0.left()),
             ),
             JJLayout::Vertical => (
-                row.saturating_sub(r0.top()),
+                position.y.saturating_sub(r0.top()),
                 r1.bottom().saturating_sub(r0.top()),
             ),
         };

--- a/src/ui/utils/large_string.rs
+++ b/src/ui/utils/large_string.rs
@@ -21,26 +21,37 @@ pub struct LargeString {
 
 /// The characters `line` puts on screen, leaving out its terminator and
 /// any ANSI escape sequences.
-fn line_width(line: &str) -> usize {
-    let mut width = 0;
+fn visible(line: &str) -> impl Iterator<Item = char> {
     let mut chars = line.chars();
-    while let Some(c) = chars.next() {
-        match c {
-            '\x1b' => {
-                // Past the introducer, everything up to and including the
-                // first character in 0x40..=0x7e belongs to the sequence.
-                chars.next();
-                for c in chars.by_ref() {
-                    if ('\x40'..='\x7e').contains(&c) {
-                        break;
+    std::iter::from_fn(move || {
+        loop {
+            match chars.next()? {
+                '\x1b' => {
+                    // Past the introducer, everything up to and including
+                    // the first character in 0x40..=0x7e belongs to the
+                    // sequence.
+                    chars.next();
+                    for c in chars.by_ref() {
+                        if ('\x40'..='\x7e').contains(&c) {
+                            break;
+                        }
                     }
                 }
+                '\n' | '\r' => {}
+                c => return Some(c),
             }
-            '\n' | '\r' => {}
-            _ => width += 1,
         }
-    }
-    width
+    })
+}
+
+/// What `line` puts on screen.
+fn plain(line: &str) -> String {
+    visible(line).collect()
+}
+
+/// How many characters `line` puts on screen.
+fn line_width(line: &str) -> usize {
+    visible(line).count()
 }
 
 impl LargeString {
@@ -92,13 +103,28 @@ impl LargeString {
         self.width
     }
 
+    /// Where the line at `index` begins, the end of the content standing
+    /// in for every line past the last one.
+    fn line_start(&self, index: usize) -> usize {
+        self.line_start
+            .get(index)
+            .copied()
+            .unwrap_or(self.content.len())
+    }
+
+    /// A range of lines of the content as the plain text they read as,
+    /// leaving out the terminators and any ANSI escape sequences.
+    pub fn plain_lines(&self, top_line: usize, line_count: usize) -> Vec<String> {
+        (top_line..top_line + line_count)
+            .take_while(|&line| line < self.lines())
+            .map(|line| plain(&self.content[self.line_start(line)..self.line_start(line + 1)]))
+            .collect()
+    }
+
     /// Render a range of lines of the content as Text
     pub fn render(&self, top_line: usize, line_count: usize) -> Text<'_> {
-        let end_of_content = self.content.len();
-        let get_line_start = |line| self.line_start.get(line).copied().unwrap_or(end_of_content);
-        let start = get_line_start(top_line);
-        let end = get_line_start(top_line + line_count);
-        let content_str: &str = &self.content[start..end];
+        let content_str: &str =
+            &self.content[self.line_start(top_line)..self.line_start(top_line + line_count)];
         match content_str.into_text() {
             Ok(text) => text,
             Err(err) => {


### PR DESCRIPTION
There is no way to get at what a details panel shows other than reading
it: the app takes the mouse, so the terminal never sees a drag over the
panel, and the keybindings that yank only ever name a change or a
revision. Marking the cells on screen is not enough either, as a line
too long for the width is wrapped or cut off to show, so the panel takes
down where each row picks up the content behind it and copies that.

Counting double and triple clicks needs somewhere to live that is not
every component in turn, so put a layer of our own between the terminal
events and the components first, and give the components a mouse entry
point separate from the keys.