### PR TITLE
ui/log: Mark a change with a double click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Clicking a change in the log tab no longer scrolls the log to put the
+  selection into the middle of the panel; the line clicked stays where it is
 - The set-bookmark dialog now offers the bookmarks the change is standing on
   first, nearest first, rather than ordering them by how recently the change
   each points at was committed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Drag to resize pane divider in all tabs
 - Mouse scrolling in the file and bookmark list panes
 - Left-click to select items in all list panes; log tab click now fires on press rather than release
+- A double click on a change in the log tab marks it, as `space` does
 - The dedicated `Menu` key can now be used in keybindings, spelled `menu`
 - Keybinding to move the log tab selection to the parent commit (`-`), asking
   which one when a merge has more than one parent in the log view; parents

--- a/README.md
+++ b/README.md
@@ -52,9 +52,10 @@ Built in Rust with Ratatui. Interacts with `jj` CLI.
   with `W`
   - Render the git diff with a pager like delta by configuring
     `blazingjj.diff-pager`
-- Mouse: scroll the panels, click to select, drag the divider to resize, right
-  click for the context menu, drag over the details panel (or double click a
-  word, triple click a line) to copy its text
+- Mouse: scroll the panels, click to select, double click a change in the log
+  to mark it, drag the divider to resize, right click for the context menu,
+  drag over the details panel (or double click a word, triple click a line) to
+  copy its text
 - Config: Configure blazingjj with your jj config
 - Command box: Run jj commands directly in blazingjj with `:`
 - Help: See all key mappings with `?`

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -611,7 +611,8 @@ impl Component for BookmarksTab {
                 }
             }
             MouseInput::Copy(text) => return Ok(copy_marked(text)),
-            MouseInput::Handled => {}
+            // Nothing here has a second thing a double click could do.
+            MouseInput::Activate | MouseInput::Handled => {}
             MouseInput::NotHandled => return Ok(ComponentInputResult::NotHandled),
         }
         Ok(ComponentInputResult::Handled)

--- a/src/ui/evolog_tab.rs
+++ b/src/ui/evolog_tab.rs
@@ -280,7 +280,8 @@ impl Component for EvologTab<'_> {
                 }
             }
             MouseInput::Copy(text) => return Ok(copy_marked(text)),
-            MouseInput::Handled => {}
+            // Nothing here has a second thing a double click could do.
+            MouseInput::Activate | MouseInput::Handled => {}
             MouseInput::NotHandled => return Ok(ComponentInputResult::NotHandled),
         }
         Ok(ComponentInputResult::Handled)

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -501,7 +501,8 @@ impl Component for FilesTab {
                 }
             }
             MouseInput::Copy(text) => return Ok(copy_marked(text)),
-            MouseInput::Handled => {}
+            // Nothing here has a second thing a double click could do.
+            MouseInput::Activate | MouseInput::Handled => {}
             MouseInput::NotHandled => return Ok(ComponentInputResult::NotHandled),
         }
         Ok(ComponentInputResult::Handled)

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -526,7 +526,7 @@ impl Component for LogTab<'_> {
             MouseInput::Scroll(delta) => self.log_panel.scroll_relative(delta),
             MouseInput::Select(index) => {
                 if let Some(head) = self.log_panel.head_at_log_line(index) {
-                    self.log_panel.set_head(head);
+                    self.log_panel.set_head_in_place(head);
                 }
             }
             // The graph takes lines of its own, which name no change

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -529,6 +529,9 @@ impl Component for LogTab<'_> {
                     self.log_panel.set_head_in_place(head);
                 }
             }
