### PR TITLE
ui: Configure blazingjj from inside the app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `blazingjj.diff-pager` and toggled through with `w` like the others
 - The details panel now names the diff format it renders in, in its top
   right corner
+- Settings tab, listing the `blazingjj.*` options with what the configuration
+  says about them and what the app goes by while it says nothing; opened from the
+  tab bar with `0`, where it sits after the tabs that show the repo. `Enter`
+  changes the selected setting and `x` takes it back out of your config, both
+  through `jj config` on the user config file and both configurable under
+  `[blazingjj.keybinds.settings-tab]`. A change takes effect at once, without
+  a restart
 - Keybinding in the bookmarks tab to point a bookmark at the change the
   selected line stands for (`b`, as in the log tab), which settles a bookmark
   torn between several targets on the one selected, and moves a bookmark to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   through `jj config` on the user config file and both configurable under
   `[blazingjj.keybinds.settings-tab]`. A change takes effect at once, without
   a restart
+- Keybindings tab, opened from the settings tab's `blazingjj.keybinds` row,
+  listing every action a key can be bound to under the heading of where its
+  keys take effect. `Enter` takes the next key you press for the selected
+  action and `a` takes one more key beside the keys it has, `X` leaves it bound
+  to nothing and `x` takes the binding back out of your config; `Esc` goes back
+  to the settings
 - Keybinding in the bookmarks tab to point a bookmark at the change the
   selected line stands for (`b`, as in the log tab), which settles a bookmark
   torn between several targets on the one selected, and moves a bookmark to

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ Built in Rust with Ratatui. Interacts with `jj` CLI.
     an editor
   - Change the selected setting with `Enter`, take it back out of your config
     with `x`
+  - Rebind any key from the `blazingjj.keybinds` row: `Enter` on an action
+    takes the next key you press for it, `a` takes one more key beside the
+    keys it has, `X` leaves it bound to nothing
 - Config: Configure blazingjj with your jj config
 - Command box: Run jj commands directly in blazingjj with `:`
 - Help: See all key mappings with `?`
@@ -102,6 +105,9 @@ Example: `jj config set --user blazingjj.diff-format "color-words"` (for storing
 The settings tab (`0`) does the same from within blazingjj. It shows what your
 configuration says now, whichever file it comes from, and writes to the user
 config file; a setting that comes from anywhere else has to be changed there.
+Its `blazingjj.keybinds` row opens the keybindings, which are changed there one
+action at a time; [docs/keybindings.md](docs/keybindings.md) says what they are
+and how to write them out yourself.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ Built in Rust with Ratatui. Interacts with `jj` CLI.
   to mark it, drag the divider to resize, right click for the context menu,
   drag over the details panel (or double click a word, triple click a line) to
   copy its text
+- Settings
+  - Change any of the options below from within blazingjj, without leaving for
+    an editor
+  - Change the selected setting with `Enter`, take it back out of your config
+    with `x`
 - Config: Configure blazingjj with your jj config
 - Command box: Run jj commands directly in blazingjj with `:`
 - Help: See all key mappings with `?`
@@ -93,6 +98,10 @@ You can optionally configure the following options through your jj config:
   - A terminal that does not report focus changes counts as always focused, so there the hint is all you get
 
 Example: `jj config set --user blazingjj.diff-format "color-words"` (for storing in [user config file](https://martinvonz.github.io/jj/latest/config/#user-config-file), repo config is also supported)
+
+The settings tab (`0`) does the same from within blazingjj. It shows what your
+configuration says now, whichever file it comes from, and writes to the user
+config file; a setting that comes from anywhere else has to be changed there.
 
 ## Usage
 

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -11,6 +11,14 @@ describe = false
 
 In below examples default values are used.
 
+The keybindings tab does the same from within blazingjj: the settings tab
+(`0`) opens it on the `blazingjj.keybinds` row, and it lists every action
+under the heading of where its keys take effect. A key is written under
+the name it reads by, so what the app shows is also what the config file
+takes; a key it has no name for, such as one of the lock keys, is one
+it cannot offer. `Enter` takes the key you press next as the one key an
+action answers to, `a` takes it as another key beside the ones it has.
+
 ### Global
 
 These work in every tab, and `scroll-down` and `scroll-up` scroll the
@@ -185,4 +193,15 @@ copy-rev = "shift+y"
 [blazingjj.keybinds.settings-tab]
 change = "enter"
 unset = "x"
+```
+
+### Keybindings tab
+
+```toml
+[blazingjj.keybinds.keybindings-tab]
+bind = "enter"
+bind-besides = "a"
+disable = "shift+x"
+unset = "x"
+back = "esc"
 ```

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -14,7 +14,7 @@ In below examples default values are used.
 ### Global
 
 These work in every tab, and `scroll-down` and `scroll-up` scroll the
-popups as well. Selecting a tab by its number in the tab bar (`1` to `4`)
+popups as well. Selecting a tab by its number in the tab bar (`0` to `4`)
 is not configurable.
 
 ```toml
@@ -177,4 +177,12 @@ edit-change-ignore-immutable = "shift+e"
 open-files = "enter"
 duplicate = "shift+d"
 copy-rev = "shift+y"
+```
+
+### Settings tab
+
+```toml
+[blazingjj.keybinds.settings-tab]
+change = "enter"
+unset = "x"
 ```

--- a/src/app.rs
+++ b/src/app.rs
@@ -56,6 +56,7 @@ use crate::ui::dialog::CommandPopup;
 use crate::ui::dialog::HelpPopup;
 use crate::ui::evolog_tab::EvologTab;
 use crate::ui::files_tab::FilesTab;
+use crate::ui::keybindings_tab::KeybindingsTab;
 use crate::ui::log_tab::LogTab;
 use crate::ui::settings_tab::SettingsTab;
 
@@ -66,6 +67,9 @@ pub enum TabId {
     Bookmarks,
     Evolog,
     Settings,
+    /// The keybindings, which the settings tab opens and which has no
+    /// place of its own in the tab bar.
+    Keybindings,
 }
 
 impl fmt::Display for TabId {
@@ -76,11 +80,23 @@ impl fmt::Display for TabId {
             TabId::Bookmarks => write!(f, "Bookmarks"),
             TabId::Evolog => write!(f, "Evolog"),
             TabId::Settings => write!(f, "Settings"),
+            TabId::Keybindings => write!(f, "Keybindings"),
         }
     }
 }
 
 impl TabId {
+    /// Every tab there is, the transient one included
+    pub const ALL: [Self; 6] = [
+        TabId::Log,
+        TabId::Files,
+        TabId::Bookmarks,
+        TabId::Evolog,
+        TabId::Settings,
+        TabId::Keybindings,
+    ];
+
+    /// The tabs the tab bar lists, in the order it lists them
     pub const VALUES: [Self; 5] = [
         TabId::Log,
         TabId::Files,
@@ -89,12 +105,21 @@ impl TabId {
         TabId::Settings,
     ];
 
+    /// Where in the tab bar the tab shows, which for a tab that has no
+    /// place of its own is the place of the tab that opens it.
+    pub fn in_tab_bar(self) -> Self {
+        match self {
+            TabId::Keybindings => TabId::Settings,
+            tab => tab,
+        }
+    }
+
     /// The number the tab is picked by, which is where it sits in the
-    /// tab bar except for the settings tab, which comes first by its
-    /// number and last in the bar.
+    /// tab bar except for the settings tab and the one it opens: those
+    /// come first by their number and last in the bar.
     pub fn number(self) -> usize {
         match self {
-            TabId::Settings => 0,
+            TabId::Settings | TabId::Keybindings => 0,
             TabId::Log => 1,
             TabId::Files => 2,
             TabId::Bookmarks => 3,
@@ -143,6 +168,7 @@ pub struct App<'a> {
     pub bookmarks: BookmarksTab,
     pub evolog: EvologTab<'a>,
     pub settings: SettingsTab,
+    pub keybindings: KeybindingsTab,
     pub popup: Option<Box<dyn Component>>,
     pub stats: Stats,
     /// Where the tabs overview was last drawn, for mouse input.
@@ -174,10 +200,6 @@ impl<'a> App<'a> {
         let running = Arc::from(AtomicBool::new(true));
         let event_source = EventSource::new(running.clone());
         let background_tasks = BackgroundTasks::new(event_source.clone_event_sender());
-        let mut global_keybinds = GlobalKeybinds::default();
-        if let Some(keybinds_config) = get_env().jj_config.keybinds() {
-            global_keybinds.extend_from_config(keybinds_config);
-        }
         let current_head = new_commander().get_current_head()?;
 
         Ok(App {
@@ -187,13 +209,14 @@ impl<'a> App<'a> {
             bookmarks: BookmarksTab::new(background_tasks.clone()),
             evolog: EvologTab::new(&current_head, background_tasks.clone()),
             settings: SettingsTab::new(),
+            keybindings: KeybindingsTab::new(),
             popup: None,
             stats: Stats {
                 start_time: Instant::now(),
             },
             tabs_rect: Rect::ZERO,
             tab_hits: Vec::new(),
-            global_keybinds,
+            global_keybinds: GlobalKeybinds::new(),
             popup_keybinds: PopupKeybinds::dialog(),
 
             repo_watch: RepoWatch::new(get_env().jj_config.poll_interval(), Instant::now()),
@@ -213,7 +236,7 @@ impl<'a> App<'a> {
     pub fn set_next_tab_with_offset(&mut self, offset: i64) {
         let current_index = TabId::VALUES
             .iter()
-            .position(|&t| t == self.current_tab)
+            .position(|&t| t == self.current_tab.in_tab_bar())
             .unwrap();
         let new_index = (current_index as i64 + TabId::VALUES.len() as i64 + offset) as usize
             % TabId::VALUES.len();
@@ -222,13 +245,13 @@ impl<'a> App<'a> {
     }
 
     fn open_help(&mut self) -> Result<()> {
-        let global_help = self.global_keybinds.make_help();
+        let global_bindings = self.global_keybinds.bindings();
         let tab = self.get_current_tab();
         let sections = HelpSection::gather(
-            global_help
+            global_bindings
                 .into_iter()
-                .chain(tab.make_main_panel_help())
-                .chain(tab.make_details_panel_help()),
+                .chain(tab.main_panel_bindings())
+                .chain(tab.details_panel_bindings()),
         );
 
         let (side, main) = sections
@@ -322,9 +345,19 @@ impl<'a> App<'a> {
         }
     }
 
+    /// Take up the configuration as it now reads, which every tab and
+    /// the app itself hold what they go by of.
+    fn config_changed(&mut self) {
+        self.global_keybinds = GlobalKeybinds::new();
+        self.popup_keybinds = PopupKeybinds::dialog();
+        for tab in TabId::ALL {
+            self.get_tab(tab).config_changed();
+        }
+    }
+
     /// Every tab is behind on what it shows, whoever moved the repo.
     fn mark_all_stale(&mut self) {
-        for tab in TabId::VALUES {
+        for tab in TabId::ALL {
             self.get_tab(tab).mark_stale();
         }
     }
@@ -336,6 +369,7 @@ impl<'a> App<'a> {
             TabId::Bookmarks => &mut self.bookmarks,
             TabId::Evolog => &mut self.evolog,
             TabId::Settings => &mut self.settings,
+            TabId::Keybindings => &mut self.keybindings,
         }
     }
 
@@ -368,6 +402,9 @@ impl<'a> App<'a> {
             AppAction::ViewLog(head) => {
                 self.log.set_head(head);
                 self.set_tab(TabId::Log);
+            }
+            AppAction::ViewTab(tab) => {
+                self.set_tab(tab);
             }
             AppAction::ViewBookmark(name) => {
                 self.set_tab(TabId::Bookmarks);
@@ -418,13 +455,11 @@ impl<'a> App<'a> {
 
                 self.repo_watch
                     .set_interval(get_env().jj_config.poll_interval());
-                for tab in TabId::VALUES {
-                    self.get_tab(tab).config_changed();
-                }
                 // The change is ours, so the tabs are caught up with it
                 // rather than left stale for the user to ask: nothing
                 // moves under them that they did not just ask for.
                 self.repo_watch.catching_up();
+                self.config_changed();
                 self.mark_all_stale();
             }
         }
@@ -482,7 +517,7 @@ impl<'a> App<'a> {
                 .select(
                     TabId::VALUES
                         .iter()
-                        .position(|tab| tab == &self.current_tab)
+                        .position(|tab| *tab == self.current_tab.in_tab_bar())
                         .unwrap_or(0),
                 )
                 .divider(symbols::line::VERTICAL);

--- a/src/app.rs
+++ b/src/app.rs
@@ -34,6 +34,7 @@ use crate::background_tasks::TaskSlot;
 use crate::commander::ids::OperationId;
 use crate::commander::new_commander;
 use crate::env::get_env;
+use crate::env::reload_env;
 use crate::event::AppEvent;
 use crate::event::Clicks;
 use crate::event::EventSource;
@@ -56,6 +57,7 @@ use crate::ui::dialog::HelpPopup;
 use crate::ui::evolog_tab::EvologTab;
 use crate::ui::files_tab::FilesTab;
 use crate::ui::log_tab::LogTab;
+use crate::ui::settings_tab::SettingsTab;
 
 #[derive(PartialEq, Copy, Clone, Debug)]
 pub enum TabId {
@@ -63,6 +65,7 @@ pub enum TabId {
     Files,
     Bookmarks,
     Evolog,
+    Settings,
 }
 
 impl fmt::Display for TabId {
@@ -72,13 +75,51 @@ impl fmt::Display for TabId {
             TabId::Files => write!(f, "Files"),
             TabId::Bookmarks => write!(f, "Bookmarks"),
             TabId::Evolog => write!(f, "Evolog"),
+            TabId::Settings => write!(f, "Settings"),
         }
     }
 }
 
 impl TabId {
-    pub const VALUES: [Self; 4] = [TabId::Log, TabId::Files, TabId::Bookmarks, TabId::Evolog];
+    pub const VALUES: [Self; 5] = [
+        TabId::Log,
+        TabId::Files,
+        TabId::Bookmarks,
+        TabId::Evolog,
+        TabId::Settings,
+    ];
+
+    /// The number the tab is picked by, which is where it sits in the
+    /// tab bar except for the settings tab, which comes first by its
+    /// number and last in the bar.
+    pub fn number(self) -> usize {
+        match self {
+            TabId::Settings => 0,
+            TabId::Log => 1,
+            TabId::Files => 2,
+            TabId::Bookmarks => 3,
+            TabId::Evolog => 4,
+        }
+    }
 }
+
+/// The line of hints in the header, in the three pieces the refresh key
+/// is lit up on its own in.
+const HINTS_BEFORE_REFRESH: &str = "q: quit | ?: help | ";
+const HINTS_REFRESH: &str = "R: refresh";
+const HINTS_AFTER_REFRESH: &str = " | 0-4: tabs";
+
+/// How much of the right of the header the runtime is drawn over. It is
+/// a count of milliseconds, which takes a column more every tenfold, so
+/// this is room for a session of days rather than a fixed width.
+const RUNTIME_WIDTH: usize = 12;
+
+/// How wide the hints are with their border and the runtime beside them.
+const HINTS_WIDTH: u16 = (HINTS_BEFORE_REFRESH.len()
+    + HINTS_REFRESH.len()
+    + HINTS_AFTER_REFRESH.len()
+    + 2
+    + RUNTIME_WIDTH) as u16;
 
 pub struct Stats {
     pub start_time: Instant,
@@ -101,6 +142,7 @@ pub struct App<'a> {
     pub files: FilesTab,
     pub bookmarks: BookmarksTab,
     pub evolog: EvologTab<'a>,
+    pub settings: SettingsTab,
     pub popup: Option<Box<dyn Component>>,
     pub stats: Stats,
     /// Where the tabs overview was last drawn, for mouse input.
@@ -144,6 +186,7 @@ impl<'a> App<'a> {
             files: FilesTab::new(&current_head, background_tasks.clone()),
             bookmarks: BookmarksTab::new(background_tasks.clone()),
             evolog: EvologTab::new(&current_head, background_tasks.clone()),
+            settings: SettingsTab::new(),
             popup: None,
             stats: Stats {
                 start_time: Instant::now(),
@@ -292,6 +335,7 @@ impl<'a> App<'a> {
             TabId::Files => &mut self.files,
             TabId::Bookmarks => &mut self.bookmarks,
             TabId::Evolog => &mut self.evolog,
+            TabId::Settings => &mut self.settings,
         }
     }
 
@@ -365,6 +409,24 @@ impl<'a> App<'a> {
             AppAction::RunInteractive(interactive) => {
                 self.pending_interactive = Some(interactive);
             }
+            AppAction::ConfigChanged => {
+                // Whatever went wrong reading it, the app goes on with
+                // the configuration it has rather than coming down.
+                if let Err(err) = reload_env() {
+                    warn!("Could not read the configuration again: {err:#}");
+                }
+
+                self.repo_watch
+                    .set_interval(get_env().jj_config.poll_interval());
+                for tab in TabId::VALUES {
+                    self.get_tab(tab).config_changed();
+                }
+                // The change is ours, so the tabs are caught up with it
+                // rather than left stale for the user to ask: nothing
+                // moves under them that they did not just ask for.
+                self.repo_watch.catching_up();
+                self.mark_all_stale();
+            }
         }
 
         Ok(())
@@ -396,16 +458,17 @@ impl<'a> App<'a> {
             .constraints([Constraint::Length(3), Constraint::Min(1)])
             .split(area);
 
+        // The hints are the same however wide the window is, so the tab
+        // bar is given everything they do not need.
         let header_chunks = Layout::default()
             .direction(Direction::Horizontal)
-            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .constraints([Constraint::Fill(1), Constraint::Max(HINTS_WIDTH)])
             .split(chunks[0]);
 
         {
             let titles: Vec<String> = TabId::VALUES
                 .iter()
-                .enumerate()
-                .map(|(i, tab)| format!("[{}] {}", i + 1, tab))
+                .map(|tab| format!("[{}] {}", tab.number(), tab))
                 .collect();
 
             let block = Block::bordered()
@@ -436,9 +499,9 @@ impl<'a> App<'a> {
             };
 
             let hints = Paragraph::new(Line::from(vec![
-                Span::raw("q: quit | ?: help | "),
-                Span::styled("R: refresh", refresh_style),
-                Span::raw(" | 1-4: change tab"),
+                Span::raw(HINTS_BEFORE_REFRESH),
+                Span::styled(HINTS_REFRESH, refresh_style),
+                Span::raw(HINTS_AFTER_REFRESH),
             ]))
             .fg(Color::DarkGray)
             .block(
@@ -739,6 +802,7 @@ impl<'a> App<'a> {
                             GlobalEvent::FilesTab => self.set_tab(TabId::Files),
                             GlobalEvent::BookmarksTab => self.set_tab(TabId::Bookmarks),
                             GlobalEvent::EvologTab => self.set_tab(TabId::Evolog),
+                            GlobalEvent::SettingsTab => self.set_tab(TabId::Settings),
                             GlobalEvent::OpenContextMenu => {
                                 if let Some(action) = self.get_current_tab().open_context_menu()? {
                                     self.handle_action(action)?;

--- a/src/app/command.rs
+++ b/src/app/command.rs
@@ -120,6 +120,17 @@ pub enum Command {
     ForgetBookmark(String),
     TrackBookmark(Bookmark),
     UntrackBookmark(Bookmark),
+    /// Set an option in the user's config, `value` being the TOML
+    /// expression to set it to.
+    SetSetting {
+        key: String,
+        value: String,
+    },
+    /// Take an option out of the user's config, leaving whatever the
+    /// rest of the configuration says.
+    UnsetSetting {
+        key: String,
+    },
 }
 
 impl Command {
@@ -325,6 +336,16 @@ impl Command {
                     Err(err) => Ok(Some(refused("Untrack", err))),
                 }
             }
+            Command::SetSetting { key, value } => {
+                match new_commander().set_user_config(&key, &value) {
+                    Ok(()) => Ok(Some(AppAction::ConfigChanged)),
+                    Err(err) => Ok(Some(refused("Set", err))),
+                }
+            }
+            Command::UnsetSetting { key } => match new_commander().unset_user_config(&key) {
+                Ok(()) => Ok(Some(AppAction::ConfigChanged)),
+                Err(err) => Ok(Some(refused("Unset", err))),
+            },
         }
     }
 }

--- a/src/app/repo_watch.rs
+++ b/src/app/repo_watch.rs
@@ -87,6 +87,12 @@ impl RepoWatch {
         }
     }
 
+    /// Poll every `interval` from here on, or only check when asked if
+    /// that is None.
+    pub fn set_interval(&mut self, interval: Option<Duration>) {
+        self.interval = interval;
+    }
+
     /// Ask for a check that does not wait out the interval.
     pub fn ask_check(&mut self, check: Check) {
         self.asked = true;
@@ -479,6 +485,27 @@ mod tests {
         assert!(watch.checked(now, op_id("b")));
 
         assert!(watch.leave_stale(true));
+    }
+
+    /// A change the app makes itself, a setting written from the
+    /// settings tab among them, is one the view is caught up with even
+    /// where it was already waiting to be asked: nothing moves under
+    /// the user that they did not just ask for.
+    #[test]
+    fn catches_up_with_a_change_of_its_own_while_waiting_to_be_asked() {
+        let now = Instant::now();
+        let mut watch = watch(now);
+        watch.check_to_start(moment(now));
+        watch.checked(now, op_id("a"));
+        watch.check_to_start(moment(now + INTERVAL));
+        watch.checked(now, op_id("b"));
+        watch.leave_stale(true);
+        assert!(watch.waiting_for_refresh());
+
+        watch.catching_up();
+
+        watch.leave_stale(true);
+        assert!(!watch.waiting_for_refresh());
     }
 
     #[test]

--- a/src/commander/config.rs
+++ b/src/commander/config.rs
@@ -1,0 +1,88 @@
+/*!
+[Commander] member functions for reading and changing the jj
+configuration.
+
+The app only ever writes to the user's own config file, which is the
+layer a setting belongs in when it says how the app is to look and
+behave rather than anything about the repo.
+*/
+use anyhow::Context;
+use anyhow::Result;
+use tracing::instrument;
+
+use crate::commander::Commander;
+
+impl Commander {
+    /// What the user's own config file says. Maps to
+    /// `jj config list --user`.
+    #[instrument(level = "trace", skip(self))]
+    pub fn get_user_config(&self) -> Result<toml::Table> {
+        // What jj lists is TOML of dotted keys.
+        self.jj(["config", "list", "--user"])
+            .run()
+            .context("Failed to get jj config")?
+            .parse()
+            .context("Failed to parse jj config")
+    }
+
+    /// Set an option in the user's config file, `value` being the TOML
+    /// expression to set it to. Maps to `jj config set --user`.
+    #[instrument(level = "trace", skip(self))]
+    pub fn set_user_config(&self, key: &str, value: &str) -> Result<()> {
+        self.jj(["config", "set", "--user", key, value])
+            .run_void()
+            .context("Failed executing jj config set")
+    }
+
+    /// Take an option out of the user's config file, leaving whatever
+    /// the other layers say. Maps to `jj config unset --user`.
+    #[instrument(level = "trace", skip(self))]
+    pub fn unset_user_config(&self, key: &str) -> Result<()> {
+        self.jj(["config", "unset", "--user", key])
+            .run_void()
+            .context("Failed executing jj config unset")
+    }
+}
+
+/// What the configuration says about `key`, which names a value through
+/// the tables holding it, as `blazingjj.layout` does.
+pub fn config_value<'a>(config: &'a toml::Table, key: &str) -> Option<&'a toml::Value> {
+    let (path, name) = key.rsplit_once('.')?;
+
+    let mut table = config;
+    for step in path.split('.') {
+        table = table.get(step)?.as_table()?;
+    }
+
+    table.get(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config() -> toml::Table {
+        "blazingjj.layout = \"vertical\"\nui.diff.format = \"git\"\n"
+            .parse()
+            .expect("the listing parses")
+    }
+
+    #[test]
+    fn a_dotted_key_names_a_value_through_the_tables_holding_it() {
+        assert_eq!(
+            config_value(&config(), "blazingjj.layout"),
+            Some(&toml::Value::String("vertical".to_owned()))
+        );
+        assert_eq!(
+            config_value(&config(), "ui.diff.format"),
+            Some(&toml::Value::String("git".to_owned()))
+        );
+    }
+
+    #[test]
+    fn a_key_the_configuration_says_nothing_about_has_no_value() {
+        assert_eq!(config_value(&config(), "blazingjj.layout-percent"), None);
+        assert_eq!(config_value(&config(), "ui.diff.tool"), None);
+        assert_eq!(config_value(&config(), "aliases.f.doc"), None);
+    }
+}

--- a/src/commander/mod.rs
+++ b/src/commander/mod.rs
@@ -26,6 +26,7 @@ invocation with [Commander::jj], which returns a [JjCommand] builder:
 
 pub mod bookmarks;
 pub mod cancel;
+pub mod config;
 pub mod files;
 pub mod ids;
 pub mod jj;
@@ -586,6 +587,7 @@ pub mod tests {
 
             let env = Env {
                 root: directory.path().to_string_lossy().to_string(),
+                config: toml::Table::new(),
                 jj_config: JjConfig::default(),
                 default_revset: None,
                 jj_bin,

--- a/src/env.rs
+++ b/src/env.rs
@@ -182,6 +182,7 @@ impl JjConfig {
         self.blazingjj.layout
     }
 
+    /// The share of a tab the main panel takes, in percent.
     pub fn layout_percent(&self) -> u16 {
         self.blazingjj.layout_percent
     }

--- a/src/env.rs
+++ b/src/env.rs
@@ -8,11 +8,16 @@ It is a combination of
 use std::fmt;
 use std::path::PathBuf;
 use std::process::Command;
-use std::sync::OnceLock;
+use std::ptr;
+#[cfg(test)]
+use std::sync::Once;
+use std::sync::atomic::AtomicPtr;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use anyhow::Context;
 use anyhow::Result;
+use anyhow::anyhow;
 use anyhow::bail;
 use ratatui::style::Color;
 use serde::Deserialize;
@@ -24,35 +29,79 @@ use crate::commander::RemoveEndLine;
 use crate::commander::get_output_args;
 use crate::keybinds::KeybindsConfig;
 
-/// Singleton holding application environment
-static ENV: OnceLock<Env> = OnceLock::new();
+/// Singleton holding application environment.
+///
+/// The environment is read through a `&'static`, so putting another one
+/// in place leaks the one that was there: whoever is reading it may
+/// still be looking at it.
+static ENV: AtomicPtr<Env> = AtomicPtr::new(ptr::null_mut());
 
-/// Set application environment. Panics if called twice
+/// Set application environment, in place of whatever was set before.
 pub fn set_env(env: Env) {
-    ENV.set(env).expect("set_env must only be called once");
+    ENV.store(Box::into_raw(Box::new(env)), Ordering::Release);
 }
 
 /// Get application environment. Panics if not set first
 pub fn get_env() -> &'static Env {
-    ENV.get().unwrap()
+    env().expect("the environment is set before anything reads it")
 }
 
 /// The configured keybindings, if any. Unlike [`get_env()`], this works
 /// before the environment is set, as in tests building components.
 pub fn keybinds_config() -> Option<&'static KeybindsConfig> {
-    ENV.get().and_then(|env| env.jj_config.keybinds())
+    env().and_then(|env| env.jj_config.keybinds())
+}
+
+/// Read the configuration again and put the environment it makes up in
+/// place of the one the app has been running on.
+pub fn reload_env() -> Result<()> {
+    let env = get_env();
+    let (config, jj_config) = read_jj_config(&env.root, &env.jj_bin)?;
+
+    set_env(Env {
+        config,
+        jj_config,
+        ..env.clone()
+    });
+
+    Ok(())
+}
+
+/// The environment, if one has been set.
+fn env() -> Option<&'static Env> {
+    // SAFETY: the pointer is either null or one leaked in `set_env`, and
+    // nothing ever frees what it points at.
+    unsafe { ENV.load(Ordering::Acquire).as_ref() }
 }
 
 /// A default environment for tests that build components reading it. The
 /// tests share one process, so whichever gets there first sets it.
 #[cfg(test)]
 pub fn set_test_env() {
-    let _ = ENV.set(Env {
-        root: ".".to_owned(),
-        jj_config: JjConfig::default(),
-        default_revset: None,
-        jj_bin: "jj".to_owned(),
+    static ONCE: Once = Once::new();
+
+    ONCE.call_once(|| {
+        set_env(Env {
+            root: ".".to_owned(),
+            config: toml::Table::new(),
+            jj_config: JjConfig::default(),
+            default_revset: None,
+            jj_bin: "jj".to_owned(),
+        })
     });
+}
+
+/// Whether the configuration would still be read the same way with `key`
+/// set to `value`, which is a TOML expression as `jj config set` takes
+/// one.
+pub fn check_config_value(key: &str, value: &str) -> Result<()> {
+    // Only what the value was refused for is worth reading; the line
+    // and column of a document we wrote ourselves are not.
+    toml::from_str::<JjConfig>(&format!("{key} = {value}\n"))
+        .map_err(|err| anyhow!("{}", err.message()))
+        .context("The setting cannot take that value")?;
+
+    Ok(())
 }
 
 #[derive(Deserialize, Debug, Clone, Default)]
@@ -73,6 +122,9 @@ pub struct JjConfigBlazingjj {
     diff_pager: Option<DiffPager>,
     bookmark_template: Option<String>,
     layout: JJLayout,
+    /// The share of a tab the main panel takes, of the whole of it at
+    /// the most.
+    #[serde(deserialize_with = "deserialize_layout_percent")]
     layout_percent: u16,
     keybinds: Option<KeybindsConfig>,
     /// How long to wait between checks for work done outside the app, or
@@ -97,6 +149,18 @@ impl Default for JjConfigBlazingjj {
             keybinds: None,
         }
     }
+}
+
+/// Reads a share of a tab, which is refused above the whole of it: a
+/// share the panels cannot be divided in is one to say something about
+/// where it is set rather than one to make what we can of.
+fn deserialize_layout_percent<'de, D: Deserializer<'de>>(deserializer: D) -> Result<u16, D::Error> {
+    let percent = u16::deserialize(deserializer)?;
+    if percent > 100 {
+        return Err(de::Error::custom("a share of a tab is 100 percent at most"));
+    }
+
+    Ok(percent)
 }
 
 /// Reads a number of seconds, of which zero means never checking.
@@ -182,7 +246,6 @@ impl JjConfig {
         self.blazingjj.layout
     }
 
-    /// The share of a tab the main panel takes, in percent.
     pub fn layout_percent(&self) -> u16 {
         self.blazingjj.layout_percent
     }
@@ -199,6 +262,10 @@ impl JjConfig {
 #[derive(Debug, Clone)]
 pub struct Env {
     pub jj_config: JjConfig,
+    /// The configuration as jj lists it, which is what an option is
+    /// read out of by the key it is named by rather than by what the
+    /// app makes of it.
+    pub config: toml::Table,
     pub root: String,
     pub default_revset: Option<String>,
     pub jj_bin: String,
@@ -216,25 +283,37 @@ impl Env {
             bail!("No jj repository found in {}", path.to_str().unwrap_or(""))
         }
         let root = String::from_utf8(root_output.stdout)?.remove_end_line();
-
-        // Read/parse jj config
-        let cfg = Command::new(&jj_bin)
-            .arg("config")
-            .arg("list")
-            .args(get_output_args(false, true))
-            .current_dir(&root)
-            .output()
-            .context("Failed to get jj config")?
-            .stdout;
-        let jj_config: JjConfig = toml::from_slice(&cfg).context("Failed to parse jj config")?;
+        let (config, jj_config) = read_jj_config(&root, &jj_bin)?;
 
         Ok(Env {
             root,
+            config,
             jj_config,
             default_revset,
             jj_bin,
         })
     }
+}
+
+/// What the configuration of the repo at `root` says, across all the
+/// layers jj reads it from, as it is listed and as the app reads it.
+fn read_jj_config(root: &str, jj_bin: &str) -> Result<(toml::Table, JjConfig)> {
+    let cfg = Command::new(jj_bin)
+        .arg("config")
+        .arg("list")
+        .args(get_output_args(false, true))
+        .current_dir(root)
+        .output()
+        .context("Failed to get jj config")?
+        .stdout;
+
+    let config: toml::Table = toml::from_slice(&cfg).context("Failed to parse jj config")?;
+    let jj_config = config
+        .clone()
+        .try_into()
+        .context("Failed to read the jj config")?;
+
+    Ok((config, jj_config))
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Default, PartialEq)]
@@ -540,6 +619,17 @@ mod tests {
 
         let with_tool = config(r#"blazingjj.diff-tool = "difft""#);
         assert_eq!(DiffFormat::Git.get_next(&with_tool), difft);
+    }
+
+    #[test]
+    fn a_value_is_checked_against_the_setting_it_is_for() {
+        assert!(check_config_value("blazingjj.layout", "\"vertical\"").is_ok());
+        assert!(check_config_value("blazingjj.layout-percent", "40").is_ok());
+
+        // A number written as text is not a number, and neither is text
+        // that names nothing the setting can be.
+        assert!(check_config_value("blazingjj.layout-percent", "\"40\"").is_err());
+        assert!(check_config_value("blazingjj.layout", "\"sideways\"").is_err());
     }
 
     #[test]

--- a/src/keybinds/bookmark_set_popup.rs
+++ b/src/keybinds/bookmark_set_popup.rs
@@ -7,10 +7,14 @@ use std::str::FromStr;
 
 use ratatui::crossterm::event::KeyEvent;
 
+use super::Binding;
+use super::Context;
 use super::Shortcut;
 use super::config::BookmarkSetPopupKeybindsConfig;
+use super::config::KeybindsConfig;
 use super::keybinds_store::KeybindsStore;
 use crate::env::keybinds_config;
+use crate::make_bindings;
 use crate::set_keybinds;
 use crate::update_keybinds;
 
@@ -42,10 +46,13 @@ impl Default for BookmarkSetPopupKeybinds {
 impl BookmarkSetPopupKeybinds {
     /// The bindings as the configuration has them.
     pub fn new() -> Self {
+        Self::from_config(keybinds_config())
+    }
+
+    /// The bindings as `config` has them.
+    pub(super) fn from_config(config: Option<&KeybindsConfig>) -> Self {
         let mut keybinds = Self::default();
-        if let Some(config) =
-            keybinds_config().and_then(|config| config.bookmark_set_popup.as_ref())
-        {
+        if let Some(config) = config.and_then(|config| config.bookmark_set_popup.as_ref()) {
             keybinds.extend_from_config(config);
         }
         keybinds
@@ -55,6 +62,14 @@ impl BookmarkSetPopupKeybinds {
         self.keys
             .match_event(event)
             .unwrap_or(BookmarkSetPopupEvent::Unbound)
+    }
+
+    pub fn bindings(&self) -> Vec<Binding> {
+        make_bindings!(
+            self.keys, Self::default().keys, Context::BookmarkSetPopup,
+            BookmarkSetPopupEvent::UseGeneratedName => "use-generated-name", None, "take the proposed name",
+            BookmarkSetPopupEvent::CreateBookmark => "create-bookmark", None, "create the bookmark",
+        )
     }
 
     /// The shortcut to name `event` by, of those bound to it.

--- a/src/keybinds/bookmarks_tab.rs
+++ b/src/keybinds/bookmarks_tab.rs
@@ -2,13 +2,15 @@ use std::str::FromStr;
 
 use ratatui::crossterm::event::KeyEvent;
 
-use super::HelpItem;
+use super::Binding;
+use super::Context;
 use super::Section;
 use super::Shortcut;
 use super::config::BookmarksTabKeybindsConfig;
+use super::config::KeybindsConfig;
 use super::keybinds_store::KeybindsStore;
 use crate::env::keybinds_config;
-use crate::make_keybinds_help;
+use crate::make_bindings;
 use crate::set_keybinds;
 use crate::update_keybinds;
 
@@ -66,8 +68,13 @@ impl Default for BookmarksTabKeybinds {
 impl BookmarksTabKeybinds {
     /// The bindings as the configuration has them.
     pub fn new() -> Self {
+        Self::from_config(keybinds_config())
+    }
+
+    /// The bindings as `config` has them.
+    pub(super) fn from_config(config: Option<&KeybindsConfig>) -> Self {
         let mut keybinds = Self::default();
-        if let Some(config) = keybinds_config().and_then(|config| config.bookmarks_tab.as_ref()) {
+        if let Some(config) = config.and_then(|config| config.bookmarks_tab.as_ref()) {
             keybinds.extend_from_config(config);
         }
         keybinds
@@ -98,24 +105,24 @@ impl BookmarksTabKeybinds {
             .unwrap_or(BookmarksTabEvent::Unbound)
     }
 
-    pub fn make_help(&self) -> Vec<HelpItem> {
-        make_keybinds_help!(
-            self.keys,
-            BookmarksTabEvent::ViewInLog => Section::Navigation, "view in log",
-            BookmarksTabEvent::ToggleShowAll => Section::Navigation, "show all remotes",
+    pub fn bindings(&self) -> Vec<Binding> {
+        make_bindings!(
+            self.keys, Self::default().keys, Context::BookmarksTab,
+            BookmarksTabEvent::ViewInLog => "view-in-log", Some(Section::Navigation), "view in log",
+            BookmarksTabEvent::ToggleShowAll => "toggle-show-all", Some(Section::Navigation), "show all remotes",
 
-            BookmarksTabEvent::NewChange { describe: false } => Section::Changes, "new from bookmark",
-            BookmarksTabEvent::NewChange { describe: true } => Section::Changes, "new and describe",
-            BookmarksTabEvent::EditChange { ignore_immutable: false } => Section::Changes, "edit bookmark",
-            BookmarksTabEvent::EditChange { ignore_immutable: true } => Section::Changes, "edit bookmark ignoring immutability",
+            BookmarksTabEvent::NewChange { describe: false } => "create-new", Some(Section::Changes), "new from bookmark",
+            BookmarksTabEvent::NewChange { describe: true } => "create-new-describe", Some(Section::Changes), "new and describe",
+            BookmarksTabEvent::EditChange { ignore_immutable: false } => "edit-change", Some(Section::Changes), "edit bookmark",
+            BookmarksTabEvent::EditChange { ignore_immutable: true } => "edit-change-ignore-immutable", Some(Section::Changes), "edit bookmark ignoring immutability",
 
-            BookmarksTabEvent::CreateBookmark => Section::BookmarksAndRemotes, "create bookmark",
-            BookmarksTabEvent::RenameBookmark => Section::BookmarksAndRemotes, "rename bookmark",
-            BookmarksTabEvent::DeleteBookmark => Section::BookmarksAndRemotes, "delete bookmark",
-            BookmarksTabEvent::ForgetBookmark => Section::BookmarksAndRemotes, "forget bookmark",
-            BookmarksTabEvent::TrackBookmark => Section::BookmarksAndRemotes, "track bookmark",
-            BookmarksTabEvent::UntrackBookmark => Section::BookmarksAndRemotes, "untrack bookmark",
-            BookmarksTabEvent::SetBookmark => Section::BookmarksAndRemotes, "set bookmark here",
+            BookmarksTabEvent::CreateBookmark => "create-bookmark", Some(Section::BookmarksAndRemotes), "create bookmark",
+            BookmarksTabEvent::RenameBookmark => "rename-bookmark", Some(Section::BookmarksAndRemotes), "rename bookmark",
+            BookmarksTabEvent::DeleteBookmark => "delete-bookmark", Some(Section::BookmarksAndRemotes), "delete bookmark",
+            BookmarksTabEvent::ForgetBookmark => "forget-bookmark", Some(Section::BookmarksAndRemotes), "forget bookmark",
+            BookmarksTabEvent::TrackBookmark => "track-bookmark", Some(Section::BookmarksAndRemotes), "track bookmark",
+            BookmarksTabEvent::UntrackBookmark => "untrack-bookmark", Some(Section::BookmarksAndRemotes), "untrack bookmark",
+            BookmarksTabEvent::SetBookmark => "set-bookmark", Some(Section::BookmarksAndRemotes), "set bookmark to the selection",
         )
     }
 }

--- a/src/keybinds/config.rs
+++ b/src/keybinds/config.rs
@@ -26,6 +26,7 @@ pub struct KeybindsConfig {
     pub files_tab: Option<FilesTabKeybindsConfig>,
     pub bookmarks_tab: Option<BookmarksTabKeybindsConfig>,
     pub evolog_tab: Option<EvologTabKeybindsConfig>,
+    pub settings_tab: Option<SettingsTabKeybindsConfig>,
     pub details_panel: Option<DetailsPanelKeybindsConfig>,
     pub popup: Option<PopupKeybindsConfig>,
     pub text_popup: Option<TextPopupKeybindsConfig>,
@@ -169,4 +170,11 @@ pub struct EvologTabKeybindsConfig {
     pub open_files: Option<Keybind>,
     pub duplicate: Option<Keybind>,
     pub copy_rev: Option<Keybind>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct SettingsTabKeybindsConfig {
+    pub change: Option<Keybind>,
+    pub unset: Option<Keybind>,
 }

--- a/src/keybinds/config.rs
+++ b/src/keybinds/config.rs
@@ -27,6 +27,7 @@ pub struct KeybindsConfig {
     pub bookmarks_tab: Option<BookmarksTabKeybindsConfig>,
     pub evolog_tab: Option<EvologTabKeybindsConfig>,
     pub settings_tab: Option<SettingsTabKeybindsConfig>,
+    pub keybindings_tab: Option<KeybindingsTabKeybindsConfig>,
     pub details_panel: Option<DetailsPanelKeybindsConfig>,
     pub popup: Option<PopupKeybindsConfig>,
     pub text_popup: Option<TextPopupKeybindsConfig>,
@@ -177,4 +178,14 @@ pub struct EvologTabKeybindsConfig {
 pub struct SettingsTabKeybindsConfig {
     pub change: Option<Keybind>,
     pub unset: Option<Keybind>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct KeybindingsTabKeybindsConfig {
+    pub bind: Option<Keybind>,
+    pub bind_besides: Option<Keybind>,
+    pub disable: Option<Keybind>,
+    pub unset: Option<Keybind>,
+    pub back: Option<Keybind>,
 }

--- a/src/keybinds/confirm_popup.rs
+++ b/src/keybinds/confirm_popup.rs
@@ -6,10 +6,14 @@ use std::str::FromStr;
 
 use ratatui::crossterm::event::KeyEvent;
 
+use super::Binding;
+use super::Context;
 use super::Shortcut;
 use super::config::ConfirmPopupKeybindsConfig;
+use super::config::KeybindsConfig;
 use super::keybinds_store::KeybindsStore;
 use crate::env::keybinds_config;
+use crate::make_bindings;
 use crate::set_keybinds;
 use crate::update_keybinds;
 
@@ -45,8 +49,13 @@ impl Default for ConfirmPopupKeybinds {
 impl ConfirmPopupKeybinds {
     /// The bindings as the configuration has them.
     pub fn new() -> Self {
+        Self::from_config(keybinds_config())
+    }
+
+    /// The bindings as `config` has them.
+    pub(super) fn from_config(config: Option<&KeybindsConfig>) -> Self {
         let mut keybinds = Self::default();
-        if let Some(config) = keybinds_config().and_then(|config| config.confirm_popup.as_ref()) {
+        if let Some(config) = config.and_then(|config| config.confirm_popup.as_ref()) {
             keybinds.extend_from_config(config);
         }
         keybinds
@@ -56,6 +65,16 @@ impl ConfirmPopupKeybinds {
         self.keys
             .match_event(event)
             .unwrap_or(ConfirmPopupEvent::Unbound)
+    }
+
+    pub fn bindings(&self) -> Vec<Binding> {
+        make_bindings!(
+            self.keys, Self::default().keys, Context::ConfirmPopup,
+            ConfirmPopupEvent::Answer(true) => "yes", None, "answer yes",
+            ConfirmPopupEvent::Answer(false) => "no", None, "answer no",
+            ConfirmPopupEvent::Select(true) => "select-yes", None, "select the yes button",
+            ConfirmPopupEvent::Select(false) => "select-no", None, "select the no button",
+        )
     }
 
     /// The shortcut to name `event` by, of those bound to it.

--- a/src/keybinds/details_panel.rs
+++ b/src/keybinds/details_panel.rs
@@ -2,13 +2,15 @@ use std::str::FromStr;
 
 use ratatui::crossterm::event::KeyEvent;
 
-use super::HelpItem;
+use super::Binding;
+use super::Context;
 use super::Section;
 use super::Shortcut;
 use super::config::DetailsPanelKeybindsConfig;
+use super::config::KeybindsConfig;
 use super::keybinds_store::KeybindsStore;
 use crate::env::keybinds_config;
-use crate::make_keybinds_help;
+use crate::make_bindings;
 use crate::set_keybinds;
 use crate::update_keybinds;
 
@@ -52,8 +54,13 @@ impl DetailsPanelKeybinds {
     /// The bindings as the configuration has them, which every tab's
     /// details panel answers to alike.
     pub fn new() -> Self {
+        Self::from_config(keybinds_config())
+    }
+
+    /// The bindings as `config` has them.
+    pub(super) fn from_config(config: Option<&KeybindsConfig>) -> Self {
         let mut keybinds = Self::default();
-        if let Some(config) = keybinds_config().and_then(|config| config.details_panel.as_ref()) {
+        if let Some(config) = config.and_then(|config| config.details_panel.as_ref()) {
             keybinds.extend_from_config(config);
         }
         keybinds
@@ -79,17 +86,17 @@ impl DetailsPanelKeybinds {
         );
     }
 
-    pub fn make_help(&self) -> Vec<HelpItem> {
-        make_keybinds_help!(
-            self.keys,
-            DetailsPanelEvent::ScrollDown => Section::DetailsPanel, "scroll down",
-            DetailsPanelEvent::ScrollUp => Section::DetailsPanel, "scroll up",
-            DetailsPanelEvent::ScrollDownHalfPage => Section::DetailsPanel, "scroll down by ½ page",
-            DetailsPanelEvent::ScrollUpHalfPage => Section::DetailsPanel, "scroll up by ½ page",
-            DetailsPanelEvent::ScrollDownPage => Section::DetailsPanel, "scroll down by page",
-            DetailsPanelEvent::ScrollUpPage => Section::DetailsPanel, "scroll up by page",
-            DetailsPanelEvent::ToggleDiffFormat => Section::DetailsPanel, "toggle diff format",
-            DetailsPanelEvent::ToggleWrap => Section::DetailsPanel, "toggle wrapping",
+    pub fn bindings(&self) -> Vec<Binding> {
+        make_bindings!(
+            self.keys, Self::default().keys, Context::DetailsPanel,
+            DetailsPanelEvent::ScrollDown => "scroll-down", Some(Section::DetailsPanel), "scroll down",
+            DetailsPanelEvent::ScrollUp => "scroll-up", Some(Section::DetailsPanel), "scroll up",
+            DetailsPanelEvent::ScrollDownHalfPage => "scroll-down-half", Some(Section::DetailsPanel), "scroll down by ½ page",
+            DetailsPanelEvent::ScrollUpHalfPage => "scroll-up-half", Some(Section::DetailsPanel), "scroll up by ½ page",
+            DetailsPanelEvent::ScrollDownPage => "scroll-down-page", Some(Section::DetailsPanel), "scroll down by page",
+            DetailsPanelEvent::ScrollUpPage => "scroll-up-page", Some(Section::DetailsPanel), "scroll up by page",
+            DetailsPanelEvent::ToggleDiffFormat => "toggle-diff-format", Some(Section::DetailsPanel), "toggle diff format",
+            DetailsPanelEvent::ToggleWrap => "toggle-wrap", Some(Section::DetailsPanel), "toggle wrapping",
         )
     }
 }

--- a/src/keybinds/evolog_tab.rs
+++ b/src/keybinds/evolog_tab.rs
@@ -2,13 +2,15 @@ use std::str::FromStr;
 
 use ratatui::crossterm::event::KeyEvent;
 
-use super::HelpItem;
+use super::Binding;
+use super::Context;
 use super::Section;
 use super::Shortcut;
 use super::config::EvologTabKeybindsConfig;
+use super::config::KeybindsConfig;
 use super::keybinds_store::KeybindsStore;
 use crate::env::keybinds_config;
-use crate::make_keybinds_help;
+use crate::make_bindings;
 use crate::set_keybinds;
 use crate::update_keybinds;
 
@@ -42,8 +44,13 @@ impl Default for EvologTabKeybinds {
 impl EvologTabKeybinds {
     /// The bindings as the configuration has them.
     pub fn new() -> Self {
+        Self::from_config(keybinds_config())
+    }
+
+    /// The bindings as `config` has them.
+    pub(super) fn from_config(config: Option<&KeybindsConfig>) -> Self {
         let mut keybinds = Self::default();
-        if let Some(config) = keybinds_config().and_then(|config| config.evolog_tab.as_ref()) {
+        if let Some(config) = config.and_then(|config| config.evolog_tab.as_ref()) {
             keybinds.extend_from_config(config);
         }
         keybinds
@@ -64,12 +71,12 @@ impl EvologTabKeybinds {
             .unwrap_or(EvologTabEvent::Unbound)
     }
 
-    pub fn make_help(&self) -> Vec<HelpItem> {
-        make_keybinds_help!(
-            self.keys,
-            EvologTabEvent::OpenFiles => Section::Navigation, "see files of this version",
-            EvologTabEvent::Duplicate => Section::Changes, "duplicate this version as a new change",
-            EvologTabEvent::CopyRev => Section::Clipboard, "yank revision to clipboard",
+    pub fn bindings(&self) -> Vec<Binding> {
+        make_bindings!(
+            self.keys, Self::default().keys, Context::EvologTab,
+            EvologTabEvent::OpenFiles => "open-files", Some(Section::Navigation), "see files of this version",
+            EvologTabEvent::Duplicate => "duplicate", Some(Section::Changes), "duplicate this version as a new change",
+            EvologTabEvent::CopyRev => "copy-rev", Some(Section::Clipboard), "yank revision to clipboard",
         )
     }
 }

--- a/src/keybinds/files_tab.rs
+++ b/src/keybinds/files_tab.rs
@@ -2,13 +2,15 @@ use std::str::FromStr;
 
 use ratatui::crossterm::event::KeyEvent;
 
-use super::HelpItem;
+use super::Binding;
+use super::Context;
 use super::Section;
 use super::Shortcut;
 use super::config::FilesTabKeybindsConfig;
+use super::config::KeybindsConfig;
 use super::keybinds_store::KeybindsStore;
 use crate::env::keybinds_config;
-use crate::make_keybinds_help;
+use crate::make_bindings;
 use crate::set_keybinds;
 use crate::update_keybinds;
 
@@ -40,8 +42,13 @@ impl Default for FilesTabKeybinds {
 impl FilesTabKeybinds {
     /// The bindings as the configuration has them.
     pub fn new() -> Self {
+        Self::from_config(keybinds_config())
+    }
+
+    /// The bindings as `config` has them.
+    pub(super) fn from_config(config: Option<&KeybindsConfig>) -> Self {
         let mut keybinds = Self::default();
-        if let Some(config) = keybinds_config().and_then(|config| config.files_tab.as_ref()) {
+        if let Some(config) = config.and_then(|config| config.files_tab.as_ref()) {
             keybinds.extend_from_config(config);
         }
         keybinds
@@ -61,11 +68,11 @@ impl FilesTabKeybinds {
             .unwrap_or(FilesTabEvent::Unbound)
     }
 
-    pub fn make_help(&self) -> Vec<HelpItem> {
-        make_keybinds_help!(
-            self.keys,
-            FilesTabEvent::Untrack => Section::Files, "untrack file",
-            FilesTabEvent::Restore => Section::Files, "restore file",
+    pub fn bindings(&self) -> Vec<Binding> {
+        make_bindings!(
+            self.keys, Self::default().keys, Context::FilesTab,
+            FilesTabEvent::Untrack => "untrack", Some(Section::Files), "untrack file",
+            FilesTabEvent::Restore => "restore", Some(Section::Files), "restore file",
         )
     }
 }

--- a/src/keybinds/global.rs
+++ b/src/keybinds/global.rs
@@ -2,12 +2,14 @@ use std::str::FromStr;
 
 use ratatui::crossterm::event::KeyEvent;
 
-use super::HelpItem;
+use super::Binding;
+use super::Context;
 use super::Section;
 use super::Shortcut;
 use super::config::KeybindsConfig;
 use super::keybinds_store::KeybindsStore;
-use crate::make_keybinds_help;
+use crate::env::keybinds_config;
+use crate::make_bindings;
 use crate::set_keybinds;
 use crate::update_keybinds;
 
@@ -82,11 +84,25 @@ impl Default for GlobalKeybinds {
 }
 
 impl GlobalKeybinds {
+    /// The bindings as the configuration has them.
+    pub fn new() -> Self {
+        Self::from_config(keybinds_config())
+    }
+
+    /// The bindings as `config` has them.
+    pub(super) fn from_config(config: Option<&KeybindsConfig>) -> Self {
+        let mut keybinds = Self::default();
+        if let Some(config) = config {
+            keybinds.extend_from_config(config);
+        }
+        keybinds
+    }
+
     pub fn match_event(&self, event: KeyEvent) -> GlobalEvent {
         self.keys.match_event(event).unwrap_or(GlobalEvent::Unbound)
     }
 
-    pub fn extend_from_config(&mut self, config: &KeybindsConfig) {
+    fn extend_from_config(&mut self, config: &KeybindsConfig) {
         update_keybinds!(
             self.keys,
             GlobalEvent::ScrollDown => config.scroll_down,
@@ -107,30 +123,30 @@ impl GlobalKeybinds {
         );
     }
 
-    pub fn make_help(&self) -> Vec<HelpItem> {
-        make_keybinds_help!(
-            self.keys,
-            GlobalEvent::ScrollDown => Section::Navigation, "scroll down",
-            GlobalEvent::ScrollUp => Section::Navigation, "scroll up",
-            GlobalEvent::ScrollDownHalf => Section::Navigation, "scroll down by ½ page",
-            GlobalEvent::ScrollUpHalf => Section::Navigation, "scroll up by ½ page",
-            GlobalEvent::ScrollToTop => Section::Navigation, "go to the top of the list",
-            GlobalEvent::ScrollToBottom => Section::Navigation, "go to the bottom of the list",
-            GlobalEvent::FocusCurrent => Section::Navigation, "go to current change",
-            GlobalEvent::OpenContextMenu => Section::Navigation, "open the context menu",
+    pub fn bindings(&self) -> Vec<Binding> {
+        make_bindings!(
+            self.keys, Self::default().keys, Context::Global,
+            GlobalEvent::ScrollDown => "scroll-down", Some(Section::Navigation), "scroll down",
+            GlobalEvent::ScrollUp => "scroll-up", Some(Section::Navigation), "scroll up",
+            GlobalEvent::ScrollDownHalf => "scroll-down-half", Some(Section::Navigation), "scroll down by ½ page",
+            GlobalEvent::ScrollUpHalf => "scroll-up-half", Some(Section::Navigation), "scroll up by ½ page",
+            GlobalEvent::ScrollToTop => "scroll-to-top", Some(Section::Navigation), "go to the top of the list",
+            GlobalEvent::ScrollToBottom => "scroll-to-bottom", Some(Section::Navigation), "go to the bottom of the list",
+            GlobalEvent::FocusCurrent => "focus-current", Some(Section::Navigation), "go to current change",
+            GlobalEvent::OpenContextMenu => "open-context-menu", Some(Section::Navigation), "open the context menu",
 
-            GlobalEvent::Refresh => Section::App, "refresh",
-            GlobalEvent::NextTab => Section::App, "next tab",
-            GlobalEvent::PrevTab => Section::App, "previous tab",
-            GlobalEvent::LogTab => Section::App, "log tab",
-            GlobalEvent::FilesTab => Section::App, "files tab",
-            GlobalEvent::BookmarksTab => Section::App, "bookmarks tab",
-            GlobalEvent::EvologTab => Section::App, "evolog tab",
-            GlobalEvent::SettingsTab => Section::App, "settings tab",
-            GlobalEvent::CommandPopup => Section::App, "run jj command",
-            GlobalEvent::InteractiveCommandPopup => Section::App, "run jj command interactively",
-            GlobalEvent::OpenHelp => Section::App, "open help",
-            GlobalEvent::Quit => Section::App, "quit",
+            GlobalEvent::Refresh => "refresh", Some(Section::App), "refresh",
+            GlobalEvent::NextTab => "next-tab", Some(Section::App), "next tab",
+            GlobalEvent::PrevTab => "prev-tab", Some(Section::App), "previous tab",
+            GlobalEvent::LogTab => _, Some(Section::App), "log tab",
+            GlobalEvent::FilesTab => _, Some(Section::App), "files tab",
+            GlobalEvent::BookmarksTab => _, Some(Section::App), "bookmarks tab",
+            GlobalEvent::EvologTab => _, Some(Section::App), "evolog tab",
+            GlobalEvent::SettingsTab => _, Some(Section::App), "settings tab",
+            GlobalEvent::CommandPopup => "command-popup", Some(Section::App), "run jj command",
+            GlobalEvent::InteractiveCommandPopup => "interactive-command-popup", Some(Section::App), "run jj command interactively",
+            GlobalEvent::OpenHelp => "open-help", Some(Section::App), "open help",
+            GlobalEvent::Quit => "quit", Some(Section::App), "quit",
         )
     }
 }
@@ -283,22 +299,31 @@ mod tests {
             keybinds.match_event(key(KeyCode::Char('?'))),
             GlobalEvent::Unbound
         );
-        assert!(keybinds.make_help().contains(&HelpItem {
-            section: Section::App,
-            keys: "[disabled]".to_owned(),
-            description: "open help".to_owned(),
-        }));
+        let help = binding(&keybinds, "open help");
+        assert_eq!(help.keys_text(), "[disabled]");
+        // What it comes bound to is what taking it back out restores.
+        assert_eq!(help.defaults_text(), "?");
     }
 
     #[test]
-    fn test_make_help_lists_every_default_binding() {
-        let help = GlobalKeybinds::default().make_help();
+    fn test_the_bindings_list_every_default_binding() {
+        let keybinds = GlobalKeybinds::default();
 
-        assert!(help.iter().all(|item| item.keys != "[disabled]"));
-        let refresh = help
-            .iter()
-            .find(|item| item.description == "refresh")
-            .expect("refresh should be listed");
-        assert_eq!(refresh.keys, "Shift+r/F5");
+        assert!(
+            keybinds
+                .bindings()
+                .iter()
+                .all(|binding| binding.keys_text() != "[disabled]")
+        );
+        assert_eq!(binding(&keybinds, "refresh").keys_text(), "Shift+r/F5");
+    }
+
+    /// The binding for the action `description` says it does.
+    fn binding(keybinds: &GlobalKeybinds, description: &str) -> Binding {
+        keybinds
+            .bindings()
+            .into_iter()
+            .find(|binding| binding.description == description)
+            .expect("the action is one the app has")
     }
 }

--- a/src/keybinds/global.rs
+++ b/src/keybinds/global.rs
@@ -36,6 +36,7 @@ pub enum GlobalEvent {
     FilesTab,
     BookmarksTab,
     EvologTab,
+    SettingsTab,
 
     OpenContextMenu,
     CommandPopup,
@@ -68,6 +69,7 @@ impl Default for GlobalKeybinds {
             GlobalEvent::FilesTab => "2",
             GlobalEvent::BookmarksTab => "3",
             GlobalEvent::EvologTab => "4",
+            GlobalEvent::SettingsTab => "0",
             GlobalEvent::OpenContextMenu => "menu",
             GlobalEvent::CommandPopup => ":",
             GlobalEvent::InteractiveCommandPopup => "!",
@@ -124,6 +126,7 @@ impl GlobalKeybinds {
             GlobalEvent::FilesTab => Section::App, "files tab",
             GlobalEvent::BookmarksTab => Section::App, "bookmarks tab",
             GlobalEvent::EvologTab => Section::App, "evolog tab",
+            GlobalEvent::SettingsTab => Section::App, "settings tab",
             GlobalEvent::CommandPopup => Section::App, "run jj command",
             GlobalEvent::InteractiveCommandPopup => Section::App, "run jj command interactively",
             GlobalEvent::OpenHelp => Section::App, "open help",

--- a/src/keybinds/keybindings_tab.rs
+++ b/src/keybinds/keybindings_tab.rs
@@ -1,0 +1,149 @@
+use std::str::FromStr;
+
+use ratatui::crossterm::event::KeyEvent;
+
+use super::Binding;
+use super::Context;
+use super::Section;
+use super::Shortcut;
+use super::config::KeybindingsTabKeybindsConfig;
+use super::config::KeybindsConfig;
+use super::keybinds_store::KeybindsStore;
+use crate::env::keybinds_config;
+use crate::make_bindings;
+use crate::set_keybinds;
+use crate::update_keybinds;
+
+#[derive(Debug)]
+pub struct KeybindingsTabKeybinds {
+    keys: KeybindsStore<KeybindingsTabEvent>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum KeybindingsTabEvent {
+    Bind,
+    BindBesides,
+    Disable,
+    Unset,
+    Back,
+
+    Unbound,
+}
+
+impl Default for KeybindingsTabKeybinds {
+    fn default() -> Self {
+        let mut keys = KeybindsStore::<KeybindingsTabEvent>::default();
+        set_keybinds!(
+            keys,
+            KeybindingsTabEvent::Bind => "enter",
+            KeybindingsTabEvent::BindBesides => "a",
+            KeybindingsTabEvent::Disable => "shift+x",
+            KeybindingsTabEvent::Unset => "x",
+            KeybindingsTabEvent::Back => "esc",
+        );
+        Self { keys }
+    }
+}
+
+impl KeybindingsTabKeybinds {
+    /// The bindings as the configuration has them.
+    pub fn new() -> Self {
+        Self::from_config(keybinds_config())
+    }
+
+    /// The bindings as `config` has them.
+    pub(super) fn from_config(config: Option<&KeybindsConfig>) -> Self {
+        let mut keybinds = Self::default();
+        if let Some(config) = config.and_then(|config| config.keybindings_tab.as_ref()) {
+            keybinds.extend_from_config(config);
+        }
+        keybinds
+    }
+
+    fn extend_from_config(&mut self, config: &KeybindingsTabKeybindsConfig) {
+        update_keybinds!(
+            self.keys,
+            KeybindingsTabEvent::Bind => config.bind,
+            KeybindingsTabEvent::BindBesides => config.bind_besides,
+            KeybindingsTabEvent::Disable => config.disable,
+            KeybindingsTabEvent::Unset => config.unset,
+            KeybindingsTabEvent::Back => config.back,
+        );
+    }
+
+    pub fn match_event(&self, event: KeyEvent) -> KeybindingsTabEvent {
+        self.keys
+            .match_event(event)
+            .unwrap_or(KeybindingsTabEvent::Unbound)
+    }
+
+    /// The line under the list saying what it answers to, in as much of
+    /// `width` as it takes. Where there is no room for all of it, what
+    /// is least worth saying goes first, down to binding a key and
+    /// leaving the list again.
+    pub fn hint(&self, width: usize) -> String {
+        let mut parts: Vec<String> = [
+            (KeybindingsTabEvent::Bind, "bind"),
+            (KeybindingsTabEvent::BindBesides, "add a key"),
+            (KeybindingsTabEvent::Disable, "bind nothing"),
+            (KeybindingsTabEvent::Unset, "take out"),
+            (KeybindingsTabEvent::Back, "back"),
+        ]
+        .into_iter()
+        .filter_map(|(event, what)| Some(format!("{}: {what}", self.shortcut(event)?)))
+        .collect();
+
+        while parts.len() > 2 && Self::hint_width(&parts) > width {
+            parts.remove(parts.len() - 2);
+        }
+
+        parts.join(" | ")
+    }
+
+    /// How wide the hint `parts` are with what joins them.
+    fn hint_width(parts: &[String]) -> usize {
+        let joins = 3 * parts.len().saturating_sub(1);
+
+        joins + parts.iter().map(|part| part.chars().count()).sum::<usize>()
+    }
+
+    /// The shortcut to name `event` by, of those bound to it.
+    fn shortcut(&self, event: KeybindingsTabEvent) -> Option<Shortcut> {
+        self.keys.get_shortcuts(event).into_iter().next()
+    }
+
+    pub fn bindings(&self) -> Vec<Binding> {
+        make_bindings!(
+            self.keys, Self::default().keys, Context::KeybindingsTab,
+            KeybindingsTabEvent::Bind => "bind", Some(Section::Settings), "bind a key to the action",
+            KeybindingsTabEvent::BindBesides => "bind-besides", Some(Section::Settings), "bind another key to the action",
+            KeybindingsTabEvent::Disable => "disable", Some(Section::Settings), "leave the action bound to nothing",
+            KeybindingsTabEvent::Unset => "unset", Some(Section::Settings), "take the binding out of your config",
+            KeybindingsTabEvent::Back => "back", Some(Section::Settings), "go back to the settings",
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_keybindings_tab_keybinds_default() {
+        let _ = KeybindingsTabKeybinds::default();
+    }
+
+    /// The hint says as much as there is room for, and what it drops is
+    /// what is least worth saying rather than what comes last.
+    #[test]
+    fn test_the_hint_drops_what_there_is_no_room_for() {
+        let keybinds = KeybindingsTabKeybinds::default();
+
+        assert_eq!(
+            keybinds.hint(80),
+            "Enter: bind | a: add a key | Shift+x: bind nothing | x: take out | Esc: back"
+        );
+        assert_eq!(keybinds.hint(40), "Enter: bind | a: add a key | Esc: back");
+        assert_eq!(keybinds.hint(1), "Enter: bind | Esc: back");
+    }
+}

--- a/src/keybinds/log_tab.rs
+++ b/src/keybinds/log_tab.rs
@@ -2,13 +2,15 @@ use std::str::FromStr;
 
 use ratatui::crossterm::event::KeyEvent;
 
-use super::HelpItem;
+use super::Binding;
+use super::Context;
 use super::Section;
 use super::Shortcut;
+use super::config::KeybindsConfig;
 use super::config::LogTabKeybindsConfig;
 use super::keybinds_store::KeybindsStore;
 use crate::env::keybinds_config;
-use crate::make_keybinds_help;
+use crate::make_bindings;
 use crate::set_keybinds;
 use crate::update_keybinds;
 
@@ -97,8 +99,13 @@ impl Default for LogTabKeybinds {
 impl LogTabKeybinds {
     /// The bindings as the configuration has them.
     pub fn new() -> Self {
+        Self::from_config(keybinds_config())
+    }
+
+    /// The bindings as `config` has them.
+    pub(super) fn from_config(config: Option<&KeybindsConfig>) -> Self {
         let mut keybinds = Self::default();
-        if let Some(config) = keybinds_config().and_then(|config| config.log_tab.as_ref()) {
+        if let Some(config) = config.and_then(|config| config.log_tab.as_ref()) {
             keybinds.extend_from_config(config);
         }
         keybinds
@@ -143,37 +150,37 @@ impl LogTabKeybinds {
         );
     }
 
-    pub fn make_main_panel_help(&self) -> Vec<HelpItem> {
-        make_keybinds_help!(
-            self.keys,
-            LogTabEvent::GotoParent => Section::Navigation, "go to parent commit",
-            LogTabEvent::OpenFiles => Section::Navigation, "see files",
-            LogTabEvent::OpenEvolog => Section::Navigation, "see how the change evolved",
-            LogTabEvent::EditRevset => Section::Navigation, "set revset",
+    pub fn bindings(&self) -> Vec<Binding> {
+        make_bindings!(
+            self.keys, Self::default().keys, Context::LogTab,
+            LogTabEvent::GotoParent => "goto-parent", Some(Section::Navigation), "go to parent commit",
+            LogTabEvent::OpenFiles => "open-files", Some(Section::Navigation), "see files",
+            LogTabEvent::OpenEvolog => "open-evolog", Some(Section::Navigation), "see how the change evolved",
+            LogTabEvent::EditRevset => "edit-revset", Some(Section::Navigation), "set revset",
 
-            LogTabEvent::ToggleHeadMark => Section::Changes, "mark change to act on",
-            LogTabEvent::CreateNew { describe: false } => Section::Changes, "new change",
-            LogTabEvent::CreateNew { describe: true } => Section::Changes, "new with message",
-            LogTabEvent::Describe => Section::Changes, "describe change",
-            LogTabEvent::EditChange { ignore_immutable: false } => Section::Changes, "edit change",
-            LogTabEvent::EditChange { ignore_immutable: true } => Section::Changes, "edit change ignoring immutability",
-            LogTabEvent::Duplicate => Section::Changes, "duplicate change",
-            LogTabEvent::Abandon => Section::Changes, "abandon change",
-            LogTabEvent::Rebase => Section::Changes, "rebase @ onto it",
-            LogTabEvent::Squash { ignore_immutable: false } => Section::Changes, "squash @ into it",
-            LogTabEvent::Squash { ignore_immutable: true } => Section::Changes, "squash @ into it, ignoring immutability",
-            LogTabEvent::Absorb => Section::Changes, "absorb into its mutable ancestors",
+            LogTabEvent::ToggleHeadMark => "mark-head", Some(Section::Changes), "mark change to act on",
+            LogTabEvent::CreateNew { describe: false } => "create-new", Some(Section::Changes), "new change",
+            LogTabEvent::CreateNew { describe: true } => "create-new-describe", Some(Section::Changes), "new with message",
+            LogTabEvent::Describe => "describe", Some(Section::Changes), "describe change",
+            LogTabEvent::EditChange { ignore_immutable: false } => "edit-change", Some(Section::Changes), "edit change",
+            LogTabEvent::EditChange { ignore_immutable: true } => "edit-change-ignore-immutable", Some(Section::Changes), "edit change ignoring immutability",
+            LogTabEvent::Duplicate => "duplicate", Some(Section::Changes), "duplicate change",
+            LogTabEvent::Abandon => "abandon", Some(Section::Changes), "abandon change",
+            LogTabEvent::Rebase => "rebase", Some(Section::Changes), "rebase @ onto the selection",
+            LogTabEvent::Squash { ignore_immutable: false } => "squash", Some(Section::Changes), "squash @ into the selection",
+            LogTabEvent::Squash { ignore_immutable: true } => "squash-ignore-immutable", Some(Section::Changes), "squash @ into the selection, ignoring immutability",
+            LogTabEvent::Absorb => "absorb", Some(Section::Changes), "absorb the selection into its mutable ancestors",
 
-            LogTabEvent::SetBookmark => Section::BookmarksAndRemotes, "set bookmark",
-            LogTabEvent::Fetch { all_remotes: false } => Section::BookmarksAndRemotes, "git fetch",
-            LogTabEvent::Fetch { all_remotes: true } => Section::BookmarksAndRemotes, "git fetch all remotes",
-            LogTabEvent::Push(PushScope::Selected) => Section::BookmarksAndRemotes, "git push",
-            LogTabEvent::Push(PushScope::SelectedWithNew) => Section::BookmarksAndRemotes, "git push, tracking new bookmarks",
-            LogTabEvent::Push(PushScope::Tracked) => Section::BookmarksAndRemotes, "git push all tracked bookmarks",
-            LogTabEvent::Push(PushScope::All) => Section::BookmarksAndRemotes, "git push all bookmarks, new ones included",
+            LogTabEvent::SetBookmark => "set-bookmark", Some(Section::BookmarksAndRemotes), "set bookmark",
+            LogTabEvent::Fetch { all_remotes: false } => "fetch", Some(Section::BookmarksAndRemotes), "git fetch",
+            LogTabEvent::Fetch { all_remotes: true } => "fetch-all", Some(Section::BookmarksAndRemotes), "git fetch all remotes",
+            LogTabEvent::Push(PushScope::Selected) => "push", Some(Section::BookmarksAndRemotes), "git push",
+            LogTabEvent::Push(PushScope::SelectedWithNew) => "push-new", Some(Section::BookmarksAndRemotes), "git push, tracking new bookmarks",
+            LogTabEvent::Push(PushScope::Tracked) => "push-all", Some(Section::BookmarksAndRemotes), "git push all tracked bookmarks",
+            LogTabEvent::Push(PushScope::All) => "push-all-new", Some(Section::BookmarksAndRemotes), "git push all bookmarks, new ones included",
 
-            LogTabEvent::CopyChangeId => Section::Clipboard, "yank change id",
-            LogTabEvent::CopyRev => Section::Clipboard, "yank revision",
+            LogTabEvent::CopyChangeId => "copy-change-id", Some(Section::Clipboard), "yank change id",
+            LogTabEvent::CopyRev => "copy-rev", Some(Section::Clipboard), "yank revision",
         )
     }
 }

--- a/src/keybinds/mod.rs
+++ b/src/keybinds/mod.rs
@@ -25,6 +25,8 @@ pub use popup::PopupKeybinds;
 use ratatui::crossterm::event::KeyCode;
 use ratatui::crossterm::event::KeyEvent;
 use ratatui::crossterm::event::KeyModifiers;
+pub use settings_tab::SettingsTabEvent;
+pub use settings_tab::SettingsTabKeybinds;
 
 mod bookmark_set_popup;
 mod bookmarks_tab;
@@ -38,6 +40,7 @@ mod keybinds_store;
 mod log_tab;
 mod popup;
 pub mod rebase_popup;
+mod settings_tab;
 
 /*#[derive(Debug)]
 pub struct Keybinds {
@@ -55,6 +58,7 @@ pub enum Section {
     Files,
     BookmarksAndRemotes,
     Clipboard,
+    Settings,
     DetailsPanel,
     /// What the app does, rather than what it does to the repo
     App,
@@ -62,12 +66,13 @@ pub enum Section {
 
 impl Section {
     /// Every section, in the order the help lists them
-    const ORDER: [Self; 7] = [
+    const ORDER: [Self; 8] = [
         Self::Navigation,
         Self::Changes,
         Self::Files,
         Self::BookmarksAndRemotes,
         Self::Clipboard,
+        Self::Settings,
         Self::DetailsPanel,
         Self::App,
     ];
@@ -79,6 +84,7 @@ impl Section {
             Self::Files => "Files",
             Self::BookmarksAndRemotes => "Bookmarks and remotes",
             Self::Clipboard => "Clipboard",
+            Self::Settings => "Settings",
             Self::DetailsPanel => "Details panel",
             Self::App => "Global",
         }

--- a/src/keybinds/mod.rs
+++ b/src/keybinds/mod.rs
@@ -17,6 +17,8 @@ pub use files_tab::FilesTabEvent;
 pub use files_tab::FilesTabKeybinds;
 pub use global::GlobalEvent;
 pub use global::GlobalKeybinds;
+pub use keybindings_tab::KeybindingsTabEvent;
+pub use keybindings_tab::KeybindingsTabKeybinds;
 pub use log_tab::LogTabEvent;
 pub use log_tab::LogTabKeybinds;
 pub use log_tab::PushScope;
@@ -28,6 +30,8 @@ use ratatui::crossterm::event::KeyModifiers;
 pub use settings_tab::SettingsTabEvent;
 pub use settings_tab::SettingsTabKeybinds;
 
+use crate::env::keybinds_config;
+
 mod bookmark_set_popup;
 mod bookmarks_tab;
 mod config;
@@ -36,6 +40,7 @@ mod details_panel;
 mod evolog_tab;
 mod files_tab;
 mod global;
+mod keybindings_tab;
 mod keybinds_store;
 mod log_tab;
 mod popup;
@@ -97,13 +102,211 @@ impl Section {
     }
 }
 
-/// A keybinding as the help lists it
+/// Where a binding takes effect, which is also where it is configured.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Context {
+    Global,
+    LogTab,
+    FilesTab,
+    BookmarksTab,
+    EvologTab,
+    SettingsTab,
+    KeybindingsTab,
+    DetailsPanel,
+    Popup,
+    TextPopup,
+    ConfirmPopup,
+    BookmarkSetPopup,
+    RebasePopup,
+}
+
+impl Context {
+    /// Every context, in the order the keybindings are listed in
+    pub const ORDER: [Self; 13] = [
+        Self::Global,
+        Self::LogTab,
+        Self::FilesTab,
+        Self::BookmarksTab,
+        Self::EvologTab,
+        Self::SettingsTab,
+        Self::KeybindingsTab,
+        Self::DetailsPanel,
+        Self::Popup,
+        Self::TextPopup,
+        Self::ConfirmPopup,
+        Self::BookmarkSetPopup,
+        Self::RebasePopup,
+    ];
+
+    pub fn title(self) -> &'static str {
+        match self {
+            Self::Global => "Everywhere",
+            Self::LogTab => "Log tab",
+            Self::FilesTab => "Files tab",
+            Self::BookmarksTab => "Bookmarks tab",
+            Self::EvologTab => "Evolog tab",
+            Self::SettingsTab => "Settings tab",
+            Self::KeybindingsTab => "Keybindings tab",
+            Self::DetailsPanel => "Details panel",
+            Self::Popup => "Popups",
+            Self::TextPopup => "Popups holding a text field",
+            Self::ConfirmPopup => "Confirmation popup",
+            Self::BookmarkSetPopup => "Set-bookmark popup",
+            Self::RebasePopup => "Rebase popup",
+        }
+    }
+
+    /// The table under `blazingjj.keybinds` its bindings are configured
+    /// in, the ones that hold everywhere being configured in that table
+    /// itself.
+    pub fn table(self) -> Option<&'static str> {
+        match self {
+            Self::Global => None,
+            Self::LogTab => Some("log-tab"),
+            Self::FilesTab => Some("files-tab"),
+            Self::BookmarksTab => Some("bookmarks-tab"),
+            Self::EvologTab => Some("evolog-tab"),
+            Self::SettingsTab => Some("settings-tab"),
+            Self::KeybindingsTab => Some("keybindings-tab"),
+            Self::DetailsPanel => Some("details-panel"),
+            Self::Popup => Some("popup"),
+            Self::TextPopup => Some("text-popup"),
+            Self::ConfirmPopup => Some("confirm-popup"),
+            Self::BookmarkSetPopup => Some("bookmark-set-popup"),
+            Self::RebasePopup => Some("rebase-popup"),
+        }
+    }
+
+    /// Whether keys bound here and keys bound in `other` are ever live
+    /// at once, so that one of them would answer for both. A tab and
+    /// its details panel answer to the keys that hold everywhere as
+    /// well, and a popup of its own to the keys every popup takes; the
+    /// tabs are never up together, and nothing under a popup is asked
+    /// while it is up.
+    pub fn shares_keys_with(self, other: Self) -> bool {
+        self == other || self.beside().contains(&other)
+    }
+
+    /// The contexts whose keys are live alongside its own.
+    fn beside(self) -> &'static [Self] {
+        /// What is live with the details panel: the keys that hold
+        /// everywhere and those of the tabs that have one.
+        const BESIDE_DETAILS_PANEL: [Context; 5] = [
+            Context::Global,
+            Context::LogTab,
+            Context::FilesTab,
+            Context::BookmarksTab,
+            Context::EvologTab,
+        ];
+        const IN_A_TAB: [Context; 7] = [
+            Context::LogTab,
+            Context::FilesTab,
+            Context::BookmarksTab,
+            Context::EvologTab,
+            Context::SettingsTab,
+            Context::KeybindingsTab,
+            Context::DetailsPanel,
+        ];
+        const IN_A_POPUP: [Context; 4] = [
+            Context::Popup,
+            Context::ConfirmPopup,
+            Context::BookmarkSetPopup,
+            Context::RebasePopup,
+        ];
+
+        match self {
+            // The keys that hold everywhere are up against those of
+            // whichever tab is showing and those of its details panel.
+            Self::Global => &IN_A_TAB,
+            Self::DetailsPanel => &BESIDE_DETAILS_PANEL,
+            Self::LogTab | Self::FilesTab | Self::BookmarksTab | Self::EvologTab => {
+                &[Self::Global, Self::DetailsPanel]
+            }
+            // The tabs about the app have no details panel beside them.
+            Self::SettingsTab | Self::KeybindingsTab => &[Self::Global],
+            Self::Popup => &IN_A_POPUP,
+            Self::ConfirmPopup | Self::BookmarkSetPopup | Self::RebasePopup => &[Self::Popup],
+            Self::TextPopup => &[],
+        }
+    }
+
+    /// What it binds, as the configuration leaves it.
+    pub fn bindings(self) -> Vec<Binding> {
+        self.bindings_of(keybinds_config())
+    }
+
+    /// What it binds, as `config` leaves it.
+    fn bindings_of(self, config: Option<&KeybindsConfig>) -> Vec<Binding> {
+        match self {
+            Self::Global => GlobalKeybinds::from_config(config).bindings(),
+            Self::LogTab => LogTabKeybinds::from_config(config).bindings(),
+            Self::FilesTab => FilesTabKeybinds::from_config(config).bindings(),
+            Self::BookmarksTab => BookmarksTabKeybinds::from_config(config).bindings(),
+            Self::EvologTab => EvologTabKeybinds::from_config(config).bindings(),
+            Self::SettingsTab => SettingsTabKeybinds::from_config(config).bindings(),
+            Self::KeybindingsTab => KeybindingsTabKeybinds::from_config(config).bindings(),
+            Self::DetailsPanel => DetailsPanelKeybinds::from_config(config).bindings(),
+            Self::Popup => PopupKeybinds::dialog_from_config(config).bindings(),
+            Self::TextPopup => PopupKeybinds::text_from_config(config).text_bindings(),
+            Self::ConfirmPopup => ConfirmPopupKeybinds::from_config(config).bindings(),
+            Self::BookmarkSetPopup => BookmarkSetPopupKeybinds::from_config(config).bindings(),
+            Self::RebasePopup => rebase_popup::Keybinds::from_config(config).bindings(),
+        }
+    }
+}
+
+/// One action a key can be bound to: what it does, the keys it answers
+/// to, and how it is configured.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct HelpItem {
-    pub section: Section,
-    /// The keys bound to it, or `[disabled]` where there are none
-    pub keys: String,
-    pub description: String,
+pub struct Binding {
+    pub context: Context,
+    /// The name the configuration gives it, or None where the keys are
+    /// not the user's to change.
+    pub name: Option<&'static str>,
+    /// The section the help lists it under, or None for a binding the
+    /// help says nothing about: a popup says for itself what it takes.
+    pub section: Option<Section>,
+    pub description: &'static str,
+    /// The keys bound to it, of which there may be none.
+    pub keys: Vec<Shortcut>,
+    /// The keys it comes bound to.
+    pub defaults: Vec<Shortcut>,
+}
+
+impl Binding {
+    /// The config key it is configured under, for a binding that is the
+    /// user's to change.
+    pub fn key(&self) -> Option<String> {
+        let name = self.name?;
+
+        Some(match self.context.table() {
+            Some(table) => format!("blazingjj.keybinds.{table}.{name}"),
+            None => format!("blazingjj.keybinds.{name}"),
+        })
+    }
+
+    /// The keys bound to it, as they read.
+    pub fn keys_text(&self) -> String {
+        Self::text_of(&self.keys)
+    }
+
+    /// The keys it comes bound to, as they read.
+    pub fn defaults_text(&self) -> String {
+        Self::text_of(&self.defaults)
+    }
+
+    /// `shortcuts` as they read, or `[disabled]` where there are none.
+    fn text_of(shortcuts: &[Shortcut]) -> String {
+        if shortcuts.is_empty() {
+            return "[disabled]".to_owned();
+        }
+
+        shortcuts
+            .iter()
+            .map(Shortcut::to_string)
+            .collect::<Vec<_>>()
+            .join("/")
+    }
 }
 
 /// The keybindings of one section, as the help lists them
@@ -115,19 +318,19 @@ pub struct HelpSection {
 }
 
 impl HelpSection {
-    /// The `items` gathered into the sections they belong to, in the
+    /// The `bindings` gathered into the sections they belong to, in the
     /// order the help lists those; a section nothing belongs to is left
     /// out.
-    pub fn gather(items: impl IntoIterator<Item = HelpItem>) -> Vec<Self> {
-        let items: Vec<HelpItem> = items.into_iter().collect();
+    pub fn gather(bindings: impl IntoIterator<Item = Binding>) -> Vec<Self> {
+        let bindings: Vec<Binding> = bindings.into_iter().collect();
 
         Section::ORDER
             .into_iter()
             .filter_map(|section| {
-                let items: Vec<(String, String)> = items
+                let items: Vec<(String, String)> = bindings
                     .iter()
-                    .filter(|item| item.section == section)
-                    .map(|item| (item.keys.clone(), item.description.clone()))
+                    .filter(|binding| binding.section == Some(section))
+                    .map(|binding| (binding.keys_text(), binding.description.to_owned()))
                     .collect();
 
                 (!items.is_empty()).then_some(Self { section, items })
@@ -163,33 +366,41 @@ macro_rules! update_keybinds {
     };
 }
 
-/// The help entry of every listed action: what it does, the section it
-/// belongs to, and the keys it is bound to.
+/// Every action of one context: the name the configuration gives it, or
+/// `_` for one that is not the user's to bind, the section the help
+/// lists it under, and what it does. The keys come from `$keys` as they
+/// are and from `$defaults` as the app ships them.
 #[macro_export]
-macro_rules! make_keybinds_help {
-    () => {};
-    ($keys:expr, $($action:expr => $section:expr, $desc:literal),* $(,)?) => {
+macro_rules! make_bindings {
+    ($keys:expr, $defaults:expr, $context:expr, $($action:expr => $name:tt, $section:expr, $desc:literal),* $(,)?) => {
         #[allow(clippy::vec_init_then_push)]
         {
+            let defaults = $defaults;
             let mut res = vec![];
             $(
-                let shortcuts = $keys.get_shortcuts($action)
-                    .iter()
-                    .map(|s| s.to_string())
-                    .collect::<Vec<_>>()
-                    .join("/");
-                res.push($crate::keybinds::HelpItem {
+                res.push($crate::keybinds::Binding {
+                    context: $context,
+                    name: $crate::binding_name!($name),
                     section: $section,
-                    keys: if shortcuts.is_empty() {
-                        "[disabled]".to_string()
-                    } else {
-                        shortcuts
-                    },
-                    description: $desc.to_string(),
+                    description: $desc,
+                    keys: $keys.get_shortcuts($action),
+                    defaults: defaults.get_shortcuts($action),
                 });
             )*
             res
         }
+    };
+}
+
+/// The name a binding is configured under, `_` standing for one that
+/// cannot be.
+#[macro_export]
+macro_rules! binding_name {
+    (_) => {
+        None
+    };
+    ($name:literal) => {
+        Some($name)
     };
 }
 
@@ -230,10 +441,21 @@ impl FromStr for Shortcut {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let mut modifiers = KeyModifiers::empty();
         let mut key = None;
+        if s.trim().is_empty() {
+            return Err(ShortcutParseError::NoKey);
+        }
+
         for s in s.to_lowercase().split('+').map(|s| s.trim()) {
             match s {
-                "ctrl" => modifiers |= KeyModifiers::CONTROL,
+                // Written out is how a shortcut reads on screen, which
+                // is what someone copying one out of the app writes.
+                "ctrl" | "control" => modifiers |= KeyModifiers::CONTROL,
+                "alt" => modifiers |= KeyModifiers::ALT,
                 "shift" => modifiers |= KeyModifiers::SHIFT,
+                // A plus is what the parts are told apart by, so it is
+                // no part of its own; what is left where one stands on
+                // its own is the key it is.
+                "" => key = Some(KeyCode::Char('+')),
                 "space" => key = Some(KeyCode::Char(' ')),
                 "enter" => key = Some(KeyCode::Enter),
                 "esc" => key = Some(KeyCode::Esc),
@@ -246,6 +468,13 @@ impl FromStr for Shortcut {
                 "pagedown" => key = Some(KeyCode::PageDown),
                 "pageup" => key = Some(KeyCode::PageUp),
                 "menu" => key = Some(KeyCode::Menu),
+                "tab" => key = Some(KeyCode::Tab),
+                // What a terminal reports for Shift+Tab, which it tells
+                // apart from a Tab of its own.
+                "backtab" => key = Some(KeyCode::BackTab),
+                "backspace" => key = Some(KeyCode::Backspace),
+                "delete" => key = Some(KeyCode::Delete),
+                "insert" => key = Some(KeyCode::Insert),
                 s if s.starts_with('f') && s.chars().count() > 1 => {
                     let s = s.trim_start_matches('f');
                     match s.parse::<u8>() {
@@ -275,6 +504,9 @@ impl Display for Shortcut {
         if self.modifiers.contains(KeyModifiers::CONTROL) {
             parts.push("Control".to_string());
         }
+        if self.modifiers.contains(KeyModifiers::ALT) {
+            parts.push("Alt".to_string());
+        }
         if self.modifiers.contains(KeyModifiers::SHIFT) {
             parts.push("Shift".to_string());
         }
@@ -288,6 +520,11 @@ impl Display for Shortcut {
             KeyCode::PageUp => "PageUp".to_string(),
             KeyCode::Home => "Home".to_string(),
             KeyCode::End => "End".to_string(),
+            KeyCode::Tab => "Tab".to_string(),
+            KeyCode::BackTab => "BackTab".to_string(),
+            KeyCode::Backspace => "Backspace".to_string(),
+            KeyCode::Delete => "Delete".to_string(),
+            KeyCode::Insert => "Insert".to_string(),
             KeyCode::F(n) => format!("F{n}"),
             // A space of its own would be read as no key at all.
             KeyCode::Char(' ') => "Space".to_string(),
@@ -326,16 +563,19 @@ mod tests {
         }
     }
 
-    fn item(section: Section, key: &str) -> HelpItem {
-        HelpItem {
-            section,
-            keys: key.to_owned(),
-            description: format!("do {key}"),
+    fn item(section: Section, key: &'static str) -> Binding {
+        Binding {
+            context: Context::Global,
+            name: Some(key),
+            section: Some(section),
+            description: key,
+            keys: vec![Shortcut::from_str(key).expect("shortcut should parse")],
+            defaults: Vec::new(),
         }
     }
 
     fn listed(key: &str) -> (String, String) {
-        (key.to_owned(), format!("do {key}"))
+        (key.to_owned(), key.to_owned())
     }
 
     #[test]
@@ -371,10 +611,14 @@ mod tests {
     fn test_shortcut_from_str() {
         let ctrl = KeyModifiers::CONTROL;
         let shift = KeyModifiers::SHIFT;
+        let alt = KeyModifiers::ALT;
         let ctrl_shift = ctrl | shift;
+        let ctrl_alt_shift = ctrl | alt | shift;
 
         let table = [
             ("q", Ok(Shortcut::new_char('q'))),
+            ("+", Ok(Shortcut::new_char('+'))),
+            ("ctrl++", Ok(Shortcut::new_mod_char(ctrl, '+'))),
             ("Q", Ok(Shortcut::new_char('q'))),
             ("f", Ok(Shortcut::new_char('f'))),
             ("@", Ok(Shortcut::new_char('@'))),
@@ -384,6 +628,11 @@ mod tests {
             ("ctrl+Q", Ok(Shortcut::new_mod_char(ctrl, 'q'))),
             ("ctrl+ctrl+q", Ok(Shortcut::new_mod_char(ctrl, 'q'))),
             ("ctrl+shift+q", Ok(Shortcut::new_mod_char(ctrl_shift, 'q'))),
+            ("alt+q", Ok(Shortcut::new_mod_char(alt, 'q'))),
+            (
+                "ctrl+alt+shift+q",
+                Ok(Shortcut::new_mod_char(ctrl_alt_shift, 'q')),
+            ),
             (
                 "ctrl+shift+f5",
                 Ok(Shortcut::new_mod_key(ctrl_shift, KeyCode::F(5))),
@@ -404,6 +653,11 @@ mod tests {
             ("down", Ok(Shortcut::new_key(KeyCode::Down))),
             ("pagedown", Ok(Shortcut::new_key(KeyCode::PageDown))),
             ("pageup", Ok(Shortcut::new_key(KeyCode::PageUp))),
+            ("tab", Ok(Shortcut::new_key(KeyCode::Tab))),
+            ("backtab", Ok(Shortcut::new_key(KeyCode::BackTab))),
+            ("backspace", Ok(Shortcut::new_key(KeyCode::Backspace))),
+            ("delete", Ok(Shortcut::new_key(KeyCode::Delete))),
+            ("insert", Ok(Shortcut::new_key(KeyCode::Insert))),
             ("ctrl+ff", Err(ShortcutParseError::InvalidF)),
             ("qq", Err(ShortcutParseError::NoKey)),
             ("", Err(ShortcutParseError::NoKey)),
@@ -425,6 +679,8 @@ mod tests {
         let table = [
             ("q", "q"),
             ("ctrl+shift+q", "Control+Shift+q"),
+            ("alt+q", "Alt+q"),
+            ("ctrl+alt+shift+q", "Control+Alt+Shift+q"),
             ("space", "Space"),
             ("enter", "Enter"),
             ("esc", "Esc"),
@@ -439,6 +695,11 @@ mod tests {
             ("pageup", "PageUp"),
             ("menu", "Menu"),
             ("f5", "F5"),
+            ("tab", "Tab"),
+            ("backtab", "BackTab"),
+            ("backspace", "Backspace"),
+            ("delete", "Delete"),
+            ("insert", "Insert"),
         ];
 
         for (s, expected) in table {
@@ -447,6 +708,65 @@ mod tests {
                 shortcut.to_string(),
                 expected,
                 "Shortcut::from_str(\"{s}\")"
+            );
+        }
+    }
+
+    /// An action is offered under the key the configuration is to bind
+    /// it by, so binding it under that key has to be what reaches it.
+    #[test]
+    fn test_every_action_is_bound_by_the_key_it_is_offered_under() {
+        let bound = Shortcut::from_str("f12").expect("shortcut should parse");
+
+        for context in Context::ORDER {
+            for binding in context.bindings_of(None) {
+                let Some(key) = binding.key() else {
+                    continue;
+                };
+                let named = key
+                    .strip_prefix("blazingjj.keybinds.")
+                    .expect("a binding is configured under the keybinds table");
+                let config: KeybindsConfig = toml::from_str(&format!("{named} = \"f12\"\n"))
+                    .expect("the configuration parses");
+
+                let rebound = context
+                    .bindings_of(Some(&config))
+                    .into_iter()
+                    .find(|rebound| rebound.name == binding.name)
+                    .expect("the action is still listed");
+                assert_eq!(rebound.keys, vec![bound], "{key}");
+            }
+        }
+    }
+
+    /// A shortcut is offered by the name it reads by, so that name has
+    /// to be one the configuration takes back.
+    #[test]
+    fn test_a_shortcut_reads_back_as_the_one_it_was_written_from() {
+        for s in [
+            "q",
+            "ctrl+q",
+            "shift+q",
+            "ctrl+shift+f5",
+            "alt+q",
+            "ctrl+alt+delete",
+            "space",
+            "enter",
+            "esc",
+            "ctrl+end",
+            "menu",
+            "tab",
+            "shift+backtab",
+            "backspace",
+            "delete",
+            "insert",
+        ] {
+            let shortcut = Shortcut::from_str(s).expect("shortcut should parse");
+
+            assert_eq!(
+                Shortcut::from_str(&shortcut.to_string()),
+                Ok(shortcut),
+                "{shortcut}"
             );
         }
     }

--- a/src/keybinds/popup.rs
+++ b/src/keybinds/popup.rs
@@ -2,11 +2,14 @@ use std::str::FromStr;
 
 use ratatui::crossterm::event::KeyEvent;
 
+use super::Binding;
+use super::Context;
 use super::Shortcut;
 use super::config::KeybindsConfig;
 use super::config::TextPopupKeybindsConfig;
 use super::keybinds_store::KeybindsStore;
 use crate::env::keybinds_config;
+use crate::make_bindings;
 use crate::set_keybinds;
 use crate::update_keybinds;
 
@@ -32,8 +35,9 @@ pub enum PopupEvent {
 }
 
 impl PopupKeybinds {
-    /// Keys for a popup that lists what there is to pick from.
-    pub fn dialog() -> Self {
+    /// The keys a popup that lists what there is to pick from comes
+    /// with.
+    fn dialog_keys() -> KeybindsStore<PopupEvent> {
         let mut keys = KeybindsStore::<PopupEvent>::default();
         set_keybinds!(
             keys,
@@ -52,8 +56,20 @@ impl PopupKeybinds {
             PopupEvent::ScrollUpPage => "ctrl+b",
             PopupEvent::ScrollUpPage => "pageup",
         );
-        let mut keybinds = Self { keys };
-        if let Some(config) = keybinds_config() {
+        keys
+    }
+
+    /// Keys for a popup that lists what there is to pick from.
+    pub fn dialog() -> Self {
+        Self::dialog_from_config(keybinds_config())
+    }
+
+    /// The same as `config` has them.
+    pub(super) fn dialog_from_config(config: Option<&KeybindsConfig>) -> Self {
+        let mut keybinds = Self {
+            keys: Self::dialog_keys(),
+        };
+        if let Some(config) = config {
             keybinds.extend_dialog_from_config(config);
         }
         keybinds
@@ -62,22 +78,33 @@ impl PopupKeybinds {
     /// Keys for a popup holding a text field, where every key the field
     /// can take is the field's.
     pub fn text() -> Self {
-        Self::text_field(false)
+        Self::text_field(false, keybinds_config())
+    }
+
+    /// The same as `config` has them.
+    pub(super) fn text_from_config(config: Option<&KeybindsConfig>) -> Self {
+        Self::text_field(false, config)
     }
 
     /// Keys for a popup holding a text field of a single line, which has
     /// no newline to put an Enter in.
     pub fn text_line() -> Self {
-        Self::text_field(true)
+        Self::text_field(true, keybinds_config())
     }
 
-    fn text_field(single_line: bool) -> Self {
+    /// The keys a popup holding a text field comes with.
+    fn text_keys() -> KeybindsStore<PopupEvent> {
         let mut keys = KeybindsStore::<PopupEvent>::default();
         set_keybinds!(
             keys,
             PopupEvent::Accept => "ctrl+s",
             PopupEvent::Cancel => "esc",
         );
+        keys
+    }
+
+    fn text_field(single_line: bool, config: Option<&KeybindsConfig>) -> Self {
+        let mut keys = Self::text_keys();
         if single_line {
             keys.add_action(
                 Shortcut::from_str("enter").expect("shortcut should parse"),
@@ -86,7 +113,7 @@ impl PopupKeybinds {
         }
 
         let mut keybinds = Self { keys };
-        if let Some(config) = keybinds_config().and_then(|config| config.text_popup.as_ref()) {
+        if let Some(config) = config.and_then(|config| config.text_popup.as_ref()) {
             keybinds.extend_text_from_config(config);
         }
         keybinds
@@ -94,6 +121,31 @@ impl PopupKeybinds {
 
     pub fn match_event(&self, event: KeyEvent) -> PopupEvent {
         self.keys.match_event(event).unwrap_or(PopupEvent::Unbound)
+    }
+
+    /// What a popup that lists what there is to pick from binds. Which
+    /// keys scroll it is not its own to say: they are the keys that
+    /// scroll everywhere.
+    pub fn bindings(&self) -> Vec<Binding> {
+        make_bindings!(
+            self.keys, Self::dialog_keys(), Context::Popup,
+            PopupEvent::Accept => "accept", None, "take the popup up on what is selected",
+            PopupEvent::Cancel => "cancel", None, "take the popup down",
+            PopupEvent::ScrollDownHalf => "scroll-down-half", None, "scroll down by ½ page",
+            PopupEvent::ScrollUpHalf => "scroll-up-half", None, "scroll up by ½ page",
+            PopupEvent::ScrollDownPage => "scroll-down-page", None, "scroll down by page",
+            PopupEvent::ScrollUpPage => "scroll-up-page", None, "scroll up by page",
+        )
+    }
+
+    /// What a popup holding a text field binds, which is only what the
+    /// field itself leaves free.
+    pub fn text_bindings(&self) -> Vec<Binding> {
+        make_bindings!(
+            self.keys, Self::text_keys(), Context::TextPopup,
+            PopupEvent::Accept => "accept", None, "accept what was typed, as Enter does in a field of a single line",
+            PopupEvent::Cancel => "cancel", None, "take the popup down",
+        )
     }
 
     /// The line under a popup saying what it answers to, with `accept`

--- a/src/keybinds/rebase_popup.rs
+++ b/src/keybinds/rebase_popup.rs
@@ -4,10 +4,14 @@ use std::str::FromStr; // used by set_keybinds macro
 
 use ratatui::crossterm::event::KeyEvent;
 
+use super::Binding;
+use super::Context;
 use super::Shortcut;
+use super::config::KeybindsConfig;
 use super::config::RebasePopupKeybindsConfig;
 use super::keybinds_store::KeybindsStore;
 use crate::env::keybinds_config;
+use crate::make_bindings;
 use crate::set_keybinds;
 use crate::update_keybinds;
 
@@ -65,8 +69,13 @@ impl Default for Keybinds {
 impl Keybinds {
     /// The bindings as the configuration has them.
     pub fn new() -> Self {
+        Self::from_config(keybinds_config())
+    }
+
+    /// The bindings as `config` has them.
+    pub(super) fn from_config(config: Option<&KeybindsConfig>) -> Self {
         let mut keybinds = Self::default();
-        if let Some(config) = keybinds_config().and_then(|config| config.rebase_popup.as_ref()) {
+        if let Some(config) = config.and_then(|config| config.rebase_popup.as_ref()) {
             keybinds.extend_from_config(config);
         }
         keybinds
@@ -78,6 +87,18 @@ impl Keybinds {
         } else {
             PopupAction::None
         }
+    }
+
+    pub fn bindings(&self) -> Vec<Binding> {
+        make_bindings!(
+            self.keys, default_keybinds(), Context::RebasePopup,
+            PopupAction::SetSourceMode(CutOption::IncludeDescendants) => "source-with-descendants", None, "take the change and its descendants",
+            PopupAction::SetSourceMode(CutOption::IncludeBranch) => "source-whole-branch", None, "take the whole branch",
+            PopupAction::SetSourceMode(CutOption::SingleRevision) => "source-single-revision", None, "take the change on its own",
+            PopupAction::SetTargetMode(PasteOption::NewBranch) => "target-new-branch", None, "put the source onto the destination",
+            PopupAction::SetTargetMode(PasteOption::InsertAfter) => "target-insert-after", None, "put the source after the destination",
+            PopupAction::SetTargetMode(PasteOption::InsertBefore) => "target-insert-before", None, "put the source before the destination",
+        )
     }
 
     fn extend_from_config(&mut self, config: &RebasePopupKeybindsConfig) {

--- a/src/keybinds/settings_tab.rs
+++ b/src/keybinds/settings_tab.rs
@@ -1,0 +1,76 @@
+use std::str::FromStr;
+
+use ratatui::crossterm::event::KeyEvent;
+
+use super::HelpItem;
+use super::Section;
+use super::Shortcut;
+use super::config::SettingsTabKeybindsConfig;
+use super::keybinds_store::KeybindsStore;
+use crate::env::keybinds_config;
+use crate::make_keybinds_help;
+use crate::set_keybinds;
+use crate::update_keybinds;
+
+#[derive(Debug)]
+pub struct SettingsTabKeybinds {
+    keys: KeybindsStore<SettingsTabEvent>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum SettingsTabEvent {
+    Change,
+    Unset,
+
+    Unbound,
+}
+
+impl Default for SettingsTabKeybinds {
+    fn default() -> Self {
+        let mut keys = KeybindsStore::<SettingsTabEvent>::default();
+        set_keybinds!(
+            keys,
+            SettingsTabEvent::Change => "enter",
+            SettingsTabEvent::Unset => "x",
+        );
+        Self { keys }
+    }
+}
+
+impl SettingsTabKeybinds {
+    /// The bindings as the configuration has them.
+    pub fn new() -> Self {
+        let mut keybinds = Self::default();
+        if let Some(config) = keybinds_config().and_then(|config| config.settings_tab.as_ref()) {
+            keybinds.extend_from_config(config);
+        }
+        keybinds
+    }
+
+    fn extend_from_config(&mut self, config: &SettingsTabKeybindsConfig) {
+        update_keybinds!(
+            self.keys,
+            SettingsTabEvent::Change => config.change,
+            SettingsTabEvent::Unset => config.unset,
+        );
+    }
+
+    pub fn match_event(&self, event: KeyEvent) -> SettingsTabEvent {
+        self.keys
+            .match_event(event)
+            .unwrap_or(SettingsTabEvent::Unbound)
+    }
+
+    pub fn make_help(&self) -> Vec<HelpItem> {
+        make_keybinds_help!(
+            self.keys,
+            SettingsTabEvent::Change => Section::Settings, "change the setting",
+            SettingsTabEvent::Unset => Section::Settings, "take the setting out of your config",
+        )
+    }
+}
+
+#[test]
+fn test_settings_tab_keybinds_default() {
+    let _ = SettingsTabKeybinds::default();
+}

--- a/src/keybinds/settings_tab.rs
+++ b/src/keybinds/settings_tab.rs
@@ -2,13 +2,15 @@ use std::str::FromStr;
 
 use ratatui::crossterm::event::KeyEvent;
 
-use super::HelpItem;
+use super::Binding;
+use super::Context;
 use super::Section;
 use super::Shortcut;
+use super::config::KeybindsConfig;
 use super::config::SettingsTabKeybindsConfig;
 use super::keybinds_store::KeybindsStore;
 use crate::env::keybinds_config;
-use crate::make_keybinds_help;
+use crate::make_bindings;
 use crate::set_keybinds;
 use crate::update_keybinds;
 
@@ -40,8 +42,13 @@ impl Default for SettingsTabKeybinds {
 impl SettingsTabKeybinds {
     /// The bindings as the configuration has them.
     pub fn new() -> Self {
+        Self::from_config(keybinds_config())
+    }
+
+    /// The bindings as `config` has them.
+    pub(super) fn from_config(config: Option<&KeybindsConfig>) -> Self {
         let mut keybinds = Self::default();
-        if let Some(config) = keybinds_config().and_then(|config| config.settings_tab.as_ref()) {
+        if let Some(config) = config.and_then(|config| config.settings_tab.as_ref()) {
             keybinds.extend_from_config(config);
         }
         keybinds
@@ -61,11 +68,11 @@ impl SettingsTabKeybinds {
             .unwrap_or(SettingsTabEvent::Unbound)
     }
 
-    pub fn make_help(&self) -> Vec<HelpItem> {
-        make_keybinds_help!(
-            self.keys,
-            SettingsTabEvent::Change => Section::Settings, "change the setting",
-            SettingsTabEvent::Unset => Section::Settings, "take the setting out of your config",
+    pub fn bindings(&self) -> Vec<Binding> {
+        make_bindings!(
+            self.keys, Self::default().keys, Context::SettingsTab,
+            SettingsTabEvent::Change => "change", Some(Section::Settings), "change the setting",
+            SettingsTabEvent::Unset => "unset", Some(Section::Settings), "take the setting out of your config",
         )
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,7 @@ mod env;
 mod event;
 mod interrupt;
 mod keybinds;
+mod settings;
 mod ui;
 use crate::app::App;
 use crate::app::Handled;

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,321 @@
+/*! The options the app can be configured with, as the settings tab
+offers them.
+
+Each option is a jj config key, so what the tab reads and writes is the
+configuration jj already keeps. A value is passed around as the TOML
+expression `jj config set` takes, which is also what the configuration
+is checked against before anything is written.
+*/
+
+use anyhow::Result;
+
+use crate::env::check_config_value;
+
+/// What kind of value an option takes, which decides both how it is
+/// asked for and how what is typed becomes a TOML expression.
+pub enum SettingKind {
+    /// One of a fixed set of values.
+    Choice(&'static [&'static str]),
+    /// Free text.
+    Text,
+    /// A number, which is written as one rather than as the text of one.
+    Number,
+    /// A command line, which is written as the list of the program and
+    /// its arguments. Arguments are taken apart at whitespace, so one
+    /// that holds any has to be written in the config file itself.
+    CommandLine,
+}
+
+/// One option the settings tab shows.
+pub struct Setting {
+    /// The config key, as jj names it.
+    pub key: &'static str,
+    /// The heading the tab lists it under.
+    pub section: &'static str,
+    /// What the option does.
+    pub doc: &'static str,
+    /// What the app goes by while the option is not set.
+    pub fallback: &'static str,
+    pub kind: SettingKind,
+}
+
+impl Setting {
+    /// The TOML expression `input` stands for, refused when the option
+    /// cannot be read back from it.
+    pub fn value_of(&self, input: &str) -> Result<String> {
+        let value = match self.kind {
+            SettingKind::Number => input.trim().to_owned(),
+            SettingKind::Choice(_) | SettingKind::Text => {
+                toml::Value::String(input.to_owned()).to_string()
+            }
+            SettingKind::CommandLine => toml::Value::Array(
+                input
+                    .split_whitespace()
+                    .map(|word| toml::Value::String(word.to_owned()))
+                    .collect(),
+            )
+            .to_string(),
+        };
+        check_config_value(self.key, &value)?;
+
+        Ok(value)
+    }
+
+    /// How `value` reads on screen, and so also how it is offered for
+    /// changing: a string as it says rather than as it is quoted, a
+    /// command line as the command, anything else as TOML writes it.
+    pub fn text_of(&self, value: &toml::Value) -> String {
+        match (&self.kind, value) {
+            (SettingKind::CommandLine, toml::Value::Array(words)) => words
+                .iter()
+                .map(|word| {
+                    word.as_str()
+                        .map_or_else(|| word.to_string(), str::to_owned)
+                })
+                .collect::<Vec<_>>()
+                .join(" "),
+            (_, toml::Value::String(text)) => text.clone(),
+            _ => value.to_string(),
+        }
+    }
+
+    /// The values the option can take, for an option that only takes one
+    /// of a fixed set.
+    pub fn choices(&self) -> Option<&'static [&'static str]> {
+        match self.kind {
+            SettingKind::Choice(choices) => Some(choices),
+            _ => None,
+        }
+    }
+}
+
+/// Every option the settings tab shows, in the order it lists them. The
+/// options of a section come one after another, that being how the tab
+/// gathers them under it.
+pub const SETTINGS: &[Setting] = &[
+    Setting {
+        key: "blazingjj.highlight-color",
+        section: "Appearance",
+        doc: "Background colour of the selected row, as a colour name or a #rrggbb code.",
+        fallback: "#323296",
+        kind: SettingKind::Text,
+    },
+    Setting {
+        key: "blazingjj.layout",
+        section: "Appearance",
+        doc: "How a tab divides itself between its main and its details panel.",
+        fallback: "horizontal",
+        kind: SettingKind::Choice(&["horizontal", "vertical"]),
+    },
+    Setting {
+        key: "blazingjj.layout-percent",
+        section: "Appearance",
+        doc: "The share of a tab the main panel takes, from 0 to 100.",
+        fallback: "50",
+        kind: SettingKind::Number,
+    },
+    Setting {
+        key: "blazingjj.diff-format",
+        section: "Diffs",
+        doc: "How a diff is rendered. Without one, a configured diff pager or diff tool is used.",
+        fallback: "ui.diff.format, else color-words",
+        kind: SettingKind::Choice(&["color-words", "git", "pager", "summary", "stat"]),
+    },
+    Setting {
+        key: "blazingjj.diff-pager",
+        section: "Diffs",
+        doc: "The command a diff in the pager format is piped through, like `delta --width=$width`. It reads a Git format diff and must not page itself; $width stands for the columns it renders into.",
+        fallback: "no pager",
+        kind: SettingKind::CommandLine,
+    },
+    Setting {
+        key: "blazingjj.diff-tool",
+        section: "Diffs",
+        doc: "The program that renders a diff when the diff format is the diff tool.",
+        fallback: "ui.diff.tool",
+        kind: SettingKind::Text,
+    },
+    Setting {
+        key: "blazingjj.describe-mode",
+        section: "Changes",
+        doc: "What describing a change puts up: the built-in editor, or `jj describe` with the terminal and your own editor.",
+        fallback: "popup",
+        kind: SettingKind::Choice(&["popup", "jj"]),
+    },
+    Setting {
+        key: "blazingjj.bookmark-template",
+        section: "Changes",
+        doc: "Template for the name a generated bookmark is proposed under. Without one, 'push-' ++ change_id.short().",
+        fallback: "templates.git_push_bookmark",
+        kind: SettingKind::Text,
+    },
+    Setting {
+        key: "blazingjj.poll-interval",
+        section: "Watching the repo",
+        doc: "Seconds between checks for work done outside the app, or 0 to only check when asked.",
+        fallback: "1",
+        kind: SettingKind::Number,
+    },
+];
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use ratatui::style::Color;
+
+    use super::*;
+    use crate::env::DescribeMode;
+    use crate::env::DiffFormat;
+    use crate::env::JJLayout;
+    use crate::env::JjConfig;
+
+    fn setting(key: &str) -> &'static Setting {
+        SETTINGS
+            .iter()
+            .find(|setting| setting.key == key)
+            .expect("the setting is one the app has")
+    }
+
+    /// The configuration as it reads with the option set to what the
+    /// tab says the app goes by while it is not.
+    fn as_fallback(key: &str) -> JjConfig {
+        let setting = setting(key);
+        let value = setting
+            .value_of(setting.fallback)
+            .expect("the fallback is a value the option takes");
+
+        toml::from_str(&format!("{key} = {value}\n")).expect("the configuration parses")
+    }
+
+    /// The configuration as it reads with `key` set to `value`.
+    fn set(key: &str, value: &str) -> JjConfig {
+        toml::from_str(&format!("{key} = {value}\n")).expect("the configuration parses")
+    }
+
+    /// Every option is a key the app reads, and a key it does not read
+    /// is one the tab would write to the user's config for nothing:
+    /// what names no option is taken as saying nothing rather than
+    /// refused.
+    #[test]
+    fn every_option_is_a_key_the_app_reads() {
+        assert_eq!(
+            set("blazingjj.highlight-color", "\"#010203\"").highlight_color(),
+            Color::Rgb(1, 2, 3)
+        );
+        assert_eq!(
+            set("blazingjj.diff-format", "\"git\"").diff_format(),
+            DiffFormat::Git
+        );
+        assert_eq!(
+            set("blazingjj.diff-tool", "\"difft\"").diff_tool(),
+            Some(Some("difft".to_owned()))
+        );
+        assert!(
+            set("blazingjj.diff-pager", "\"delta\"")
+                .diff_pager()
+                .is_some()
+        );
+        assert_eq!(
+            set("blazingjj.bookmark-template", "\"name\"").bookmark_template(),
+            "name"
+        );
+        assert_eq!(
+            set("blazingjj.describe-mode", "\"jj\"").describe_mode(),
+            DescribeMode::Jj
+        );
+        assert_eq!(
+            set("blazingjj.layout", "\"vertical\"").layout(),
+            JJLayout::Vertical
+        );
+        assert_eq!(set("blazingjj.layout-percent", "40").layout_percent(), 40);
+        assert_eq!(
+            set("blazingjj.poll-interval", "5").poll_interval(),
+            Some(Duration::from_secs(5))
+        );
+    }
+
+    /// What the tab says the app goes by without an option has to be
+    /// what it does go by, for an option whose fallback is a value of
+    /// its own rather than another key of the configuration.
+    #[test]
+    fn a_fallback_says_what_the_app_goes_by_without_the_option() {
+        let default = JjConfig::default();
+
+        assert_eq!(
+            as_fallback("blazingjj.highlight-color").highlight_color(),
+            default.highlight_color()
+        );
+        assert_eq!(
+            as_fallback("blazingjj.describe-mode").describe_mode(),
+            default.describe_mode()
+        );
+        assert_eq!(as_fallback("blazingjj.layout").layout(), default.layout());
+        assert_eq!(
+            as_fallback("blazingjj.layout-percent").layout_percent(),
+            default.layout_percent()
+        );
+        assert_eq!(
+            as_fallback("blazingjj.poll-interval").poll_interval(),
+            default.poll_interval()
+        );
+    }
+
+    #[test]
+    fn text_is_quoted_into_a_value_of_its_own() {
+        let color = setting("blazingjj.highlight-color");
+
+        assert_eq!(color.value_of("#123456").unwrap(), "\"#123456\"");
+        assert!(color.value_of("chartreuse").is_err());
+    }
+
+    #[test]
+    fn a_number_is_written_as_one_rather_than_as_its_text() {
+        let percent = setting("blazingjj.layout-percent");
+
+        assert_eq!(percent.value_of(" 40 ").unwrap(), "40");
+        assert!(percent.value_of("half").is_err());
+    }
+
+    /// A number the option cannot take is refused where it is typed,
+    /// rather than written for the app to make what it can of.
+    #[test]
+    fn a_number_outside_what_the_option_takes_is_refused() {
+        let percent = setting("blazingjj.layout-percent");
+
+        assert!(percent.value_of("100").is_ok());
+        assert!(percent.value_of("101").is_err());
+    }
+
+    #[test]
+    fn a_command_line_is_written_as_the_program_and_its_arguments() {
+        let pager = setting("blazingjj.diff-pager");
+
+        assert_eq!(
+            pager.value_of("delta --width=$width").unwrap(),
+            r#"["delta", "--width=$width"]"#
+        );
+        assert!(pager.value_of("  ").is_err());
+    }
+
+    #[test]
+    fn a_command_line_reads_back_as_the_command_it_was_typed_as() {
+        let pager = setting("blazingjj.diff-pager");
+        let value = toml::Value::Array(
+            ["delta", "--width=$width"]
+                .map(|word| toml::Value::String(word.to_owned()))
+                .to_vec(),
+        );
+
+        assert_eq!(pager.text_of(&value), "delta --width=$width");
+    }
+
+    #[test]
+    fn every_choice_an_option_offers_is_one_it_can_take() {
+        for setting in SETTINGS {
+            for choice in setting.choices().unwrap_or_default() {
+                assert!(setting.value_of(choice).is_ok(), "{} {choice}", setting.key);
+            }
+        }
+    }
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -8,6 +8,7 @@ is checked against before anything is written.
 */
 
 use anyhow::Result;
+use anyhow::bail;
 
 use crate::env::check_config_value;
 
@@ -24,6 +25,9 @@ pub enum SettingKind {
     /// its arguments. Arguments are taken apart at whitespace, so one
     /// that holds any has to be written in the config file itself.
     CommandLine,
+    /// The keybindings, which are a table rather than a value to type,
+    /// so they are changed one binding at a time in a tab of their own.
+    Keybindings,
 }
 
 /// One option the settings tab shows.
@@ -44,6 +48,7 @@ impl Setting {
     /// cannot be read back from it.
     pub fn value_of(&self, input: &str) -> Result<String> {
         let value = match self.kind {
+            SettingKind::Keybindings => bail!("The keybindings are not an option to type"),
             SettingKind::Number => input.trim().to_owned(),
             SettingKind::Choice(_) | SettingKind::Text => {
                 toml::Value::String(input.to_owned()).to_string()
@@ -66,6 +71,13 @@ impl Setting {
     /// command line as the command, anything else as TOML writes it.
     pub fn text_of(&self, value: &toml::Value) -> String {
         match (&self.kind, value) {
+            // What the keybindings are is the keybindings tab's to say;
+            // what the settings tab says is only how many of them the
+            // configuration has anything to say about.
+            (SettingKind::Keybindings, _) => match bindings_set(value) {
+                1 => "1 binding set".to_owned(),
+                set => format!("{set} bindings set"),
+            },
             (SettingKind::CommandLine, toml::Value::Array(words)) => words
                 .iter()
                 .map(|word| {
@@ -86,6 +98,15 @@ impl Setting {
             SettingKind::Choice(choices) => Some(choices),
             _ => None,
         }
+    }
+}
+
+/// How many bindings `value` holds, counting the ones in the tables of
+/// the contexts they take effect in.
+fn bindings_set(value: &toml::Value) -> usize {
+    match value {
+        toml::Value::Table(table) => table.values().map(bindings_set).sum(),
+        _ => 1,
     }
 }
 
@@ -155,6 +176,13 @@ pub const SETTINGS: &[Setting] = &[
         doc: "Seconds between checks for work done outside the app, or 0 to only check when asked.",
         fallback: "1",
         kind: SettingKind::Number,
+    },
+    Setting {
+        key: "blazingjj.keybinds",
+        section: "Keys",
+        doc: "The keys the app answers to, one binding per action. Opens the list of them.",
+        fallback: "the keys the app comes with",
+        kind: SettingKind::Keybindings,
     },
 ];
 
@@ -229,6 +257,11 @@ mod tests {
             JJLayout::Vertical
         );
         assert_eq!(set("blazingjj.layout-percent", "40").layout_percent(), 40);
+        assert!(
+            set("blazingjj.keybinds", "{ quit = \"x\" }")
+                .keybinds()
+                .is_some()
+        );
         assert_eq!(
             set("blazingjj.poll-interval", "5").poll_interval(),
             Some(Duration::from_secs(5))
@@ -285,6 +318,24 @@ mod tests {
 
         assert!(percent.value_of("100").is_ok());
         assert!(percent.value_of("101").is_err());
+    }
+
+    /// The keybindings are a table of tables, so what the row says is
+    /// how many bindings they come to rather than how many tables.
+    #[test]
+    fn the_keybindings_read_as_how_many_of_them_the_configuration_holds() {
+        let keybinds = setting("blazingjj.keybinds");
+        let read = |config: &str| {
+            let config: toml::Value = toml::from_str(config).expect("the configuration parses");
+
+            keybinds.text_of(&config)
+        };
+
+        assert_eq!(read("scroll-down = \"j\"\n"), "1 binding set");
+        assert_eq!(
+            read("scroll-down = \"j\"\nlog-tab.abandon = \"x\"\nlog-tab.absorb = false\n"),
+            "3 bindings set"
+        );
     }
 
     #[test]

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -22,11 +22,11 @@ use crate::commander::new_commander;
 use crate::commander::revset::Revset;
 use crate::env::get_env;
 use crate::event::Mouse;
+use crate::keybinds::Binding;
 use crate::keybinds::BookmarksTabEvent;
 use crate::keybinds::BookmarksTabKeybinds;
 use crate::keybinds::DetailsPanelEvent;
 use crate::keybinds::DetailsPanelKeybinds;
-use crate::keybinds::HelpItem;
 use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
@@ -393,6 +393,8 @@ impl Tab for BookmarksTab {
 
     fn config_changed(&mut self) {
         self.bookmark_panel.config_changed();
+        self.keybinds = BookmarksTabKeybinds::new();
+        self.details_keybinds = DetailsPanelKeybinds::new();
     }
 
     fn is_stale(&self) -> bool {
@@ -438,12 +440,12 @@ impl Tab for BookmarksTab {
         ))
     }
 
-    fn make_main_panel_help(&self) -> Vec<HelpItem> {
-        self.keybinds.make_help()
+    fn main_panel_bindings(&self) -> Vec<Binding> {
+        self.keybinds.bindings()
     }
 
-    fn make_details_panel_help(&self) -> Vec<HelpItem> {
-        self.details_keybinds.make_help()
+    fn details_panel_bindings(&self) -> Vec<Binding> {
+        self.details_keybinds.bindings()
     }
 }
 

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -391,6 +391,10 @@ impl Tab for BookmarksTab {
         self.stale = true;
     }
 
+    fn config_changed(&mut self) {
+        self.bookmark_panel.config_changed();
+    }
+
     fn is_stale(&self) -> bool {
         self.stale
     }

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -20,7 +20,6 @@ use crate::commander::bookmarks::BookmarkLine;
 use crate::commander::log::Head;
 use crate::commander::new_commander;
 use crate::commander::revset::Revset;
-use crate::env::JjConfig;
 use crate::env::get_env;
 use crate::event::Mouse;
 use crate::keybinds::BookmarksTabEvent;
@@ -54,7 +53,6 @@ pub struct BookmarksTab {
 
     bookmark_panel: CommitShowPanel,
 
-    config: JjConfig,
     keybinds: BookmarksTabKeybinds,
     details_keybinds: DetailsPanelKeybinds,
     pane_divider: PaneDivider,
@@ -118,8 +116,7 @@ impl BookmarksTab {
     /// A stale tab holding no bookmarks yet.
     #[instrument(level = "info", name = "Initializing bookmarks tab", parent = None, skip(background_tasks))]
     pub fn new(background_tasks: BackgroundTasks) -> Self {
-        let config = get_env().jj_config.clone();
-        let pane_divider = PaneDivider::new(config.layout_percent());
+        let pane_divider = PaneDivider::default();
         let keybinds = BookmarksTabKeybinds::new();
         let details_keybinds = DetailsPanelKeybinds::new();
 
@@ -133,7 +130,6 @@ impl BookmarksTab {
 
             bookmark_panel: CommitShowPanel::new(TabId::Bookmarks, background_tasks),
 
-            config,
             keybinds,
             details_keybinds,
             pane_divider,
@@ -280,7 +276,7 @@ impl BookmarksTab {
     /// `anchor` or centered when there is nowhere to point at.
     fn context_menu(&self, anchor: Option<Position>) -> Option<AppAction> {
         Some(AppAction::SetPopup(Box::new(bookmarks_context_menu(
-            self.config.clone(),
+            get_env().jj_config.clone(),
             anchor,
             self.selected_target(),
         ))))
@@ -308,7 +304,7 @@ impl BookmarksTab {
             BookmarksTabEvent::DeleteBookmark => {
                 if let Some(bookmark) = self.selected_bookmark() {
                     return Ok(Some(command::ask_delete_bookmark(
-                        self.config.clone(),
+                        get_env().jj_config.clone(),
                         &bookmark.name,
                     )));
                 }
@@ -316,7 +312,7 @@ impl BookmarksTab {
             BookmarksTabEvent::ForgetBookmark => {
                 if let Some(bookmark) = self.listed_bookmark() {
                     return Ok(Some(command::ask_forget_bookmark(
-                        self.config.clone(),
+                        get_env().jj_config.clone(),
                         &bookmark.name,
                     )));
                 }
@@ -339,7 +335,7 @@ impl BookmarksTab {
             BookmarksTabEvent::SetBookmark => {
                 if let Some((bookmark, head)) = self.selected_target() {
                     return Ok(Some(command::ask_set_bookmark(
-                        self.config.clone(),
+                        get_env().jj_config.clone(),
                         bookmark,
                         head,
                     )));
@@ -348,7 +344,7 @@ impl BookmarksTab {
             BookmarksTabEvent::NewChange { describe } => {
                 if let Some((bookmark, head)) = self.selected_target() {
                     return Ok(Some(command::ask_new_change(
-                        self.config.clone(),
+                        get_env().jj_config.clone(),
                         Revset::from(&head.commit_id),
                         NewSource::Change,
                         &bookmark.to_string(),
@@ -359,7 +355,7 @@ impl BookmarksTab {
             BookmarksTabEvent::EditChange { ignore_immutable } => {
                 if let Some((bookmark, head)) = self.selected_target() {
                     return Ok(Some(command::ask_edit(
-                        self.config.clone(),
+                        get_env().jj_config.clone(),
                         head,
                         format!("Bookmark: {bookmark}"),
                         ignore_immutable,
@@ -470,7 +466,7 @@ impl Component for BookmarksTab {
         f: &mut ratatui::prelude::Frame<'_>,
         area: ratatui::prelude::Rect,
     ) -> Result<()> {
-        let chunks = self.pane_divider.split(area, self.config.layout());
+        let chunks = self.pane_divider.split(area);
 
         // Draw bookmarks
         {
@@ -491,14 +487,13 @@ impl Component for BookmarksTab {
                                 line.spans.insert(0, Span::from(" "));
 
                                 if current_bookmark_index == Some(i) {
-                                    line = line.bg(self.config.highlight_color());
+                                    let highlight = get_env().jj_config.highlight_color();
 
+                                    line = line.bg(highlight);
                                     line.spans = line
                                         .spans
                                         .iter_mut()
-                                        .map(|span| {
-                                            span.to_owned().bg(self.config.highlight_color())
-                                        })
+                                        .map(|span| span.to_owned().bg(highlight))
                                         .collect();
                                 }
 
@@ -585,7 +580,7 @@ impl Component for BookmarksTab {
     }
 
     fn input_mouse(&mut self, mouse: Mouse) -> Result<ComponentInputResult> {
-        if self.pane_divider.handle_mouse(mouse, self.config.layout()) {
+        if self.pane_divider.handle_mouse(mouse) {
             return Ok(ComponentInputResult::Handled);
         }
         match route_mouse(

--- a/src/ui/dialog/bind_key.rs
+++ b/src/ui/dialog/bind_key.rs
@@ -1,0 +1,330 @@
+/*! A popup taking the key an action is to answer to, which it hands on
+as the operation that writes it to the user's config.
+
+Every key it is given is one to bind, so there is nothing left to answer
+the popup with: it is done as soon as a key that is not a modifier of its
+own is pressed.
+*/
+
+use std::str::FromStr;
+
+use anyhow::Result;
+use anyhow::bail;
+use ratatui::Frame;
+use ratatui::crossterm::event::Event;
+use ratatui::crossterm::event::KeyCode;
+use ratatui::crossterm::event::KeyEvent;
+use ratatui::crossterm::event::KeyEventKind;
+use ratatui::layout::Alignment;
+use ratatui::layout::Constraint;
+use ratatui::layout::Direction;
+use ratatui::layout::Layout;
+use ratatui::layout::Rect;
+use ratatui::style::Color;
+use ratatui::style::Stylize;
+use ratatui::text::Line;
+use ratatui::widgets::Clear;
+use ratatui::widgets::Paragraph;
+use ratatui::widgets::Wrap;
+
+use crate::app::command::Command;
+use crate::keybinds::Binding;
+use crate::keybinds::Context;
+use crate::keybinds::Shortcut;
+use crate::ui::AppAction;
+use crate::ui::Component;
+use crate::ui::ComponentInputResult;
+use crate::ui::styles::POPUP_WIDTH_PERCENT;
+use crate::ui::styles::create_popup_block;
+use crate::ui::styles::popup_footer;
+use crate::ui::styles::popup_text_width;
+use crate::ui::styles::wrapped_height;
+use crate::ui::utils::centered_rect_line_height;
+
+/// What the key pressed is to become of the keys the action answers to.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum BindKey {
+    /// The one key it is to answer to from now on.
+    Only,
+    /// Another key beside the ones it answers to already.
+    Besides,
+}
+
+pub struct BindKeyPopup {
+    binding: Binding,
+    bind: BindKey,
+    /// What was said about the key that was pressed, if it was refused.
+    error: Option<anyhow::Error>,
+}
+
+impl BindKeyPopup {
+    /// Ask for a key `binding` is to answer to.
+    pub fn new(binding: Binding, bind: BindKey) -> Self {
+        Self {
+            binding,
+            bind,
+            error: None,
+        }
+    }
+
+    /// What binding `key` to the action comes to, or why it cannot be
+    /// bound to it.
+    fn bind(&self, key: KeyEvent) -> Result<AppAction> {
+        let shortcut = Shortcut::from_event(key);
+        let text = shortcut.to_string();
+        // The configuration holds a key by the name it is written under,
+        // so one we could not read back is one we cannot offer.
+        if Shortcut::from_str(&text) != Ok(shortcut) {
+            bail!("{text} is not a key that can be bound.");
+        }
+
+        if let Some(bound) = self.bound_elsewhere(shortcut) {
+            bail!(
+                "{text} is already bound to “{}” ({}).",
+                bound.description,
+                bound.context.title()
+            );
+        }
+
+        Ok(AppAction::Multiple(vec![
+            AppAction::ClosePopup,
+            AppAction::Run(Command::SetSetting {
+                key: self.config_key(),
+                value: self.value_of(shortcut),
+            }),
+        ]))
+    }
+
+    /// The TOML expression for the action answering to `shortcut`,
+    /// which for one key beside others is the list of them all.
+    fn value_of(&self, shortcut: Shortcut) -> String {
+        let keys = match self.bind {
+            BindKey::Only => vec![shortcut],
+            BindKey::Besides => {
+                let mut keys = self.binding.keys.clone();
+                // Pressing a key the action already answers to leaves it
+                // answering to it, rather than twice over.
+                if !keys.contains(&shortcut) {
+                    keys.push(shortcut);
+                }
+                keys
+            }
+        };
+
+        match keys.as_slice() {
+            [key] => toml::Value::String(key.to_string()).to_string(),
+            keys => toml::Value::Array(
+                keys.iter()
+                    .map(|key| toml::Value::String(key.to_string()))
+                    .collect(),
+            )
+            .to_string(),
+        }
+    }
+
+    /// The action `shortcut` answers to already, of those whose keys are
+    /// live alongside the ones being bound.
+    fn bound_elsewhere(&self, shortcut: Shortcut) -> Option<Binding> {
+        Context::ORDER
+            .into_iter()
+            .filter(|context| self.binding.context.shares_keys_with(*context))
+            .flat_map(Context::bindings)
+            .find(|binding| {
+                (binding.context, binding.name) != (self.binding.context, self.binding.name)
+                    && binding.keys.contains(&shortcut)
+            })
+    }
+
+    fn config_key(&self) -> String {
+        self.binding
+            .key()
+            .expect("the binding is one the user can change")
+    }
+}
+
+impl Component for BindKeyPopup {
+    fn draw(&mut self, f: &mut Frame<'_>, area: Rect) -> Result<()> {
+        let key = self.config_key();
+        let block = create_popup_block(&key);
+
+        let asked = match self.bind {
+            BindKey::Only => "Press the key for",
+            BindKey::Besides => "Press another key for",
+        };
+        let lines = vec![
+            Line::raw(format!("{asked} “{}”.", self.binding.description)),
+            Line::raw(""),
+            match self.error.as_ref() {
+                Some(error) => Line::raw(format!("{error:#}")).fg(Color::Red),
+                None => Line::raw(format!("It answers to {} now.", self.binding.keys_text()))
+                    .fg(Color::DarkGray),
+            },
+        ];
+
+        // What is said about a key is a sentence rather than a line, so
+        // the popup takes however many rows it wraps into, plus the two
+        // the hint under it takes and the two of the border.
+        let text_height = wrapped_height(&lines, popup_text_width(area));
+
+        let area = centered_rect_line_height(area, POPUP_WIDTH_PERCENT, text_height + 4);
+        f.render_widget(Clear, area);
+        f.render_widget(&block, area);
+
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Fill(1), Constraint::Length(2)])
+            .split(block.inner(area));
+
+        f.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), chunks[0]);
+        f.render_widget(
+            popup_footer(vec![Line::raw(
+                "every key is one to bind, so there is none to leave by",
+            )])
+            .fg(Color::DarkGray)
+            .alignment(Alignment::Center),
+            chunks[1],
+        );
+
+        Ok(())
+    }
+
+    fn input(&mut self, event: Event) -> Result<ComponentInputResult> {
+        let Event::Key(key) = event else {
+            return Ok(ComponentInputResult::Handled);
+        };
+        if key.kind != KeyEventKind::Press {
+            return Ok(ComponentInputResult::Handled);
+        }
+        // A modifier is only ever half of a key to bind, so holding one
+        // down is the popup waiting rather than the popup answered.
+        if matches!(key.code, KeyCode::Modifier(_) | KeyCode::Null) {
+            return Ok(ComponentInputResult::Handled);
+        }
+
+        // A key the action cannot be bound to is one to press again
+        // rather than one to give up on, so the popup stays up with what
+        // was said about it.
+        match self.bind(key) {
+            Ok(action) => Ok(ComponentInputResult::HandledAction(action)),
+            Err(error) => {
+                self.error = Some(error);
+                Ok(ComponentInputResult::Handled)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ratatui::crossterm::event::KeyModifiers;
+
+    use super::*;
+    use crate::env::set_test_env;
+
+    fn popup(description: &str) -> BindKeyPopup {
+        bind_popup(description, BindKey::Only)
+    }
+
+    fn bind_popup(description: &str, bind: BindKey) -> BindKeyPopup {
+        set_test_env();
+        let binding = Context::LogTab
+            .bindings()
+            .into_iter()
+            .find(|binding| binding.description == description)
+            .expect("the action is one the app has");
+
+        BindKeyPopup::new(binding, bind)
+    }
+
+    #[test]
+    fn a_key_is_written_under_the_name_it_reads_by() {
+        let popup = popup("abandon change");
+
+        let action = popup
+            .bind(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::CONTROL))
+            .expect("the key can be bound");
+
+        let AppAction::Multiple(actions) = action else {
+            panic!("binding a key closes the popup and writes the key");
+        };
+        assert!(matches!(
+            actions.as_slice(),
+            [
+                AppAction::ClosePopup,
+                AppAction::Run(Command::SetSetting { key, value })
+            ] if key == "blazingjj.keybinds.log-tab.abandon" && value == "\"Control+k\""
+        ));
+    }
+
+    /// An action can answer to several keys, so binding one beside the
+    /// keys it has writes them all rather than the one.
+    #[test]
+    fn a_key_bound_besides_is_written_beside_the_keys_it_joins() {
+        let only = popup("new change");
+        let besides = bind_popup("new change", BindKey::Besides);
+        let key = Shortcut::from_str("ctrl+n").expect("shortcut should parse");
+
+        assert_eq!(only.value_of(key), "\"Control+n\"");
+        assert_eq!(besides.value_of(key), "[\"n\", \"Control+n\"]");
+        // The keys it answers to are the keys it answers to, however
+        // many times one of them is pressed.
+        let bound = Shortcut::from_str("n").expect("shortcut should parse");
+        assert_eq!(besides.value_of(bound), "\"n\"");
+    }
+
+    /// A key we cannot write down is one we would lose on the way to the
+    /// config file, so it is refused where it is pressed.
+    #[test]
+    fn a_key_that_cannot_be_written_down_is_refused() {
+        let popup = popup("abandon change");
+
+        assert!(
+            popup
+                .bind(KeyEvent::new(KeyCode::CapsLock, KeyModifiers::empty()))
+                .is_err()
+        );
+    }
+
+    /// Only one tab is up at a time, so a key another tab answers to is
+    /// a key this one is free to take.
+    #[test]
+    fn a_key_only_another_context_answers_to_is_taken() {
+        let popup = popup("abandon change");
+
+        // What the files tab untracks a file with, which the log tab
+        // has nothing bound to.
+        assert!(
+            popup
+                .bind(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::empty()))
+                .is_ok()
+        );
+    }
+
+    /// A tab answers to the keys that hold everywhere as well, so one
+    /// of its actions taking such a key leaves that key doing only the
+    /// one thing, in that tab.
+    #[test]
+    fn a_key_an_action_beside_the_context_answers_to_is_refused() {
+        let popup = popup("abandon change");
+
+        let Err(error) = popup.bind(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::empty()))
+        else {
+            panic!("the key is the quit binding");
+        };
+        assert!(error.to_string().contains("quit"), "{error}");
+        assert!(error.to_string().contains("Everywhere"), "{error}");
+    }
+
+    /// Two actions of one context answering to the same key leaves only
+    /// one of them reachable, whichever the app happens to match first.
+    #[test]
+    fn a_key_another_action_of_the_same_context_answers_to_is_refused() {
+        let popup = popup("abandon change");
+
+        let Err(error) = popup.bind(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::empty()))
+        else {
+            panic!("the key is the describe binding");
+        };
+        assert!(error.to_string().contains("describe change"), "{error}");
+    }
+}

--- a/src/ui/dialog/choice.rs
+++ b/src/ui/dialog/choice.rs
@@ -86,6 +86,16 @@ impl ChoicePopup {
         self
     }
 
+    /// Open with this choice under the cursor rather than the first,
+    /// for a list of what something can be where one of them is what it
+    /// already is.
+    pub fn selected(mut self, index: usize) -> Self {
+        if index < self.items.len() {
+            self.list_state.select(Some(index));
+        }
+        self
+    }
+
     fn scroll(&mut self, delta: isize) {
         self.list_state.select(Some(
             self.list_state

--- a/src/ui/dialog/mod.rs
+++ b/src/ui/dialog/mod.rs
@@ -7,6 +7,7 @@ Once launched, a dialog will receive all input events from the App,
 until it sends [`AppAction::ClosePopup`](crate::ui::AppAction).
 */
 
+mod bind_key;
 mod bookmark_name;
 mod bookmark_set;
 mod choice;
@@ -22,6 +23,8 @@ mod parent_select;
 mod rebase;
 mod setting_value;
 
+pub use bind_key::BindKey;
+pub use bind_key::BindKeyPopup;
 pub use bookmark_name::BookmarkNameMode;
 pub use bookmark_name::BookmarkNamePopup;
 pub use bookmark_set::BookmarkSetPopup;

--- a/src/ui/dialog/mod.rs
+++ b/src/ui/dialog/mod.rs
@@ -20,6 +20,7 @@ mod message;
 mod new_insert;
 mod parent_select;
 mod rebase;
+mod setting_value;
 
 pub use bookmark_name::BookmarkNameMode;
 pub use bookmark_name::BookmarkNamePopup;
@@ -40,3 +41,4 @@ pub use message::MessagePopup;
 pub use new_insert::new_insert;
 pub use parent_select::parent_select;
 pub use rebase::RebasePopup;
+pub use setting_value::SettingValuePopup;

--- a/src/ui/dialog/setting_value.rs
+++ b/src/ui/dialog/setting_value.rs
@@ -14,13 +14,7 @@ use ratatui::layout::Layout;
 use ratatui::layout::Rect;
 use ratatui::prelude::Stylize;
 use ratatui::style::Color;
-use ratatui::style::Style;
-use ratatui::widgets::Block;
-use ratatui::widgets::BorderType;
-use ratatui::widgets::Borders;
 use ratatui::widgets::Clear;
-use ratatui::widgets::Paragraph;
-use ratatui::widgets::Wrap;
 use ratatui_textarea::CursorMove;
 use ratatui_textarea::TextArea;
 
@@ -31,14 +25,12 @@ use crate::settings::Setting;
 use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
+use crate::ui::styles::POPUP_WIDTH_PERCENT;
 use crate::ui::styles::create_popup_block;
+use crate::ui::styles::popup_footer;
+use crate::ui::styles::popup_text_width;
+use crate::ui::styles::wrapped_height;
 use crate::ui::utils::centered_rect_line_height;
-
-/// How much of the width of the screen the popup takes.
-const WIDTH_PERCENT: u16 = 60;
-
-/// How much of that the border and the padding take.
-const CHROME_WIDTH: u16 = 4;
 
 pub struct SettingValuePopup<'a> {
     setting: &'static Setting,
@@ -76,18 +68,11 @@ impl Component for SettingValuePopup<'_> {
             .map(|text| text.lines);
         // What jj says about a value is a sentence rather than a line,
         // so the popup grows by however many rows it wraps into.
-        let text_width = (area.width * WIDTH_PERCENT / 100)
-            .saturating_sub(CHROME_WIDTH)
-            .max(1);
-        let error_height = error_lines.as_ref().map_or(0, |lines| {
-            lines
-                .iter()
-                .map(|line| (line.width() as u16).div_ceil(text_width).max(1))
-                .sum::<u16>()
-                + 1
-        });
+        let error_height = error_lines
+            .as_ref()
+            .map_or(0, |lines| wrapped_height(lines, popup_text_width(area)) + 1);
 
-        let area = centered_rect_line_height(area, WIDTH_PERCENT, 5 + error_height);
+        let area = centered_rect_line_height(area, POPUP_WIDTH_PERCENT, 5 + error_height);
         f.render_widget(Clear, area);
         f.render_widget(&block, area);
 
@@ -102,21 +87,12 @@ impl Component for SettingValuePopup<'_> {
 
         f.render_widget(&self.textarea, chunks[0]);
 
-        let footer = |lines: Vec<ratatui::text::Line<'static>>| {
-            Paragraph::new(lines).wrap(Wrap { trim: false }).block(
-                Block::default()
-                    .borders(Borders::TOP)
-                    .border_type(BorderType::Rounded)
-                    .border_style(Style::default().fg(Color::DarkGray)),
-            )
-        };
-
         if let Some(error_lines) = error_lines {
-            f.render_widget(footer(error_lines), chunks[1]);
+            f.render_widget(popup_footer(error_lines), chunks[1]);
         }
 
         f.render_widget(
-            footer(vec![self.keybinds.hint("accept").into()])
+            popup_footer(vec![self.keybinds.hint("accept").into()])
                 .fg(Color::DarkGray)
                 .alignment(Alignment::Center),
             chunks[2],

--- a/src/ui/dialog/setting_value.rs
+++ b/src/ui/dialog/setting_value.rs
@@ -1,0 +1,165 @@
+/*! A popup taking the value of one setting, which it hands on as the
+operation that writes it to the user's config.
+*/
+
+use ansi_to_tui::IntoText;
+use anyhow::Result;
+use ratatui::Frame;
+use ratatui::crossterm::event::Event;
+use ratatui::crossterm::event::KeyEventKind;
+use ratatui::layout::Alignment;
+use ratatui::layout::Constraint;
+use ratatui::layout::Direction;
+use ratatui::layout::Layout;
+use ratatui::layout::Rect;
+use ratatui::prelude::Stylize;
+use ratatui::style::Color;
+use ratatui::style::Style;
+use ratatui::widgets::Block;
+use ratatui::widgets::BorderType;
+use ratatui::widgets::Borders;
+use ratatui::widgets::Clear;
+use ratatui::widgets::Paragraph;
+use ratatui::widgets::Wrap;
+use ratatui_textarea::CursorMove;
+use ratatui_textarea::TextArea;
+
+use crate::app::command::Command;
+use crate::keybinds::PopupEvent;
+use crate::keybinds::PopupKeybinds;
+use crate::settings::Setting;
+use crate::ui::AppAction;
+use crate::ui::Component;
+use crate::ui::ComponentInputResult;
+use crate::ui::styles::create_popup_block;
+use crate::ui::utils::centered_rect_line_height;
+
+/// How much of the width of the screen the popup takes.
+const WIDTH_PERCENT: u16 = 60;
+
+/// How much of that the border and the padding take.
+const CHROME_WIDTH: u16 = 4;
+
+pub struct SettingValuePopup<'a> {
+    setting: &'static Setting,
+    textarea: TextArea<'a>,
+    /// What was said about the value that was typed, if it was refused.
+    error: Option<anyhow::Error>,
+    keybinds: PopupKeybinds,
+}
+
+impl SettingValuePopup<'static> {
+    /// Ask for the value of `setting`, starting from `value` as it reads
+    /// on screen rather than as the TOML it is written as.
+    pub fn new(setting: &'static Setting, value: String) -> Self {
+        let mut textarea = TextArea::new(vec![value]);
+        textarea.move_cursor(CursorMove::End);
+
+        Self {
+            setting,
+            textarea,
+            error: None,
+            keybinds: PopupKeybinds::text_line(),
+        }
+    }
+}
+
+impl Component for SettingValuePopup<'_> {
+    fn draw(&mut self, f: &mut Frame<'_>, area: Rect) -> Result<()> {
+        let block = create_popup_block(self.setting.key);
+
+        let error_lines = self
+            .error
+            .as_ref()
+            .map(|err| format!("{err:#}").into_text())
+            .transpose()?
+            .map(|text| text.lines);
+        // What jj says about a value is a sentence rather than a line,
+        // so the popup grows by however many rows it wraps into.
+        let text_width = (area.width * WIDTH_PERCENT / 100)
+            .saturating_sub(CHROME_WIDTH)
+            .max(1);
+        let error_height = error_lines.as_ref().map_or(0, |lines| {
+            lines
+                .iter()
+                .map(|line| (line.width() as u16).div_ceil(text_width).max(1))
+                .sum::<u16>()
+                + 1
+        });
+
+        let area = centered_rect_line_height(area, WIDTH_PERCENT, 5 + error_height);
+        f.render_widget(Clear, area);
+        f.render_widget(&block, area);
+
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Fill(1),
+                Constraint::Length(error_height),
+                Constraint::Length(2),
+            ])
+            .split(block.inner(area));
+
+        f.render_widget(&self.textarea, chunks[0]);
+
+        let footer = |lines: Vec<ratatui::text::Line<'static>>| {
+            Paragraph::new(lines).wrap(Wrap { trim: false }).block(
+                Block::default()
+                    .borders(Borders::TOP)
+                    .border_type(BorderType::Rounded)
+                    .border_style(Style::default().fg(Color::DarkGray)),
+            )
+        };
+
+        if let Some(error_lines) = error_lines {
+            f.render_widget(footer(error_lines), chunks[1]);
+        }
+
+        f.render_widget(
+            footer(vec![self.keybinds.hint("accept").into()])
+                .fg(Color::DarkGray)
+                .alignment(Alignment::Center),
+            chunks[2],
+        );
+
+        Ok(())
+    }
+
+    fn input(&mut self, event: Event) -> Result<ComponentInputResult> {
+        if let Event::Key(key) = event
+            && key.kind == KeyEventKind::Press
+        {
+            match self.keybinds.match_event(key) {
+                PopupEvent::Accept => {
+                    // A value the setting cannot be read from is one to
+                    // correct rather than one to give up on, so the
+                    // question stays up with what was said about it.
+                    let value = match self.setting.value_of(&self.textarea.lines().join("\n")) {
+                        Ok(value) => value,
+                        Err(err) => {
+                            self.error = Some(err);
+                            return Ok(ComponentInputResult::Handled);
+                        }
+                    };
+
+                    return Ok(ComponentInputResult::HandledAction(AppAction::Multiple(
+                        vec![
+                            AppAction::ClosePopup,
+                            AppAction::Run(Command::SetSetting {
+                                key: self.setting.key.to_owned(),
+                                value,
+                            }),
+                        ],
+                    )));
+                }
+                PopupEvent::Cancel => {
+                    return Ok(ComponentInputResult::HandledAction(AppAction::ClosePopup));
+                }
+                _ => {}
+            }
+        }
+
+        self.textarea.input(event);
+        Ok(ComponentInputResult::Handled)
+    }
+}

--- a/src/ui/evolog_tab.rs
+++ b/src/ui/evolog_tab.rs
@@ -21,11 +21,11 @@ use crate::commander::new_commander;
 use crate::commander::revset::Revset;
 use crate::env::get_env;
 use crate::event::Mouse;
+use crate::keybinds::Binding;
 use crate::keybinds::DetailsPanelEvent;
 use crate::keybinds::DetailsPanelKeybinds;
 use crate::keybinds::EvologTabEvent;
 use crate::keybinds::EvologTabKeybinds;
-use crate::keybinds::HelpItem;
 use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
@@ -172,6 +172,8 @@ impl Tab for EvologTab<'_> {
 
     fn config_changed(&mut self) {
         self.patch_panel.config_changed();
+        self.keybinds = EvologTabKeybinds::new();
+        self.details_keybinds = DetailsPanelKeybinds::new();
     }
 
     fn is_stale(&self) -> bool {
@@ -196,12 +198,12 @@ impl Tab for EvologTab<'_> {
         Ok(self.context_menu(self.entry_panel.selected_position()))
     }
 
-    fn make_main_panel_help(&self) -> Vec<HelpItem> {
-        self.keybinds.make_help()
+    fn main_panel_bindings(&self) -> Vec<Binding> {
+        self.keybinds.bindings()
     }
 
-    fn make_details_panel_help(&self) -> Vec<HelpItem> {
-        self.details_keybinds.make_help()
+    fn details_panel_bindings(&self) -> Vec<Binding> {
+        self.details_keybinds.bindings()
     }
 }
 

--- a/src/ui/evolog_tab.rs
+++ b/src/ui/evolog_tab.rs
@@ -170,6 +170,10 @@ impl Tab for EvologTab<'_> {
         self.stale = true;
     }
 
+    fn config_changed(&mut self) {
+        self.patch_panel.config_changed();
+    }
+
     fn is_stale(&self) -> bool {
         self.stale
     }

--- a/src/ui/evolog_tab.rs
+++ b/src/ui/evolog_tab.rs
@@ -19,7 +19,6 @@ use crate::commander::log::EVOLOG_LINES_PER_HEAD;
 use crate::commander::log::Head;
 use crate::commander::new_commander;
 use crate::commander::revset::Revset;
-use crate::env::JjConfig;
 use crate::env::get_env;
 use crate::event::Mouse;
 use crate::keybinds::DetailsPanelEvent;
@@ -51,7 +50,6 @@ pub struct EvologTab<'a> {
     /// The panel showing what the selected version changed
     patch_panel: EvologShowPanel,
 
-    config: JjConfig,
     keybinds: EvologTabKeybinds,
     details_keybinds: DetailsPanelKeybinds,
     pane_divider: PaneDivider,
@@ -63,16 +61,13 @@ impl<'a> EvologTab<'a> {
     /// A stale tab for `current_head`, holding no entries yet.
     #[instrument(level = "info", name = "Initializing evolog tab", parent = None, skip(background_tasks))]
     pub fn new(current_head: &Head, background_tasks: BackgroundTasks) -> Self {
-        let config = get_env().jj_config.clone();
-
         Self {
             change: current_head.clone(),
 
             entry_panel: LogPanel::new(current_head.clone(), EVOLOG_LINES_PER_HEAD),
             patch_panel: EvologShowPanel::new(TabId::Evolog, background_tasks),
 
-            pane_divider: PaneDivider::new(config.layout_percent()),
-            config,
+            pane_divider: PaneDivider::default(),
             keybinds: EvologTabKeybinds::new(),
             details_keybinds: DetailsPanelKeybinds::new(),
 
@@ -123,7 +118,7 @@ impl<'a> EvologTab<'a> {
     /// `anchor` or centered when there is nowhere to point at.
     fn context_menu(&self, anchor: Option<Position>) -> Option<AppAction> {
         Some(AppAction::SetPopup(Box::new(evolog_context_menu(
-            self.config.clone(),
+            get_env().jj_config.clone(),
             anchor,
             &self.entry_panel.head,
             &self.change,
@@ -225,7 +220,7 @@ impl Component for EvologTab<'_> {
     }
 
     fn draw(&mut self, f: &mut Frame<'_>, area: Rect) -> Result<()> {
-        let chunks = self.pane_divider.split(area, self.config.layout());
+        let chunks = self.pane_divider.split(area);
 
         self.entry_panel.draw(f, chunks[0])?;
         self.patch_panel.draw(f, chunks[1]);
@@ -259,7 +254,7 @@ impl Component for EvologTab<'_> {
     }
 
     fn input_mouse(&mut self, mouse: Mouse) -> Result<ComponentInputResult> {
-        if self.pane_divider.handle_mouse(mouse, self.config.layout()) {
+        if self.pane_divider.handle_mouse(mouse) {
             return Ok(ComponentInputResult::Handled);
         }
         match route_mouse(mouse, &mut [&mut self.entry_panel, &mut self.patch_panel]) {

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -24,11 +24,11 @@ use crate::commander::new_commander;
 use crate::env::DiffFormat;
 use crate::env::get_env;
 use crate::event::Mouse;
+use crate::keybinds::Binding;
 use crate::keybinds::DetailsPanelEvent;
 use crate::keybinds::DetailsPanelKeybinds;
 use crate::keybinds::FilesTabEvent;
 use crate::keybinds::FilesTabKeybinds;
-use crate::keybinds::HelpItem;
 use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
@@ -299,6 +299,8 @@ impl Tab for FilesTab {
 
     fn config_changed(&mut self) {
         self.diff_panel.config_changed();
+        self.keybinds = FilesTabKeybinds::new();
+        self.details_keybinds = DetailsPanelKeybinds::new();
     }
 
     fn is_stale(&self) -> bool {
@@ -326,12 +328,12 @@ impl Tab for FilesTab {
         ))
     }
 
-    fn make_main_panel_help(&self) -> Vec<HelpItem> {
-        self.keybinds.make_help()
+    fn main_panel_bindings(&self) -> Vec<Binding> {
+        self.keybinds.bindings()
     }
 
-    fn make_details_panel_help(&self) -> Vec<HelpItem> {
-        self.details_keybinds.make_help()
+    fn details_panel_bindings(&self) -> Vec<Binding> {
+        self.details_keybinds.bindings()
     }
 }
 

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -22,7 +22,6 @@ use crate::commander::ids::ChangeId;
 use crate::commander::log::Head;
 use crate::commander::new_commander;
 use crate::env::DiffFormat;
-use crate::env::JjConfig;
 use crate::env::get_env;
 use crate::event::Mouse;
 use crate::keybinds::DetailsPanelEvent;
@@ -63,7 +62,6 @@ pub struct FilesTab {
     pub file: Option<File>,
     diff_panel: FileDiffPanel,
 
-    config: JjConfig,
     keybinds: FilesTabKeybinds,
     details_keybinds: DetailsPanelKeybinds,
     pane_divider: PaneDivider,
@@ -145,8 +143,7 @@ impl FilesTab {
     /// A stale tab at `current_head`, holding no files yet.
     #[instrument(level = "info", name = "Initializing files tab", parent = None, skip(background_tasks))]
     pub fn new(current_head: &Head, background_tasks: BackgroundTasks) -> Self {
-        let config = get_env().jj_config.clone();
-        let pane_divider = PaneDivider::new(config.layout_percent());
+        let pane_divider = PaneDivider::default();
         let keybinds = FilesTabKeybinds::new();
         let details_keybinds = DetailsPanelKeybinds::new();
 
@@ -164,7 +161,6 @@ impl FilesTab {
 
             diff_panel: FileDiffPanel::new(TabId::Files, background_tasks),
 
-            config,
             keybinds,
             details_keybinds,
             pane_divider,
@@ -240,7 +236,7 @@ impl FilesTab {
         let file = self.file.as_ref()?;
 
         Some(AppAction::SetPopup(Box::new(files_context_menu(
-            self.config.clone(),
+            get_env().jj_config.clone(),
             anchor,
             file,
         ))))
@@ -358,7 +354,7 @@ impl Component for FilesTab {
         f: &mut ratatui::prelude::Frame<'_>,
         area: ratatui::prelude::Rect,
     ) -> Result<()> {
-        let chunks = self.pane_divider.split(area, self.config.layout());
+        let chunks = self.pane_divider.split(area);
 
         // Draw files
         {
@@ -389,14 +385,13 @@ impl Component for FilesTab {
                                     }
 
                                     if current_file_index == Some(i) {
-                                        line = line.bg(self.config.highlight_color());
+                                        let highlight = get_env().jj_config.highlight_color();
 
+                                        line = line.bg(highlight);
                                         line.spans = line
                                             .spans
                                             .iter_mut()
-                                            .map(|span| {
-                                                span.to_owned().bg(self.config.highlight_color())
-                                            })
+                                            .map(|span| span.to_owned().bg(highlight))
                                             .collect();
                                     }
 
@@ -476,7 +471,7 @@ impl Component for FilesTab {
     }
 
     fn input_mouse(&mut self, mouse: Mouse) -> Result<ComponentInputResult> {
-        if self.pane_divider.handle_mouse(mouse, self.config.layout()) {
+        if self.pane_divider.handle_mouse(mouse) {
             return Ok(ComponentInputResult::Handled);
         }
         match route_mouse(mouse, &mut [&mut self.files_pane, &mut self.diff_panel]) {

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -297,6 +297,10 @@ impl Tab for FilesTab {
         self.stale = true;
     }
 
+    fn config_changed(&mut self) {
+        self.diff_panel.config_changed();
+    }
+
     fn is_stale(&self) -> bool {
         self.stale
     }

--- a/src/ui/keybindings_tab.rs
+++ b/src/ui/keybindings_tab.rs
@@ -1,0 +1,628 @@
+/*! The keybindings tab lists every action a key can be bound to in the
+main panel and what the selected one does in the details panel.
+
+It is the settings tab's, opened from the row for `blazingjj.keybinds`
+and left again for it, so it has no place of its own in the tab bar. What
+it writes are the keys under that table, in the user's own config file,
+just as the settings tab writes the options beside it.
+*/
+
+use anyhow::Result;
+use ratatui::crossterm::event::Event;
+use ratatui::crossterm::event::KeyEventKind;
+use ratatui::prelude::*;
+use ratatui::widgets::*;
+use tracing::instrument;
+
+use crate::app::TabId;
+use crate::app::command::Command;
+use crate::commander::config::config_value;
+use crate::commander::new_commander;
+use crate::env::get_env;
+use crate::event::Mouse;
+use crate::keybinds::Binding;
+use crate::keybinds::Context;
+use crate::keybinds::KeybindingsTabEvent;
+use crate::keybinds::KeybindingsTabKeybinds;
+use crate::ui::AppAction;
+use crate::ui::Component;
+use crate::ui::ComponentInputResult;
+use crate::ui::Scroll;
+use crate::ui::Tab;
+use crate::ui::dialog::BindKey;
+use crate::ui::dialog::BindKeyPopup;
+use crate::ui::dialog::ChoicePopup;
+use crate::ui::panel::ListPane;
+use crate::ui::panel::MouseInput;
+use crate::ui::panel::PanelMouseInput;
+use crate::ui::panel::Row as SectionRow;
+use crate::ui::panel::Sections;
+use crate::ui::panel::copy_marked;
+use crate::ui::utils::PaneDivider;
+use crate::ui::utils::error_text;
+
+/// What every row of the list is indented by, headings apart.
+const INDENT: &str = "   ";
+
+/// An action the tab can bind a key to: what it does, the config key
+/// that binds it, and the keys it answers to as the row shows them.
+struct Bindable {
+    binding: Binding,
+    config_key: String,
+    shown_keys: String,
+}
+
+impl Bindable {
+    /// The action `binding` stands for, for one that is the user's to
+    /// bind.
+    fn of(binding: Binding) -> Option<Self> {
+        let config_key = binding.key()?;
+        let shown_keys = binding.keys_text();
+
+        Some(Self {
+            binding,
+            config_key,
+            shown_keys,
+        })
+    }
+}
+
+/// What there is to bind and what the configuration binds it to.
+#[derive(Default)]
+struct Bindings {
+    /// The actions under the context they take effect in.
+    rows: Sections<Bindable>,
+    /// What the user's own config file binds, which is the layer the tab
+    /// writes and the only one it can take a binding out of.
+    user: toml::Table,
+}
+
+impl Bindings {
+    /// Every action there is to bind, gathered under the context it
+    /// takes effect in. An action the user cannot bind is left out.
+    fn read(user: toml::Table) -> Self {
+        let bindings = Context::ORDER
+            .into_iter()
+            .flat_map(Context::bindings)
+            .filter_map(Bindable::of);
+
+        Self {
+            rows: Sections::new(bindings, |bindable| bindable.binding.context.title()),
+            user,
+        }
+    }
+
+    /// Whether the user's own config file is what binds `bindable`,
+    /// which is what makes it the tab's to take back out.
+    fn is_users(&self, bindable: &Bindable) -> bool {
+        config_value(&self.user, &bindable.config_key).is_some()
+    }
+}
+
+pub struct KeybindingsTab {
+    /// What there is to bind, or why the configuration could not be read.
+    bindings: Result<Bindings>,
+
+    bindings_pane: ListPane,
+    bindings_list_state: ListState,
+
+    keybinds: KeybindingsTabKeybinds,
+    pane_divider: PaneDivider,
+
+    stale: bool,
+}
+
+impl KeybindingsTab {
+    /// A stale tab, holding nothing of what the configuration binds yet.
+    #[instrument(level = "info", name = "Initializing keybindings tab", parent = None)]
+    pub fn new() -> Self {
+        Self {
+            bindings: Ok(Bindings::default()),
+
+            bindings_pane: ListPane::default(),
+            bindings_list_state: ListState::default(),
+
+            keybinds: KeybindingsTabKeybinds::new(),
+            pane_divider: PaneDivider::default(),
+
+            stale: true,
+        }
+    }
+
+    fn selected(&self) -> Option<&Bindable> {
+        self.bindings.as_ref().ok()?.rows.selected()
+    }
+
+    /// Move the selection by `scroll` rows, which a tab that could not
+    /// read the configuration has none of.
+    fn scroll_bindings(&mut self, scroll: isize) {
+        if let Ok(bindings) = self.bindings.as_mut() {
+            bindings.rows.scroll(scroll);
+        }
+    }
+
+    /// Which row is selected, of the headings and the actions alike.
+    fn selected_row(&self) -> usize {
+        self.bindings
+            .as_ref()
+            .map_or(0, |bindings| bindings.rows.selected_row())
+    }
+
+    /// Select the row at `index`, which is the mouse landing on it.
+    fn select_row(&mut self, index: usize) {
+        if let Ok(bindings) = self.bindings.as_mut() {
+            bindings.rows.select_row(index);
+        }
+    }
+
+    /// Ask for a key the selected action is to answer to.
+    fn bind_selected(&self, bind: BindKey) -> Option<AppAction> {
+        let bindable = self.selected()?;
+
+        Some(AppAction::SetPopup(Box::new(BindKeyPopup::new(
+            bindable.binding.clone(),
+            bind,
+        ))))
+    }
+
+    /// Leave the selected action bound to nothing, which is what the
+    /// configuration says of an action it disables.
+    fn disable_selected(&self) -> Option<AppAction> {
+        let bindable = self.selected()?;
+
+        (!bindable.binding.keys.is_empty()).then(|| {
+            AppAction::Run(Command::SetSetting {
+                key: bindable.config_key.clone(),
+                value: "false".to_owned(),
+            })
+        })
+    }
+
+    /// Take the selected binding out of the user's config file, leaving
+    /// the action bound to what it comes bound to.
+    fn unset_selected(&self) -> Option<AppAction> {
+        let bindings = self.bindings.as_ref().ok()?;
+        let bindable = self.selected()?;
+
+        bindings.is_users(bindable).then(|| {
+            AppAction::Run(Command::UnsetSetting {
+                key: bindable.config_key.clone(),
+            })
+        })
+    }
+
+    /// The menu of what can be done to the selected action, put at
+    /// `anchor` or centered when there is nowhere to point at.
+    fn context_menu(&self, anchor: Option<Position>) -> Option<AppAction> {
+        let mut items = vec![(Line::raw("Bind a key"), self.bind_selected(BindKey::Only)?)];
+        // Another key beside none is just the one key, which the menu
+        // offers already.
+        if self
+            .selected()
+            .is_some_and(|bindable| !bindable.binding.keys.is_empty())
+            && let Some(besides) = self.bind_selected(BindKey::Besides)
+        {
+            items.push((Line::raw("Bind another key besides"), besides));
+        }
+        if let Some(disable) = self.disable_selected() {
+            items.push((Line::raw("Leave it bound to nothing"), disable));
+        }
+        if let Some(unset) = self.unset_selected() {
+            items.push((Line::raw("Take out of your config"), unset));
+        }
+
+        Some(AppAction::SetPopup(Box::new(ChoicePopup::new(
+            get_env().jj_config.clone(),
+            anchor,
+            "Keybinding actions",
+            items,
+        ))))
+    }
+
+    fn handle_event(&mut self, event: KeybindingsTabEvent) -> Option<AppAction> {
+        match event {
+            KeybindingsTabEvent::Bind => self.bind_selected(BindKey::Only),
+            KeybindingsTabEvent::BindBesides => self.bind_selected(BindKey::Besides),
+            KeybindingsTabEvent::Disable => self.disable_selected(),
+            KeybindingsTabEvent::Unset => self.unset_selected(),
+            KeybindingsTabEvent::Back => Some(AppAction::ViewTab(TabId::Settings)),
+            // Not an operation of its own; the key handler deals with it.
+            KeybindingsTabEvent::Unbound => None,
+        }
+    }
+
+    /// One row per action: what it does and the keys it answers to,
+    /// under the heading of the context it takes effect in, in a
+    /// panel `width` columns wide.
+    fn binding_lines(&self, bindings: &Bindings, width: u16) -> Vec<Line<'static>> {
+        let keys_width = bindings
+            .rows
+            .rows()
+            .iter()
+            .filter_map(|row| match row {
+                SectionRow::Item(bindable) => Some(bindable.shown_keys.chars().count()),
+                SectionRow::Heading(_) => None,
+            })
+            .max()
+            .unwrap_or(0);
+        // What an action does is what the list is read by, so it takes
+        // what is left of the row once the keys have their column.
+        let description_width = (width as usize).saturating_sub(INDENT.len() + keys_width + 2);
+
+        bindings
+            .rows
+            .rows()
+            .iter()
+            .enumerate()
+            .map(|(index, row)| {
+                let line = match row {
+                    // The indent is no part of the heading, so it is no
+                    // part of what is underlined either.
+                    SectionRow::Heading(heading) => Line::from(vec![
+                        Span::raw(" "),
+                        Span::raw(*heading).bold().underlined(),
+                    ]),
+                    SectionRow::Item(bindable) => {
+                        let description: String = bindable
+                            .binding
+                            .description
+                            .chars()
+                            .take(description_width)
+                            .collect();
+                        let keys = Span::raw(bindable.shown_keys.clone());
+                        let keys = if bindable.binding.keys.is_empty() {
+                            keys.fg(Color::DarkGray)
+                        } else {
+                            keys
+                        };
+
+                        Line::from(vec![
+                            Span::raw(format!("{INDENT}{description:description_width$}  ")),
+                            keys,
+                        ])
+                    }
+                };
+
+                if index == bindings.rows.selected_row() {
+                    line.bg(get_env().jj_config.highlight_color())
+                } else {
+                    line
+                }
+            })
+            .collect()
+    }
+
+    /// What the selected action does, what it answers to and where that
+    /// comes from.
+    fn details_text(&self, bindings: &Bindings) -> Text<'static> {
+        let Some(bindable) = self.selected() else {
+            return Text::default();
+        };
+
+        // A binding the app did not come with and your own config does
+        // not hold comes from a layer of the configuration the tab does
+        // not write, the repo's among them.
+        let source = if bindings.is_users(bindable) {
+            "  (in your config)"
+        } else if bindable.binding.keys == bindable.binding.defaults {
+            "  (default)"
+        } else {
+            "  (elsewhere in your configuration)"
+        };
+
+        Text::from(vec![
+            Line::raw(bindable.binding.description).bold(),
+            Line::raw(""),
+            Line::raw(format!(
+                "Takes effect:    {}",
+                bindable.binding.context.title()
+            )),
+            Line::raw(format!("Configured as:   {}", bindable.config_key)),
+            Line::raw(""),
+            Line::from(vec![
+                Span::raw("Current binding: "),
+                Span::raw(bindable.shown_keys.clone()).bold(),
+                Span::raw(source).fg(Color::DarkGray),
+            ]),
+            Line::raw(format!(
+                "Default binding: {}",
+                bindable.binding.defaults_text()
+            )),
+        ])
+    }
+}
+
+impl Tab for KeybindingsTab {
+    fn refresh(&mut self) -> Result<()> {
+        // Reading the bindings again is what a rebinding asks for, and
+        // what was rebound is what is selected, so the list comes back
+        // with the selection where it was left.
+        let selected = self.selected_row();
+        self.bindings = new_commander().get_user_config().map(Bindings::read);
+        if let Ok(bindings) = self.bindings.as_mut() {
+            bindings.rows.select_row(selected);
+        }
+        self.stale = false;
+
+        Ok(())
+    }
+
+    /// What the tab shows is the configuration, which a repo that has
+    /// moved says nothing about.
+    fn mark_stale(&mut self) {}
+
+    fn is_stale(&self) -> bool {
+        self.stale
+    }
+
+    fn config_changed(&mut self) {
+        self.stale = true;
+        self.keybinds = KeybindingsTabKeybinds::new();
+    }
+
+    fn scroll_main_panel(&mut self, scroll: Scroll) -> Result<()> {
+        self.scroll_bindings(scroll.distance(self.bindings_pane.visible_items()));
+
+        Ok(())
+    }
+
+    fn open_context_menu(&self) -> Result<Option<AppAction>> {
+        Ok(self.context_menu(self.bindings_pane.item_anchor(self.selected_row(), 1)))
+    }
+
+    fn main_panel_bindings(&self) -> Vec<Binding> {
+        self.keybinds.bindings()
+    }
+
+    /// The details panel only says what the selected action does, so
+    /// there is nothing to do to it.
+    fn details_panel_bindings(&self) -> Vec<Binding> {
+        Vec::new()
+    }
+}
+
+impl Component for KeybindingsTab {
+    fn draw(&mut self, f: &mut Frame<'_>, area: Rect) -> Result<()> {
+        let chunks = self.pane_divider.split(area);
+
+        let (rows, details) = match self.bindings.as_ref() {
+            Ok(bindings) => (
+                self.binding_lines(bindings, chunks[0].width.saturating_sub(2)),
+                self.details_text(bindings),
+            ),
+            Err(err) => (
+                error_text("Error getting the configuration", err)?.lines,
+                Text::default(),
+            ),
+        };
+
+        // The keys of the tab itself are in the list like any others,
+        // which is nowhere to look for the key that gets you out of it.
+        // The hint goes between the corners, with a space to either side.
+        let hint_width = chunks[0].width.saturating_sub(4) as usize;
+        let block = Block::bordered()
+            .title(" Settings / Keybindings ")
+            .title_bottom(
+                Line::raw(format!(" {} ", self.keybinds.hint(hint_width)))
+                    .centered()
+                    .fg(Color::DarkGray),
+            )
+            .border_type(BorderType::Rounded);
+        *self.bindings_list_state.selected_mut() = Some(self.selected_row());
+        self.bindings_pane.render(
+            f,
+            chunks[0],
+            block,
+            List::new(rows).scroll_padding(3),
+            &mut self.bindings_list_state,
+        );
+
+        f.render_widget(
+            Paragraph::new(details).wrap(Wrap { trim: false }).block(
+                Block::bordered()
+                    .title(" About ")
+                    .border_type(BorderType::Rounded)
+                    .padding(Padding::horizontal(1)),
+            ),
+            chunks[1],
+        );
+
+        Ok(())
+    }
+
+    fn input(&mut self, event: Event) -> Result<ComponentInputResult> {
+        if let Event::Key(key) = event {
+            if key.kind != KeyEventKind::Press {
+                return Ok(ComponentInputResult::Handled);
+            }
+
+            return match self.keybinds.match_event(key) {
+                // Not the tab's to act on, so whoever else wants the key
+                // is welcome to it.
+                KeybindingsTabEvent::Unbound => Ok(ComponentInputResult::NotHandled),
+                event => Ok(self.handle_event(event).into()),
+            };
+        }
+
+        Ok(ComponentInputResult::Handled)
+    }
+
+    fn input_mouse(&mut self, mouse: Mouse) -> Result<ComponentInputResult> {
+        if self.pane_divider.handle_mouse(mouse) {
+            return Ok(ComponentInputResult::Handled);
+        }
+        match self.bindings_pane.input_mouse(mouse) {
+            MouseInput::Scroll(delta) => self.scroll_bindings(delta),
+            MouseInput::Select(index) => self.select_row(index),
+            MouseInput::Context(index) => {
+                self.select_row(index);
+                return Ok(self.context_menu(Some(mouse.position())).into());
+            }
+            MouseInput::Copy(text) => return Ok(copy_marked(text)),
+            // Nothing here has a second thing a double click could do.
+            MouseInput::Activate | MouseInput::Handled => {}
+            MouseInput::NotHandled => return Ok(ComponentInputResult::NotHandled),
+        }
+        Ok(ComponentInputResult::Handled)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::env::set_test_env;
+    use crate::ui::utils::drawn;
+
+    /// A tab holding the bindings as they are, with `config` for the
+    /// user's own config file, which the tests have in place of a repo
+    /// to read one from.
+    fn tab(config: &str) -> KeybindingsTab {
+        set_test_env();
+        let mut tab = KeybindingsTab::new();
+        tab.bindings = Ok(Bindings::read(
+            config.parse().expect("the configuration parses"),
+        ));
+        tab
+    }
+
+    /// What the main panel says, as one string per row.
+    fn rows(tab: &KeybindingsTab) -> Vec<String> {
+        let bindings = tab.bindings.as_ref().expect("the configuration was read");
+
+        tab.binding_lines(bindings, 100)
+            .iter()
+            .map(ToString::to_string)
+            .collect()
+    }
+
+    /// What the whole tab says, as one string per row of the terminal.
+    fn screen(tab: &mut KeybindingsTab) -> Vec<String> {
+        drawn(tab, 100, 20)
+    }
+
+    /// The keys the tab itself answers to are listed in it like any
+    /// others, which is nowhere to look for the way out of it.
+    #[test]
+    fn the_tab_says_what_it_answers_to() {
+        let screen = screen(&mut tab(""));
+
+        assert!(
+            screen
+                .iter()
+                .any(|row| row.contains("Enter: bind") && row.contains("Esc: back")),
+            "{screen:?}"
+        );
+    }
+
+    /// The details panel says what the selected action does and what it
+    /// answers to.
+    #[test]
+    fn the_details_panel_is_about_the_selected_action() {
+        let screen = screen(&mut tab(""));
+
+        assert!(
+            screen.iter().any(|row| row.contains("Everywhere")),
+            "{screen:?}"
+        );
+        assert!(
+            screen
+                .iter()
+                .any(|row| row.contains("blazingjj.keybinds.scroll-down")),
+            "{screen:?}"
+        );
+    }
+
+    #[test]
+    fn every_context_heads_the_actions_it_takes_the_keys_of() {
+        let rows = rows(&tab(""));
+
+        assert!(rows.iter().any(|row| row.trim() == "Log tab"), "{rows:?}");
+        assert!(
+            rows.iter().any(|row| row.contains("abandon change")),
+            "{rows:?}"
+        );
+    }
+
+    /// Going to the top lands on the first action rather than on the
+    /// heading above it, which is the first row there is.
+    #[test]
+    fn going_to_either_end_lands_on_an_action() {
+        let mut tab = tab("");
+
+        tab.scroll_bindings(isize::MAX);
+        assert_eq!(tab.selected_row(), rows(&tab).len() - 1);
+
+        tab.scroll_bindings(-isize::MAX);
+        assert_eq!(tab.selected_row(), 1);
+    }
+
+    #[test]
+    fn the_selection_passes_over_the_headings_rather_than_onto_them() {
+        let mut tab = tab("");
+
+        for _ in 0..rows(&tab).len() {
+            assert!(tab.selected().is_some(), "row {}", tab.selected_row());
+            tab.scroll_bindings(1);
+        }
+        for _ in 0..rows(&tab).len() {
+            assert!(tab.selected().is_some(), "row {}", tab.selected_row());
+            tab.scroll_bindings(-1);
+        }
+    }
+
+    /// Only what your own config binds is yours to take back out; the
+    /// keys the app ships with are not in it to begin with.
+    #[test]
+    fn a_binding_is_only_taken_out_of_the_config_that_holds_it() {
+        let mut tab = tab("blazingjj.keybinds.log-tab.abandon = \"ctrl+a\"\n");
+        while !tab
+            .selected()
+            .is_some_and(|bindable| bindable.binding.description == "abandon change")
+        {
+            tab.scroll_bindings(1);
+        }
+        assert!(tab.unset_selected().is_some());
+
+        tab.scroll_bindings(1);
+        assert!(tab.unset_selected().is_none());
+    }
+
+    /// What the two operations write is what the configuration reads as
+    /// an action bound to nothing, and as an action the user's config
+    /// says nothing about.
+    #[test]
+    fn taking_a_binding_out_and_leaving_it_bound_to_nothing_write_the_key() {
+        let mut tab = tab("blazingjj.keybinds.log-tab.abandon = \"ctrl+a\"\n");
+        while !tab
+            .selected()
+            .is_some_and(|bindable| bindable.binding.description == "abandon change")
+        {
+            tab.scroll_bindings(1);
+        }
+
+        assert!(matches!(
+            tab.disable_selected(),
+            Some(AppAction::Run(Command::SetSetting { key, value }))
+                if key == "blazingjj.keybinds.log-tab.abandon" && value == "false"
+        ));
+        assert!(matches!(
+            tab.unset_selected(),
+            Some(AppAction::Run(Command::UnsetSetting { key }))
+                if key == "blazingjj.keybinds.log-tab.abandon"
+        ));
+    }
+
+    /// A repo that has moved says nothing about the bindings, so
+    /// reading them again is for a configuration that has changed.
+    #[test]
+    fn the_tab_reads_the_bindings_again_when_the_configuration_changes() {
+        let mut tab = tab("");
+        tab.stale = false;
+
+        tab.mark_stale();
+        assert!(!tab.is_stale());
+
+        tab.config_changed();
+        assert!(tab.is_stale());
+    }
+}

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -19,7 +19,6 @@ use crate::commander::log::Head;
 use crate::commander::log::LOG_LINES_PER_HEAD;
 use crate::commander::new_commander;
 use crate::commander::revset::Revset;
-use crate::env::JjConfig;
 use crate::env::get_env;
 use crate::event::Mouse;
 use crate::keybinds::DetailsPanelEvent;
@@ -64,7 +63,6 @@ pub struct LogTab<'a> {
     /// so if these differ, we need to update `self.head`
     head: Head,
 
-    config: JjConfig,
     pane_divider: PaneDivider,
     keybinds: LogTabKeybinds,
     details_keybinds: DetailsPanelKeybinds,
@@ -98,8 +96,7 @@ impl<'a> LogTab<'a> {
         let keybinds = LogTabKeybinds::new();
         let details_keybinds = DetailsPanelKeybinds::new();
 
-        let config = get_env().jj_config.clone();
-        let pane_divider = PaneDivider::new(config.layout_percent());
+        let pane_divider = PaneDivider::default();
 
         Self {
             log_revset: get_env().default_revset.clone(),
@@ -110,7 +107,6 @@ impl<'a> LogTab<'a> {
             head,
             head_panel: CommitShowPanel::new(TabId::Log, background_tasks),
 
-            config,
             pane_divider,
             keybinds,
             details_keybinds,
@@ -170,7 +166,7 @@ impl<'a> LogTab<'a> {
     /// `anchor` or centered when there is nowhere to point at.
     fn context_menu(&self, anchor: Option<Position>) -> Result<Option<AppAction>> {
         Ok(Some(AppAction::SetPopup(Box::new(log_context_menu(
-            self.config.clone(),
+            get_env().jj_config.clone(),
             anchor,
             &self.head,
             &self.marked(),
@@ -210,7 +206,7 @@ impl<'a> LogTab<'a> {
                 Ok(None)
             }
             _ => Ok(Some(AppAction::SetPopup(Box::new(parent_select(
-                self.config.clone(),
+                get_env().jj_config.clone(),
                 &parents,
                 &out_of_view,
             ))))),
@@ -263,7 +259,7 @@ impl<'a> LogTab<'a> {
 
             LogTabEvent::CreateNew { describe } => {
                 return Ok(Some(command::ask_new_change_from_selection(
-                    self.config.clone(),
+                    get_env().jj_config.clone(),
                     &self.head,
                     &self.marked(),
                     describe,
@@ -274,14 +270,14 @@ impl<'a> LogTab<'a> {
             }
             LogTabEvent::Squash { ignore_immutable } => {
                 return Ok(Some(command::ask_squash(
-                    self.config.clone(),
+                    get_env().jj_config.clone(),
                     &self.head,
                     ignore_immutable,
                 )?));
             }
             LogTabEvent::EditChange { ignore_immutable } => {
                 return Ok(Some(command::ask_edit(
-                    self.config.clone(),
+                    get_env().jj_config.clone(),
                     &self.head,
                     format!("Change: {}", self.head.change_id.as_str()),
                     ignore_immutable,
@@ -289,7 +285,7 @@ impl<'a> LogTab<'a> {
             }
             LogTabEvent::Abandon => {
                 return Ok(Some(command::ask_abandon(
-                    self.config.clone(),
+                    get_env().jj_config.clone(),
                     &self.head,
                     self.marked(),
                 )));
@@ -314,7 +310,10 @@ impl<'a> LogTab<'a> {
                 return Ok(None);
             }
             LogTabEvent::SetBookmark => {
-                return Ok(Some(command::set_bookmark(self.config.clone(), &self.head)));
+                return Ok(Some(command::set_bookmark(
+                    get_env().jj_config.clone(),
+                    &self.head,
+                )));
             }
             LogTabEvent::OpenFiles => {
                 return Ok(Some(AppAction::ViewFiles(self.head.clone())));
@@ -423,7 +422,7 @@ impl Component for LogTab<'_> {
         f: &mut ratatui::prelude::Frame<'_>,
         area: ratatui::prelude::Rect,
     ) -> Result<()> {
-        let chunks = self.pane_divider.split(area, self.config.layout());
+        let chunks = self.pane_divider.split(area);
 
         // Draw log
         self.log_panel.draw(f, chunks[0])?;
@@ -519,7 +518,7 @@ impl Component for LogTab<'_> {
     }
 
     fn input_mouse(&mut self, mouse: Mouse) -> Result<ComponentInputResult> {
-        if self.pane_divider.handle_mouse(mouse, self.config.layout()) {
+        if self.pane_divider.handle_mouse(mouse) {
             return Ok(ComponentInputResult::Handled);
         }
         match route_mouse(mouse, &mut [&mut self.log_panel, &mut self.head_panel]) {

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -21,9 +21,9 @@ use crate::commander::new_commander;
 use crate::commander::revset::Revset;
 use crate::env::get_env;
 use crate::event::Mouse;
+use crate::keybinds::Binding;
 use crate::keybinds::DetailsPanelEvent;
 use crate::keybinds::DetailsPanelKeybinds;
-use crate::keybinds::HelpItem;
 use crate::keybinds::LogTabEvent;
 use crate::keybinds::LogTabKeybinds;
 use crate::keybinds::PopupEvent;
@@ -368,6 +368,9 @@ impl Tab for LogTab<'_> {
 
     fn config_changed(&mut self) {
         self.head_panel.config_changed();
+        self.keybinds = LogTabKeybinds::new();
+        self.revset_keybinds = PopupKeybinds::text();
+        self.details_keybinds = DetailsPanelKeybinds::new();
     }
 
     fn is_stale(&self) -> bool {
@@ -394,12 +397,12 @@ impl Tab for LogTab<'_> {
         self.context_menu(self.log_panel.selected_position())
     }
 
-    fn make_main_panel_help(&self) -> Vec<HelpItem> {
-        self.keybinds.make_main_panel_help()
+    fn main_panel_bindings(&self) -> Vec<Binding> {
+        self.keybinds.bindings()
     }
 
-    fn make_details_panel_help(&self) -> Vec<HelpItem> {
-        self.details_keybinds.make_help()
+    fn details_panel_bindings(&self) -> Vec<Binding> {
+        self.details_keybinds.bindings()
     }
 }
 

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -366,6 +366,10 @@ impl Tab for LogTab<'_> {
         self.stale = true;
     }
 
+    fn config_changed(&mut self) {
+        self.head_panel.config_changed();
+    }
+
     fn is_stale(&self) -> bool {
         self.stale
     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -4,6 +4,7 @@ pub mod bookmarks_tab;
 pub mod dialog;
 pub mod evolog_tab;
 pub mod files_tab;
+pub mod keybindings_tab;
 pub mod log_tab;
 pub mod panel;
 pub mod settings_tab;
@@ -14,12 +15,13 @@ use ratatui::Frame;
 use ratatui::crossterm::event::Event;
 use ratatui::layout::Rect;
 
+use crate::app::TabId;
 use crate::app::command::Command;
 use crate::background_tasks::TaskResult;
 use crate::commander::JjCommand;
 use crate::commander::log::Head;
 use crate::event::Mouse;
-use crate::keybinds::HelpItem;
+use crate::keybinds::Binding;
 
 /// Action commmands from component to application
 pub enum AppAction {
@@ -32,6 +34,8 @@ pub enum AppAction {
     /// Show the bookmark of this name, which may have just come into
     /// being.
     ViewBookmark(String),
+    /// Show this tab, as it stands.
+    ViewTab(TabId),
     ChangeHead(Head),
     /// Put this popup up, in place of whatever is up now.
     SetPopup(Box<dyn Component>),
@@ -178,8 +182,8 @@ pub trait Tab: Component {
     fn open_context_menu(&self) -> Result<Option<AppAction>>;
 
     /// Keybindings of the main panel, for the help popup.
-    fn make_main_panel_help(&self) -> Vec<HelpItem>;
+    fn main_panel_bindings(&self) -> Vec<Binding>;
 
     /// Keybindings of the details panel, for the help popup.
-    fn make_details_panel_help(&self) -> Vec<HelpItem>;
+    fn details_panel_bindings(&self) -> Vec<Binding>;
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -6,6 +6,7 @@ pub mod evolog_tab;
 pub mod files_tab;
 pub mod log_tab;
 pub mod panel;
+pub mod settings_tab;
 pub mod styles;
 pub mod utils;
 use anyhow::Result;
@@ -44,6 +45,9 @@ pub enum AppAction {
     /// Have every tab read itself again before it is next drawn, the
     /// operation that has just run having moved the repo.
     MarkTabsStale,
+    /// The configuration has changed, so the app reads it again and
+    /// everything that goes by it takes up what it now says.
+    ConfigChanged,
     /// Run this operation and do whatever it asks for in turn. Whoever
     /// raises one has named it in full, so the app can run it without
     /// asking anything of the component the request came from.
@@ -149,6 +153,10 @@ pub trait Tab: Component {
 
     /// Have the next [refresh](Tab::refresh) read the repo.
     fn mark_stale(&mut self);
+
+    /// Take up the configuration as it now reads, of which the tab and
+    /// its panels hold what they go by.
+    fn config_changed(&mut self);
 
     /// Whether the next [refresh](Tab::refresh) will read the repo.
     fn is_stale(&self) -> bool;

--- a/src/ui/panel/log_panel.rs
+++ b/src/ui/panel/log_panel.rs
@@ -15,7 +15,6 @@ use crate::commander::CommandError;
 use crate::commander::ids::CommitId;
 use crate::commander::log::Head;
 use crate::commander::log::LogOutput;
-use crate::env::JjConfig;
 use crate::env::get_env;
 use crate::event::Mouse;
 use crate::ui::AppAction;
@@ -59,9 +58,6 @@ pub struct LogPanel<'a> {
     pub marked_heads: HashSet<CommitId>,
 
     list_pane: ListPane,
-
-    /// Configuration of colours
-    config: JjConfig,
 
     /// Whether to apply scroll_padding on the next draw.
     /// Disabled after a right-click so the viewport doesn't jump.
@@ -119,7 +115,6 @@ impl<'a> LogPanel<'a> {
 
             list_pane: ListPane::default(),
 
-            config: get_env().jj_config.clone(),
             scroll_padding_active: true,
         }
     }
@@ -170,6 +165,8 @@ impl<'a> LogPanel<'a> {
             }
         }
 
+        let highlight = get_env().jj_config.highlight_color();
+
         self.log_output_text
             .iter()
             .enumerate()
@@ -181,7 +178,7 @@ impl<'a> LogPanel<'a> {
 
                 // Highlight lines that correspond to self.head
                 if log_output.head_at(i) == Some(&self.head) {
-                    set_bg(&mut line, self.config.highlight_color());
+                    set_bg(&mut line, highlight);
                 };
 
                 line

--- a/src/ui/panel/mod.rs
+++ b/src/ui/panel/mod.rs
@@ -5,6 +5,7 @@ mod list_pane;
 mod log_panel;
 mod output_cache;
 mod output_panel;
+mod sections;
 
 pub use commit_show::CommitShowKey;
 pub use commit_show::CommitShowPanel;
@@ -18,6 +19,8 @@ pub use log_panel::LogPanel;
 pub use output_cache::OutputKey;
 pub use output_cache::OutputRequest;
 pub use output_panel::OutputPanel;
+pub use sections::Row;
+pub use sections::Sections;
 
 use crate::app::command::Command;
 use crate::event::Mouse;

--- a/src/ui/panel/output_panel.rs
+++ b/src/ui/panel/output_panel.rs
@@ -81,6 +81,10 @@ pub struct OutputPanel<K: OutputKey> {
     /// The format changes are rendered in
     diff_format: DiffFormat,
 
+    /// The format the configuration asks for, which the panel goes back
+    /// to when it changes rather than whenever anything else does.
+    configured_format: DiffFormat,
+
     /// Where the command is run, so it does not block the UI thread
     background_tasks: BackgroundTasks,
 }
@@ -99,6 +103,7 @@ impl<K: OutputKey> OutputPanel<K> {
             request: None,
             wait: PanelWait::default(),
             diff_format: get_env().jj_config.diff_format(),
+            configured_format: get_env().jj_config.diff_format(),
             background_tasks,
         }
     }
@@ -248,6 +253,17 @@ impl<K: OutputKey> OutputPanel<K> {
     /// moved on since it was last rendered.
     pub fn mark_dirty(&mut self) {
         self.cache.mark_dirty();
+    }
+
+    /// Render in the format the configuration now asks for, whatever the
+    /// panel was toggled to before it said so. A format it still asks
+    /// for leaves the panel toggled where it is.
+    pub fn config_changed(&mut self) {
+        let configured = get_env().jj_config.diff_format();
+        if configured != self.configured_format {
+            self.configured_format = configured.clone();
+            self.diff_format = configured;
+        }
     }
 
     pub fn handle_event(&mut self, event: DetailsPanelEvent) {

--- a/src/ui/panel/sections.rs
+++ b/src/ui/panel/sections.rs
@@ -1,0 +1,160 @@
+/*! The rows of a list whose items are gathered under headings.
+
+A heading is what the rows under it are read by, not something to act
+on, so the selection passes over one rather than landing on it.
+*/
+
+/// A row of such a list.
+pub enum Row<T> {
+    Heading(&'static str),
+    Item(T),
+}
+
+/// The items of a list under the headings they belong to, and which of
+/// them is selected.
+pub struct Sections<T> {
+    rows: Vec<Row<T>>,
+    selected: usize,
+}
+
+impl<T> Default for Sections<T> {
+    fn default() -> Self {
+        Self {
+            rows: Vec::new(),
+            selected: 0,
+        }
+    }
+}
+
+impl<T> Sections<T> {
+    /// The `items` under the heading `heading` gives each of them, of
+    /// which the ones sharing a heading come one after another.
+    pub fn new(items: impl IntoIterator<Item = T>, heading: impl Fn(&T) -> &'static str) -> Self {
+        let mut rows: Vec<Row<T>> = Vec::new();
+        let mut under = None;
+
+        for item in items {
+            let title = heading(&item);
+            if under != Some(title) {
+                under = Some(title);
+                rows.push(Row::Heading(title));
+            }
+            rows.push(Row::Item(item));
+        }
+
+        let mut sections = Self { rows, selected: 0 };
+        // The first row is a heading, so the first item is the one
+        // under it.
+        sections.scroll(0);
+
+        sections
+    }
+
+    pub fn rows(&self) -> &[Row<T>] {
+        &self.rows
+    }
+
+    /// Which row is selected, for drawing the list.
+    pub fn selected_row(&self) -> usize {
+        self.selected
+    }
+
+    pub fn selected(&self) -> Option<&T> {
+        match self.rows.get(self.selected)? {
+            Row::Item(item) => Some(item),
+            Row::Heading(_) => None,
+        }
+    }
+
+    /// Move the selection by `scroll` rows, over the headings rather
+    /// than onto them.
+    pub fn scroll(&mut self, scroll: isize) {
+        let last = self.rows.len().saturating_sub(1);
+        let landed = self.selected.saturating_add_signed(scroll).min(last);
+        let item = |index: &usize| matches!(self.rows.get(*index), Some(Row::Item(_)));
+
+        // A move that ends on a heading carries on the way it was
+        // going, and turns back where there is nothing left that way.
+        let onwards = (landed..=last).find(item);
+        let backwards = (0..=landed).rev().find(item);
+        self.selected = if scroll < 0 {
+            backwards.or(onwards)
+        } else {
+            onwards.or(backwards)
+        }
+        .unwrap_or(self.selected);
+    }
+
+    /// Select the row at `index`, a heading leaving the selection where
+    /// it is: there is nothing to do to one.
+    pub fn select_row(&mut self, index: usize) {
+        if matches!(self.rows.get(index), Some(Row::Item(_))) {
+            self.selected = index;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sections() -> Sections<&'static str> {
+        Sections::new(["j", "k", "d", "y"], |item| match *item {
+            "j" | "k" => "Navigation",
+            "d" => "Changes",
+            _ => "Clipboard",
+        })
+    }
+
+    #[test]
+    fn every_run_of_items_comes_under_a_heading_of_its_own() {
+        let headings: Vec<&str> = sections()
+            .rows()
+            .iter()
+            .filter_map(|row| match row {
+                Row::Heading(heading) => Some(*heading),
+                Row::Item(_) => None,
+            })
+            .collect();
+
+        assert_eq!(headings, ["Navigation", "Changes", "Clipboard"]);
+    }
+
+    #[test]
+    fn the_selection_passes_over_the_headings_rather_than_onto_them() {
+        let mut sections = sections();
+
+        for _ in 0..sections.rows().len() {
+            assert!(sections.selected().is_some(), "row {}", sections.selected);
+            sections.scroll(1);
+        }
+        for _ in 0..sections.rows().len() {
+            assert!(sections.selected().is_some(), "row {}", sections.selected);
+            sections.scroll(-1);
+        }
+    }
+
+    /// Going to either end lands on an item, of which the first is not
+    /// the first row: a heading is.
+    #[test]
+    fn going_to_either_end_lands_on_an_item() {
+        let mut sections = sections();
+
+        sections.scroll(isize::MAX);
+        assert_eq!(sections.selected(), Some(&"y"));
+
+        sections.scroll(-isize::MAX);
+        assert_eq!(sections.selected(), Some(&"j"));
+    }
+
+    #[test]
+    fn a_heading_is_no_row_to_select() {
+        let mut sections = sections();
+        sections.select_row(2);
+        assert_eq!(sections.selected(), Some(&"k"));
+
+        sections.select_row(3);
+
+        assert_eq!(sections.selected(), Some(&"k"));
+    }
+}

--- a/src/ui/settings_tab.rs
+++ b/src/ui/settings_tab.rs
@@ -1,0 +1,509 @@
+/*! The settings tab lists the options the app can be configured with in
+the main panel and what the selected one does in the details panel.
+
+An option is a jj config key, so the tab reads the configuration jj
+already keeps and writes to the user's own config file. What it shows is
+what the configuration says now, across every layer jj reads; what it
+takes an option out of is the one layer it writes.
+*/
+
+use anyhow::Result;
+use ratatui::crossterm::event::Event;
+use ratatui::crossterm::event::KeyEventKind;
+use ratatui::prelude::*;
+use ratatui::widgets::*;
+use tracing::instrument;
+
+use crate::app::command::Command;
+use crate::commander::config::config_value;
+use crate::commander::new_commander;
+use crate::env::get_env;
+use crate::event::Mouse;
+use crate::keybinds::HelpItem;
+use crate::keybinds::SettingsTabEvent;
+use crate::keybinds::SettingsTabKeybinds;
+use crate::settings::SETTINGS;
+use crate::settings::Setting;
+use crate::ui::AppAction;
+use crate::ui::Component;
+use crate::ui::ComponentInputResult;
+use crate::ui::Scroll;
+use crate::ui::Tab;
+use crate::ui::dialog::ChoicePopup;
+use crate::ui::dialog::SettingValuePopup;
+use crate::ui::panel::ListPane;
+use crate::ui::panel::MouseInput;
+use crate::ui::panel::PanelMouseInput;
+use crate::ui::panel::Row as SectionRow;
+use crate::ui::panel::Sections;
+use crate::ui::panel::copy_marked;
+use crate::ui::utils::PaneDivider;
+use crate::ui::utils::error_text;
+
+/// What the configuration says about the options the tab shows.
+#[derive(Default)]
+struct Values {
+    /// Everything the configuration sets, across the layers jj reads.
+    all: toml::Table,
+    /// What the user's own config file sets, which is the layer the tab
+    /// writes and the only one it can take a value out of.
+    user: toml::Table,
+}
+
+impl Values {
+    /// What the configuration says now, and what of that the user's own
+    /// config file is what says it. What every layer says has been read
+    /// into the environment already; which layer a value comes from has
+    /// not.
+    fn read() -> Result<Self> {
+        Ok(Self {
+            all: get_env().config.clone(),
+            user: new_commander().get_user_config()?,
+        })
+    }
+
+    /// What `setting` is set to, as it reads on screen.
+    fn value(&self, setting: &Setting) -> Option<String> {
+        Some(setting.text_of(config_value(&self.all, setting.key)?))
+    }
+
+    /// Whether the user's own config file is what sets `setting`, which
+    /// is what makes it the tab's to take back out.
+    fn is_users(&self, setting: &Setting) -> bool {
+        config_value(&self.user, setting.key).is_some()
+    }
+}
+
+pub struct SettingsTab {
+    /// What the configuration says now, or why it could not be read.
+    values: Result<Values>,
+
+    /// The options under the headings they are listed by.
+    settings: Sections<&'static Setting>,
+    settings_pane: ListPane,
+    settings_list_state: ListState,
+
+    keybinds: SettingsTabKeybinds,
+    pane_divider: PaneDivider,
+
+    stale: bool,
+}
+
+impl SettingsTab {
+    /// A stale tab, holding nothing of what the configuration says yet.
+    #[instrument(level = "info", name = "Initializing settings tab", parent = None)]
+    pub fn new() -> Self {
+        Self {
+            values: Ok(Values::default()),
+
+            settings: Sections::new(SETTINGS, |setting| setting.section),
+            settings_pane: ListPane::default(),
+            settings_list_state: ListState::default(),
+
+            keybinds: SettingsTabKeybinds::new(),
+            pane_divider: PaneDivider::default(),
+
+            stale: true,
+        }
+    }
+
+    fn selected(&self) -> Option<&'static Setting> {
+        self.settings.selected().copied()
+    }
+
+    /// Ask for a new value for the selected option: which of the values
+    /// it takes, when it only takes one of a few, or what it is to be.
+    fn change_selected(&self) -> Option<AppAction> {
+        let setting = self.selected()?;
+        let values = self.values.as_ref().ok()?;
+
+        let Some(choices) = setting.choices() else {
+            return Some(AppAction::SetPopup(Box::new(SettingValuePopup::new(
+                setting,
+                values.value(setting).unwrap_or_default(),
+            ))));
+        };
+
+        let items = choices
+            .iter()
+            .filter_map(|choice| {
+                let value = setting.value_of(choice).ok()?;
+
+                Some((
+                    Line::raw(*choice),
+                    AppAction::Run(Command::SetSetting {
+                        key: setting.key.to_owned(),
+                        value,
+                    }),
+                ))
+            })
+            .collect();
+        // The value the option has now is the one to leave it at, so it
+        // is the one the list opens on.
+        let current = values
+            .value(setting)
+            .and_then(|value| choices.iter().position(|choice| *choice == value))
+            .unwrap_or(0);
+
+        Some(AppAction::SetPopup(Box::new(
+            ChoicePopup::new(
+                get_env().jj_config.clone(),
+                self.settings_pane
+                    .item_anchor(self.settings.selected_row(), 1),
+                setting.key,
+                items,
+            )
+            .selected(current),
+        )))
+    }
+
+    /// Take the selected option out of the user's config file, leaving
+    /// whatever the rest of the configuration says.
+    fn unset_selected(&self) -> Option<AppAction> {
+        let setting = self.selected()?;
+
+        self.values
+            .as_ref()
+            .is_ok_and(|values| values.is_users(setting))
+            .then(|| {
+                AppAction::Run(Command::UnsetSetting {
+                    key: setting.key.to_owned(),
+                })
+            })
+    }
+
+    /// The menu of what can be done to the selected option, put at
+    /// `anchor` or centered when there is nowhere to point at.
+    fn context_menu(&self, anchor: Option<Position>) -> Option<AppAction> {
+        let mut items = vec![(Line::raw("Change"), self.change_selected()?)];
+        if let Some(unset) = self.unset_selected() {
+            items.push((Line::raw("Take out of your config"), unset));
+        }
+
+        Some(AppAction::SetPopup(Box::new(ChoicePopup::new(
+            get_env().jj_config.clone(),
+            anchor,
+            "Setting actions",
+            items,
+        ))))
+    }
+
+    fn handle_event(&mut self, event: SettingsTabEvent) -> Option<AppAction> {
+        match event {
+            SettingsTabEvent::Change => self.change_selected(),
+            SettingsTabEvent::Unset => self.unset_selected(),
+            // Not an operation of its own; the key handler deals with it.
+            SettingsTabEvent::Unbound => None,
+        }
+    }
+
+    /// One row per option: its key, and what it is set to or what the
+    /// app goes by while it is not, under the heading of the section it
+    /// belongs to.
+    fn settings_lines(&self, values: &Values) -> Vec<Line<'static>> {
+        let width = SETTINGS
+            .iter()
+            .map(|setting| setting.key.len())
+            .max()
+            .unwrap_or(0);
+
+        self.settings
+            .rows()
+            .iter()
+            .enumerate()
+            .map(|(index, row)| {
+                let line = match row {
+                    // The indent is no part of the heading, so it is no
+                    // part of what is underlined either.
+                    SectionRow::Heading(heading) => Line::from(vec![
+                        Span::raw(" "),
+                        Span::raw(*heading).bold().underlined(),
+                    ]),
+                    SectionRow::Item(setting) => {
+                        let value = match values.value(setting) {
+                            Some(value) => Span::raw(value),
+                            None => Span::raw(setting.fallback.to_owned())
+                                .fg(Color::DarkGray)
+                                .italic(),
+                        };
+
+                        Line::from(vec![
+                            Span::raw(format!("   {:width$}  ", setting.key)),
+                            value,
+                        ])
+                    }
+                };
+
+                if index == self.settings.selected_row() {
+                    line.bg(get_env().jj_config.highlight_color())
+                } else {
+                    line
+                }
+            })
+            .collect()
+    }
+
+    /// What the selected option does, what it is set to and where that
+    /// comes from.
+    fn details_text(&self, values: &Values) -> Text<'static> {
+        let Some(setting) = self.selected() else {
+            return Text::default();
+        };
+        let mut lines = vec![
+            Line::raw(setting.key).bold(),
+            Line::raw(""),
+            Line::raw(setting.doc),
+            Line::raw(""),
+        ];
+
+        lines.push(match values.value(setting) {
+            Some(value) => Line::from(vec![
+                Span::raw("Set to:      "),
+                Span::raw(value).bold(),
+                Span::raw(if values.is_users(setting) {
+                    "  (in your config)"
+                } else {
+                    "  (elsewhere in your configuration)"
+                })
+                .fg(Color::DarkGray),
+            ]),
+            None => Line::raw("Not set."),
+        });
+        lines.push(Line::raw(format!("When unset:  {}", setting.fallback)));
+
+        if let Some(choices) = setting.choices() {
+            lines.push(Line::raw(format!("One of:      {}", choices.join(", "))));
+        }
+
+        Text::from(lines)
+    }
+}
+
+impl Tab for SettingsTab {
+    fn refresh(&mut self) -> Result<()> {
+        self.values = Values::read();
+        self.stale = false;
+
+        Ok(())
+    }
+
+    /// What the tab shows is the configuration, which a repo that has
+    /// moved says nothing about.
+    fn mark_stale(&mut self) {}
+
+    fn config_changed(&mut self) {
+        self.stale = true;
+    }
+
+    fn is_stale(&self) -> bool {
+        self.stale
+    }
+
+    fn scroll_main_panel(&mut self, scroll: Scroll) -> Result<()> {
+        self.settings
+            .scroll(scroll.distance(self.settings_pane.visible_items()));
+
+        Ok(())
+    }
+
+    fn open_context_menu(&self) -> Result<Option<AppAction>> {
+        Ok(self.context_menu(
+            self.settings_pane
+                .item_anchor(self.settings.selected_row(), 1),
+        ))
+    }
+
+    fn make_main_panel_help(&self) -> Vec<HelpItem> {
+        self.keybinds.make_help()
+    }
+
+    /// The details panel only says what the selected option is, so there
+    /// is nothing to do to it.
+    fn make_details_panel_help(&self) -> Vec<HelpItem> {
+        Vec::new()
+    }
+}
+
+impl Component for SettingsTab {
+    fn draw(&mut self, f: &mut Frame<'_>, area: Rect) -> Result<()> {
+        let chunks = self.pane_divider.split(area);
+
+        let (settings, details) = match self.values.as_ref() {
+            Ok(values) => (self.settings_lines(values), self.details_text(values)),
+            Err(err) => (
+                error_text("Error getting the configuration", err)?.lines,
+                Text::default(),
+            ),
+        };
+
+        let block = Block::bordered()
+            .title(" Settings ")
+            .border_type(BorderType::Rounded);
+        *self.settings_list_state.selected_mut() = Some(self.settings.selected_row());
+        self.settings_pane.render(
+            f,
+            chunks[0],
+            block,
+            List::new(settings).scroll_padding(3),
+            &mut self.settings_list_state,
+        );
+
+        f.render_widget(
+            Paragraph::new(details).wrap(Wrap { trim: false }).block(
+                Block::bordered()
+                    .title(" About ")
+                    .border_type(BorderType::Rounded)
+                    .padding(Padding::horizontal(1)),
+            ),
+            chunks[1],
+        );
+
+        Ok(())
+    }
+
+    fn input(&mut self, event: Event) -> Result<ComponentInputResult> {
+        if let Event::Key(key) = event {
+            if key.kind != KeyEventKind::Press {
+                return Ok(ComponentInputResult::Handled);
+            }
+
+            return match self.keybinds.match_event(key) {
+                // Not the tab's to act on, so whoever else wants the key
+                // is welcome to it.
+                SettingsTabEvent::Unbound => Ok(ComponentInputResult::NotHandled),
+                event => Ok(self.handle_event(event).into()),
+            };
+        }
+
+        Ok(ComponentInputResult::Handled)
+    }
+
+    fn input_mouse(&mut self, mouse: Mouse) -> Result<ComponentInputResult> {
+        if self.pane_divider.handle_mouse(mouse) {
+            return Ok(ComponentInputResult::Handled);
+        }
+        match self.settings_pane.input_mouse(mouse) {
+            MouseInput::Scroll(delta) => self.settings.scroll(delta),
+            MouseInput::Select(index) => self.settings.select_row(index),
+            MouseInput::Context(index) => {
+                self.settings.select_row(index);
+                return Ok(self.context_menu(Some(mouse.position())).into());
+            }
+            MouseInput::Copy(text) => return Ok(copy_marked(text)),
+            // Nothing here has a second thing a double click could do.
+            MouseInput::Activate | MouseInput::Handled => {}
+            MouseInput::NotHandled => return Ok(ComponentInputResult::NotHandled),
+        }
+        Ok(ComponentInputResult::Handled)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::env::set_test_env;
+    use crate::ui::utils::drawn;
+
+    fn tab(config: &str) -> SettingsTab {
+        set_test_env();
+        let mut tab = SettingsTab::new();
+        tab.values = Ok(Values {
+            all: config.parse().expect("the configuration parses"),
+            user: config.parse().expect("the configuration parses"),
+        });
+        tab
+    }
+
+    /// What the whole tab says, as one string per row of the terminal.
+    fn screen(tab: &mut SettingsTab) -> Vec<String> {
+        drawn(tab, 100, 20)
+    }
+
+    /// What the main panel says, as one string per row.
+    fn rows(tab: &SettingsTab) -> Vec<String> {
+        let values = tab.values.as_ref().expect("the configuration was read");
+
+        tab.settings_lines(values)
+            .iter()
+            .map(ToString::to_string)
+            .collect()
+    }
+
+    /// A repo that has moved says nothing about the configuration, so
+    /// reading it again is for a configuration that has changed.
+    #[test]
+    fn the_tab_reads_the_configuration_again_when_it_changes_rather_than_the_repo() {
+        let mut tab = tab("");
+        tab.stale = false;
+
+        tab.mark_stale();
+        assert!(!tab.is_stale());
+
+        tab.config_changed();
+        assert!(tab.is_stale());
+    }
+
+    /// The options are listed under what they are about, so that the
+    /// one being looked for is found by the heading over it.
+    #[test]
+    fn every_option_is_listed_under_a_heading() {
+        let rows = rows(&tab(""));
+
+        assert!(
+            rows.iter().any(|row| row.trim() == "Appearance"),
+            "{rows:?}"
+        );
+        assert!(rows.iter().any(|row| row.trim() == "Diffs"), "{rows:?}");
+    }
+
+    #[test]
+    fn an_option_the_configuration_says_nothing_about_shows_what_the_app_goes_by() {
+        let rows = rows(&tab(""));
+
+        assert!(
+            rows.iter()
+                .any(|row| row.contains("blazingjj.layout ") && row.ends_with("horizontal")),
+            "{rows:?}"
+        );
+    }
+
+    #[test]
+    fn a_string_is_shown_as_it_reads_rather_than_as_it_is_quoted() {
+        let rows = rows(&tab("blazingjj.layout = \"vertical\"\n"));
+
+        assert!(
+            rows.iter()
+                .any(|row| row.contains("blazingjj.layout ") && row.ends_with("vertical")),
+            "{rows:?}"
+        );
+    }
+
+    #[test]
+    fn the_details_panel_says_what_the_selected_option_does() {
+        let screen = screen(&mut tab("blazingjj.highlight-color = \"#123456\"\n"));
+
+        assert!(
+            screen
+                .iter()
+                .any(|row| row.contains("Background colour of the selected row")),
+            "{screen:?}"
+        );
+    }
+
+    #[test]
+    fn only_what_the_users_own_config_sets_can_be_taken_back_out() {
+        let mut tab = tab("blazingjj.layout = \"vertical\"\n");
+        while !tab
+            .selected()
+            .is_some_and(|setting| setting.key == "blazingjj.layout")
+        {
+            tab.settings.scroll(1);
+        }
+
+        assert!(tab.unset_selected().is_some());
+
+        // The same value, but coming from a layer the tab does not write.
+        tab.values.as_mut().unwrap().user = toml::Table::new();
+        assert!(tab.unset_selected().is_none());
+    }
+}

--- a/src/ui/settings_tab.rs
+++ b/src/ui/settings_tab.rs
@@ -14,16 +14,18 @@ use ratatui::prelude::*;
 use ratatui::widgets::*;
 use tracing::instrument;
 
+use crate::app::TabId;
 use crate::app::command::Command;
 use crate::commander::config::config_value;
 use crate::commander::new_commander;
 use crate::env::get_env;
 use crate::event::Mouse;
-use crate::keybinds::HelpItem;
+use crate::keybinds::Binding;
 use crate::keybinds::SettingsTabEvent;
 use crate::keybinds::SettingsTabKeybinds;
 use crate::settings::SETTINGS;
 use crate::settings::Setting;
+use crate::settings::SettingKind;
 use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
@@ -115,8 +117,11 @@ impl SettingsTab {
     /// it takes, when it only takes one of a few, or what it is to be.
     fn change_selected(&self) -> Option<AppAction> {
         let setting = self.selected()?;
-        let values = self.values.as_ref().ok()?;
+        if matches!(setting.kind, SettingKind::Keybindings) {
+            return Some(AppAction::ViewTab(TabId::Keybindings));
+        }
 
+        let values = self.values.as_ref().ok()?;
         let Some(choices) = setting.choices() else {
             return Some(AppAction::SetPopup(Box::new(SettingValuePopup::new(
                 setting,
@@ -161,6 +166,11 @@ impl SettingsTab {
     /// whatever the rest of the configuration says.
     fn unset_selected(&self) -> Option<AppAction> {
         let setting = self.selected()?;
+        // Taking the keybindings out would be taking out every binding
+        // at once, which is the keybindings tab's to do one at a time.
+        if matches!(setting.kind, SettingKind::Keybindings) {
+            return None;
+        }
 
         self.values
             .as_ref()
@@ -293,6 +303,7 @@ impl Tab for SettingsTab {
 
     fn config_changed(&mut self) {
         self.stale = true;
+        self.keybinds = SettingsTabKeybinds::new();
     }
 
     fn is_stale(&self) -> bool {
@@ -313,13 +324,13 @@ impl Tab for SettingsTab {
         ))
     }
 
-    fn make_main_panel_help(&self) -> Vec<HelpItem> {
-        self.keybinds.make_help()
+    fn main_panel_bindings(&self) -> Vec<Binding> {
+        self.keybinds.bindings()
     }
 
     /// The details panel only says what the selected option is, so there
     /// is nothing to do to it.
-    fn make_details_panel_help(&self) -> Vec<HelpItem> {
+    fn details_panel_bindings(&self) -> Vec<Binding> {
         Vec::new()
     }
 }

--- a/src/ui/styles.rs
+++ b/src/ui/styles.rs
@@ -2,8 +2,10 @@ use std::sync::LazyLock;
 
 use ansi_to_tui::IntoText;
 use ratatui::layout::Alignment;
+use ratatui::layout::Rect;
 use ratatui::style::Color;
 use ratatui::style::Style;
+use ratatui::text::Line;
 use ratatui::text::Span;
 use ratatui::widgets::Block;
 use ratatui::widgets::BorderType;
@@ -42,6 +44,39 @@ pub fn create_popup_block(title: &str) -> Block<'_> {
         .clone()
         .title(Span::styled(format!(" {title} "), *POPUP_BLOCK_TITLE_STYLE))
         .title_alignment(Alignment::Center)
+}
+
+/// How much of the width of the screen a popup asking for something
+/// takes.
+pub const POPUP_WIDTH_PERCENT: u16 = 60;
+
+/// How much of that its border and its padding take.
+const POPUP_CHROME_WIDTH: u16 = 4;
+
+/// How wide the text of such a popup is, drawn in `area`.
+pub fn popup_text_width(area: Rect) -> u16 {
+    (area.width * POPUP_WIDTH_PERCENT / 100)
+        .saturating_sub(POPUP_CHROME_WIDTH)
+        .max(1)
+}
+
+/// How many rows `lines` take once wrapped into `width` columns.
+pub fn wrapped_height(lines: &[Line], width: u16) -> u16 {
+    lines
+        .iter()
+        .map(|line| (line.width() as u16).div_ceil(width).max(1))
+        .sum()
+}
+
+/// What a popup says under a rule at the foot of it, such as what it
+/// answers to or what it made of what it was given.
+pub fn popup_footer(lines: Vec<Line<'static>>) -> Paragraph<'static> {
+    Paragraph::new(lines).wrap(Wrap { trim: false }).block(
+        Block::default()
+            .borders(Borders::TOP)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(Color::DarkGray)),
+    )
 }
 
 #[cfg(test)]

--- a/src/ui/utils.rs
+++ b/src/ui/utils.rs
@@ -20,37 +20,44 @@ use ratatui::text::Text;
 use ratatui::widgets::Block;
 
 use crate::env::JJLayout;
+use crate::env::get_env;
 use crate::event::Mouse;
 use crate::keybinds::Shortcut;
 
 /// Tracks the split position between two panes and handles drag-to-resize mouse events.
+#[derive(Default)]
 pub struct PaneDivider {
-    init_percent: u16,
+    /// The share of the area the first pane takes as configured, which
+    /// the divider goes back to whenever the configuration changes.
+    percent: u16,
+    /// Which way round the panes sat when the divider was last placed.
+    /// Its position counts cells along the axis they are divided on, so
+    /// it says nothing about the panes once they turn.
+    layout: JJLayout,
     size: Option<u16>,
     dragging: bool,
     rects: [Rect; 2],
 }
 
 impl PaneDivider {
-    pub fn new(percent: u16) -> Self {
-        Self {
-            init_percent: percent.min(100),
-            size: None,
-            dragging: false,
-            rects: [Rect::ZERO, Rect::ZERO],
-        }
-    }
-
     /// Split `area` into two panes at the current divider position and remember
     /// the resulting rects for hit-testing in `handle_mouse`.
-    pub fn split(&mut self, area: Rect, layout: JJLayout) -> [Rect; 2] {
+    pub fn split(&mut self, area: Rect) -> [Rect; 2] {
+        let config = &get_env().jj_config;
+        let (layout, percent) = (config.layout(), config.layout_percent());
+        if percent != self.percent || layout != self.layout {
+            self.percent = percent;
+            self.layout = layout;
+            self.size = None;
+        }
+
         let total = match layout {
             JJLayout::Horizontal => area.width,
             JJLayout::Vertical => area.height,
         };
         let size = match self.size {
             None => {
-                let s = ((total as u32 * self.init_percent as u32) / 100) as u16;
+                let s = ((total as u32 * self.percent as u32) / 100) as u16;
                 self.size = Some(s);
                 s
             }
@@ -67,21 +74,21 @@ impl PaneDivider {
     }
 
     /// Handle a mouse event. Returns true if the event was consumed.
-    pub fn handle_mouse(&mut self, mouse: Mouse, layout: JJLayout) -> bool {
+    pub fn handle_mouse(&mut self, mouse: Mouse) -> bool {
         let position = mouse.position();
         match mouse.kind() {
             MouseEventKind::Down(MouseButton::Left) => {
                 self.dragging = false;
-                if self.on_border(position, layout) {
+                if self.on_border(position, self.layout) {
                     self.dragging = true;
-                    self.update_size(position, layout);
+                    self.update_size(position, self.layout);
                     true
                 } else {
                     false
                 }
             }
             MouseEventKind::Drag(MouseButton::Left) if self.dragging => {
-                self.update_size(position, layout);
+                self.update_size(position, self.layout);
                 true
             }
             MouseEventKind::Up(MouseButton::Left) if self.dragging => {
@@ -388,6 +395,44 @@ mod tests {
     use std::str::FromStr;
 
     use super::*;
+    use crate::env::set_test_env;
+
+    /// A divider that was dragged keeps where it was put until the
+    /// configuration says something else.
+    #[test]
+    fn test_a_dragged_divider_goes_back_when_the_configuration_changes() {
+        set_test_env();
+        let area = Rect::new(0, 0, 100, 10);
+        let mut divider = PaneDivider::default();
+
+        let [main, _] = divider.split(area);
+        assert_eq!(main.width, 50);
+
+        divider.update_size(Position::new(20, 0), JJLayout::Horizontal);
+        let [main, _] = divider.split(area);
+        assert_eq!(main.width, 20);
+
+        // What the divider remembers is what the configuration said
+        // when it was last placed, so it stands in for a change of it.
+        divider.percent = 80;
+        let [main, _] = divider.split(area);
+        assert_eq!(main.width, 50);
+    }
+
+    /// It goes back to it when the panes turn as well.
+    #[test]
+    fn test_a_dragged_divider_goes_back_when_the_panes_turn() {
+        set_test_env();
+        let area = Rect::new(0, 0, 100, 10);
+        let mut divider = PaneDivider::default();
+
+        divider.split(area);
+        divider.update_size(Position::new(20, 0), JJLayout::Horizontal);
+        divider.layout = JJLayout::Vertical;
+
+        let [main, _] = divider.split(area);
+        assert_eq!(main.width, 50);
+    }
 
     /// A label marks the key that picks it in place where the key is one
     /// of its characters, and names it after the label otherwise.

--- a/src/ui/utils.rs
+++ b/src/ui/utils.rs
@@ -390,6 +390,26 @@ pub fn tabs_to_spaces(line: &str) -> String {
     out
 }
 
+/// What `component` draws on a terminal that many columns wide and rows
+/// tall, as one string per row of it.
+#[cfg(test)]
+pub fn drawn(component: &mut impl super::Component, width: u16, height: u16) -> Vec<String> {
+    let mut terminal = ratatui::Terminal::new(ratatui::backend::TestBackend::new(width, height))
+        .expect("the test backend");
+    terminal
+        .draw(|f| component.draw(f, f.area()).expect("the component draws"))
+        .expect("the frame is drawn");
+
+    let buffer = terminal.backend().buffer().clone();
+    (0..buffer.area.height)
+        .map(|y| {
+            (0..buffer.area.width)
+                .map(|x| buffer[(x, y)].symbol())
+                .collect()
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;


### PR DESCRIPTION
Every option blazingjj has is set by leaving it for an editor or for jj
config set, and nothing in the app says which options there are, what
each does or what it goes by while they are unset. The keys are worse
off still: what an action is called in the config file is nowhere in the
app at all. Give the app a settings tab, and a keybindings tab that its
blazingjj.keybinds row opens, both writing to the user's config file
through jj config and both listing what they offer under headings.

Nothing read the configuration again after startup, so the tabs and
panels first have to take it up where they use it rather than copy it
when they are built. Binding a key from inside the app also means the
app has to know what an action is called in the config, which was
spread over the macros each context calls, so those are gathered into
one list per context that the help is then drawn from.

The keybindings tab is the settings tab's rather than one of its own,
taking its place in the tab bar while it is up, so that it stays an
ordinary tab rather than making the details panel somewhere to act on
things in this one place alone. A key is written under the name it
reads by, which is what refuses a key with no name to be written under,
and a key another action answers to alongside it is refused rather than
left to shadow it.