+            // The press before this one selected the change, so all that
+            // is left to do is mark it.
+            MouseInput::Activate => self.log_panel.toggle_head_mark(),
             // The graph takes lines of its own, which name no change
             // for a menu to act on.
             MouseInput::Context(index) => {

--- a/src/ui/panel/list_pane.rs
+++ b/src/ui/panel/list_pane.rs
@@ -35,6 +35,11 @@ pub struct ListPane {
 
     /// Index of the first item drawn, as chosen by the list itself.
     offset: usize,
+
+    /// Item the last press hit. Selecting one can scroll the list, so a
+    /// second press on the cell may well be about another item, which is
+    /// not what a double click is.
+    pressed: Option<usize>,
 }
 
 impl ListPane {
@@ -113,16 +118,84 @@ impl PanelMouseInput for ListPane {
         match mouse.kind() {
             MouseEventKind::ScrollDown => MouseInput::Scroll(1),
             MouseEventKind::ScrollUp => MouseInput::Scroll(-1),
-            MouseEventKind::Down(MouseButton::Left) => match self.item_at(pos) {
-                Some(index) => MouseInput::Select(index),
-                // A click in the pane is ours even when it hits no item.
-                None => MouseInput::Handled,
-            },
+            MouseEventKind::Down(MouseButton::Left) => {
+                let hit = self.item_at(pos);
+                let double = mouse.clicks() == 2 && hit == self.pressed;
+                self.pressed = hit;
+                match hit {
+                    // The second press of a double click acts on the item
+                    // the first one selected; a third does nothing new.
+                    Some(_) if double => MouseInput::Activate,
+                    Some(index) => MouseInput::Select(index),
+                    // A click in the pane is ours even when it hits no item.
+                    None => MouseInput::Handled,
+                }
+            }
             MouseEventKind::Down(MouseButton::Right) => match self.item_at(pos) {
                 Some(index) => MouseInput::Context(index),
                 None => MouseInput::Handled,
             },
             _ => MouseInput::NotHandled,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A pane showing ten items in five rows, drawn from `offset` on.
+    fn pane(offset: usize) -> ListPane {
+        ListPane {
+            panel_rect: Rect::new(0, 0, 10, 7),
+            content_rect: Rect::new(1, 1, 8, 5),
+            item_count: 10,
+            offset,
+            pressed: None,
+        }
+    }
+
+    fn press(pane: &mut ListPane, row: u16, clicks: u8) -> MouseInput {
+        pane.input_mouse(Mouse::new(
+            MouseEventKind::Down(MouseButton::Left),
+            Position::new(2, row),
+            clicks,
+        ))
+    }
+
+    #[test]
+    fn a_press_selects_the_item_it_hits() {
+        let mut pane = pane(3);
+
+        assert!(matches!(press(&mut pane, 2, 1), MouseInput::Select(4)));
+    }
+
+    #[test]
+    fn a_second_press_on_the_item_activates_it() {
+        let mut pane = pane(3);
+        press(&mut pane, 2, 1);
+
+        assert!(matches!(press(&mut pane, 2, 2), MouseInput::Activate));
+    }
+
+    /// Selecting an item may scroll the list, which puts another item
+    /// under the pointer. Acting on that one is not what the double click
+    /// was aimed at, so it only selects.
+    #[test]
+    fn a_second_press_on_another_item_selects_it() {
+        let mut pane = pane(3);
+        press(&mut pane, 2, 1);
+        pane.offset = 2;
+
+        assert!(matches!(press(&mut pane, 2, 2), MouseInput::Select(3)));
+    }
+
+    #[test]
+    fn a_third_press_selects_the_item_again() {
+        let mut pane = pane(3);
+        press(&mut pane, 2, 1);
+        press(&mut pane, 2, 2);
+
+        assert!(matches!(press(&mut pane, 2, 3), MouseInput::Select(4)));
     }
 }

--- a/src/ui/panel/mod.rs
+++ b/src/ui/panel/mod.rs
@@ -35,6 +35,10 @@ pub(crate) enum MouseInput {
     /// what its items represent, so it is up to the caller to map the
     /// index onto its own domain type.
     Select(usize),
+    /// The selected item was double-clicked, asking for whatever the
+    /// caller offers as the second thing to do to an item. Only ever
+    /// follows a [`MouseInput::Select`] of that same item.
+    Activate,
     /// The item at this index was right-clicked, asking for whatever the
     /// caller offers as a context menu.
     Context(usize),


### PR DESCRIPTION
Marking a change for the batch commands is only bound to a key, so the
mouse can select a change but not put it into the set they act on. Let a
double click in the log toggle the mark, now that we count the presses a
click is made of.

Clicking a change also scrolled the log to put some context around the
selection, which moved the line out from under the pointer and made a
second click land elsewhere, so a click now selects in place as the
right click already does.