### PR TITLE
files: Add opening a file in an editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   by double clicking a word or by triple clicking a line, and goes to the
   system clipboard when the button comes up. A line the panel wrapped or
   cut off to show is copied as the one whole line it is
+- `o` in the files tab opens the selected file, as the working copy has it,
+  in an editor, which `blazingjj.editor` names and `blazingjj.editor-mode`
+  says whether to hand the terminal to or leave running on its own. Without
+  one configured, `$VISUAL` and then `$EDITOR` are used
 - Diff format rendering the Git format with a pager like
   [delta](https://github.com/dandavison/delta), configured as
   `blazingjj.diff-pager` and toggled through with `w` like the others

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     version of the file to open: the one on disk, the change's own after
     checking it out, or the change's own through a change of your own on
     top of it, which is the only way to an immutable one
+  - `blazingjj.editor-url`, like `jj://$revision/$file`, adds opening the file
+    at the revision shown to that question, for an editor that reads a
+    revision itself, such as neovim with jj.nvim
 - Diff format rendering the Git format with a pager like
   [delta](https://github.com/dandavison/delta), configured as
   `blazingjj.diff-pager` and toggled through with `w` like the others

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in an editor, which `blazingjj.editor` names and `blazingjj.editor-mode`
   says whether to hand the terminal to or leave running on its own. Without
   one configured, `$VISUAL` and then `$EDITOR` are used
+  - While the tab shows a change other than the working copy, it asks which
+    version of the file to open: the one on disk, the change's own after
+    checking it out, or the change's own through a change of your own on
+    top of it, which is the only way to an immutable one
 - Diff format rendering the Git format with a pager like
   [delta](https://github.com/dandavison/delta), configured as
   `blazingjj.diff-pager` and toggled through with `w` like the others

--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ You can optionally configure the following options through your jj config:
   - `$file` in an argument stands for the file to open; an editor whose arguments say nothing about it is given it as the last one
   - Without it, `$VISUAL` and then `$EDITOR` are used
 - `blazingjj.editor-mode`: How the editor is run. Can be `terminal` (default), which hands the terminal over to it, or `detached`, which leaves it running on its own, as an editor with a window of its own is
+- `blazingjj.editor-url`: What names a file at a revision to an editor that reads revisions itself, like neovim with jj.nvim: `jj config set --user blazingjj.editor-url 'jj://$revision/$file'`
+  - Setting it offers opening a file at the revision the files tab shows, with nothing checked out; the URL goes to the editor in place of the file to open
+  - `$revision` is the change id, except that a version out of the evolog and a divergent change are named by their commit id, those being what they are found by
 - `blazingjj.bookmark-template`: Change the bookmark name template for generated bookmark names. Defaults to `'push-' ++ change_id.short()`
   - If `blazingjj.bookmark-template` is not set but `templates.git_push_bookmark` is, the latter will be used
 - `blazingjj.describe-mode`: What describing a change puts up. Can be `popup` (default) for the built-in editor, or `jj` to hand the terminal to `jj describe` and your own editor

--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ You can optionally configure the following options through your jj config:
   - The pager reads the diff on standard input and writes its rendering to standard output; it must not page, since blazingjj shows the output itself
   - `$width` in an argument stands for the columns the details panel has, which a pager that cannot find out for itself needs to be told
   - Setting it makes `pager` the default format, unless `blazingjj.diff-format` says otherwise, and adds it to what `w` toggles through
+- `blazingjj.editor`: The editor `o` in the files tab opens the working copy's version of the selected file in, like `jj config set --user blazingjj.editor '["code", "--wait", "$file"]'`
+  - `$file` in an argument stands for the file to open; an editor whose arguments say nothing about it is given it as the last one
+  - Without it, `$VISUAL` and then `$EDITOR` are used
+- `blazingjj.editor-mode`: How the editor is run. Can be `terminal` (default), which hands the terminal over to it, or `detached`, which leaves it running on its own, as an editor with a window of its own is
 - `blazingjj.bookmark-template`: Change the bookmark name template for generated bookmark names. Defaults to `'push-' ++ change_id.short()`
   - If `blazingjj.bookmark-template` is not set but `templates.git_push_bookmark` is, the latter will be used
 - `blazingjj.describe-mode`: What describing a change puts up. Can be `popup` (default) for the built-in editor, or `jj` to hand the terminal to `jj describe` and your own editor

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -161,6 +161,7 @@ fetch-all = "shift+f"
 [blazingjj.keybinds.files-tab]
 untrack = "x"
 restore = "r"
+open = "o"
 ```
 
 ### Bookmarks tab

--- a/src/app/command.rs
+++ b/src/app/command.rs
@@ -7,6 +7,7 @@ as an [AppAction].
 */
 
 use std::fmt::Display;
+use std::path::Path;
 
 use ansi_to_tui::IntoText;
 use anyhow::Result;
@@ -20,6 +21,7 @@ use crate::background_tasks::BackgroundTasks;
 use crate::background_tasks::TaskOutput;
 use crate::background_tasks::TaskSlot;
 use crate::commander::bookmarks::Bookmark;
+use crate::commander::files::DiffType;
 use crate::commander::files::File;
 use crate::commander::ids::ChangeId;
 use crate::commander::ids::CommitId;
@@ -33,6 +35,7 @@ use crate::commander::new_commander;
 use crate::commander::operation::Operation;
 use crate::commander::program::Program;
 use crate::commander::revset::Revset;
+use crate::env::Editor;
 use crate::env::EditorMode;
 use crate::env::JjConfig;
 use crate::env::get_env;
@@ -42,6 +45,7 @@ use crate::ui::Interactive;
 use crate::ui::dialog::BookmarkNameMode;
 use crate::ui::dialog::BookmarkNamePopup;
 use crate::ui::dialog::BookmarkSetPopup;
+use crate::ui::dialog::ChoicePopup;
 use crate::ui::dialog::ConfirmPopup;
 use crate::ui::dialog::DescribePopup;
 use crate::ui::dialog::LoaderPopup;
@@ -59,6 +63,20 @@ pub enum NewSource {
     Marks,
     /// A single change, named by the selection or by a bookmark.
     Change,
+}
+
+/// Which version of a file an editor is opened on. The editor edits the
+/// working copy either way, so reaching another change's version of a
+/// file means moving the working copy there first.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum OpenAt {
+    /// The file as the working copy has it.
+    WorkingCopy,
+    /// The file as this change has it, which is checked out to get at.
+    Checkout(CommitId),
+    /// The file as this change has it, reached by a new change on top of
+    /// it, for a change that cannot be edited itself.
+    NewOnTop(CommitId),
 }
 
 /// The change the set-bookmark dialog was opened for, which is all it
@@ -117,9 +135,12 @@ pub enum Command {
     RevertOperation(OperationId),
     RestoreFile(File),
     UntrackFile(File),
-    /// Open the working copy's version of the file in the configured
-    /// editor.
-    OpenFile(File),
+    /// Open the file in the configured editor, on the version of it
+    /// `at` names.
+    OpenFile {
+        file: File,
+        at: OpenAt,
+    },
     CreateBookmark(String),
     RenameBookmark {
         old_name: String,
@@ -309,7 +330,7 @@ impl Command {
                 Ok(_) => Ok(Some(show_working_copy_files()?)),
                 Err(err) => Ok(Some(refused("Untrack", err))),
             },
-            Command::OpenFile(file) => open_file(&file),
+            Command::OpenFile { file, at } => open_file(&file, &at),
             Command::CreateBookmark(name) => match new_commander().create_bookmark(&name) {
                 Ok(_) => Ok(Some(AppAction::Multiple(vec![
                     AppAction::ViewBookmark(name),
@@ -389,15 +410,15 @@ impl Command {
     }
 }
 
-/// Open the working copy's `file` in the configured editor, either with
-/// the terminal handed over to it or left running on its own, as the
-/// configuration says.
-fn open_file(file: &File) -> Result<Option<AppAction>> {
-    let env = get_env();
+/// Open `file` in the configured editor, having taken the working copy
+/// to where `at` says the version to open is.
+fn open_file(file: &File, at: &OpenAt) -> Result<Option<AppAction>> {
     let Some(path) = file.path.as_deref() else {
         return Ok(Some(message("Open", "The line names no file to open.")));
     };
-    let Some(editor) = env.jj_config.editor() else {
+    // Whatever is in the way of opening the file is in the way before the
+    // working copy has been taken anywhere for it.
+    let Some(editor) = get_env().jj_config.editor() else {
         return Ok(Some(message(
             "Open",
             "There is no editor to open the file in. Set `blazingjj.editor`, \
@@ -405,20 +426,102 @@ fn open_file(file: &File) -> Result<Option<AppAction>> {
         )));
     };
 
+    let moved = match at {
+        OpenAt::WorkingCopy => None,
+        OpenAt::Checkout(commit_id) => match new_commander().run_edit(commit_id, false) {
+            Ok(()) => Some(show_change(new_commander().get_current_head()?)),
+            Err(err) => return Ok(Some(refused("Edit", err))),
+        },
+        OpenAt::NewOnTop(commit_id) => {
+            match new_commander().run_new_with_insert(commit_id, NewInsertMode::Child) {
+                Ok(()) => Some(show_change(new_commander().get_current_head()?)),
+                Err(err) => return Ok(Some(refused("New", err))),
+            }
+        }
+    };
+
+    let opened = open_in_editor(&editor, path);
+
+    Ok(match moved {
+        Some(moved) => Some(AppAction::Multiple(
+            [moved].into_iter().chain(opened).collect(),
+        )),
+        None => opened,
+    })
+}
+
+/// Open the working copy's `path` in `editor`, either with the terminal
+/// handed over to it or left running on its own, as the configuration
+/// says.
+fn open_in_editor(editor: &Editor, path: &str) -> Option<AppAction> {
+    let env = get_env();
     let program = Program::new(editor.program(), env.root.clone()).args(editor.args(path));
 
     match env.jj_config.editor_mode() {
-        EditorMode::Terminal => Ok(Some(AppAction::RunInteractive(Interactive {
+        EditorMode::Terminal => Some(AppAction::RunInteractive(Interactive {
             program,
             // The editor leaves the file it edited on the screen, which
             // is not something to read once it is closed.
             hold_screen: false,
-        }))),
+        })),
         EditorMode::Detached => match program.run_detached() {
-            Ok(()) => Ok(None),
-            Err(err) => Ok(Some(refused("Open", err))),
+            Ok(()) => None,
+            Err(err) => Some(refused("Open", err)),
         },
     }
+}
+
+/// Asking where to open `file`, which is shown at `head` rather than in
+/// the working copy: what is on disk now, or what that change has, which
+/// means taking the working copy there first. Only the versions there
+/// are to open are offered.
+pub fn ask_open_file(config: JjConfig, head: &Head, file: &File) -> AppAction {
+    let open = |at| {
+        AppAction::Run(Command::OpenFile {
+            file: file.clone(),
+            at,
+        })
+    };
+
+    let Some(path) = file.path.as_deref() else {
+        return message("Open", "The line names no file to open.");
+    };
+
+    let mut items = Vec::new();
+    if in_working_copy(path) {
+        items.push((
+            Line::raw("Open the file as the working copy has it"),
+            open(OpenAt::WorkingCopy),
+        ));
+    }
+    if file.diff_type != Some(DiffType::Deleted) {
+        if !head.immutable {
+            items.push((
+                Line::raw("Check this change out and open the file there"),
+                open(OpenAt::Checkout(head.commit_id.clone())),
+            ));
+        }
+        items.push((
+            Line::raw("Create a change on top of it and open the file there"),
+            open(OpenAt::NewOnTop(head.commit_id.clone())),
+        ));
+    }
+
+    if items.is_empty() {
+        return message("Open", "There is no version of the file to open.");
+    }
+
+    AppAction::SetPopup(Box::new(ChoicePopup::new(config, None, "Open", items)))
+}
+
+/// Whether the working copy has `path`. A file another change added or
+/// deleted is not there to open, however the change shows it. A symlink
+/// is there whether or not what it points at is.
+fn in_working_copy(path: &str) -> bool {
+    Path::new(&get_env().root)
+        .join(path)
+        .symlink_metadata()
+        .is_ok()
 }
 
 /// Asking for a new change from the marked changes, or from `selected`
@@ -990,6 +1093,99 @@ mod tests {
             ),
             "jj said nothing"
         ));
+    }
+
+    /// A file the working copy does not have is one there is nothing to
+    /// open at `@`, whatever the change being shown says about it.
+    #[test]
+    fn only_a_file_the_working_copy_has_is_offered_as_it_is() {
+        set_test_env();
+        let opening = |path: &str| {
+            ask_open_file(
+                JjConfig::default(),
+                &head("a", false),
+                &File {
+                    line: format!("M {path}"),
+                    path: Some(path.to_owned()),
+                    diff_type: Some(DiffType::Modified),
+                },
+            )
+        };
+
+        assert!(says(opening("Cargo.toml"), "as the working copy has it"));
+        assert!(!says(opening("gone.txt"), "as the working copy has it"));
+    }
+
+    /// An immutable change cannot be checked out to edit, so the only way
+    /// to the file is a change of one's own on top of it.
+    #[test]
+    fn an_immutable_change_is_not_offered_for_checking_out() {
+        set_test_env();
+        let opening = |immutable| {
+            ask_open_file(
+                JjConfig::default(),
+                &head("a", immutable),
+                &File {
+                    line: "M Cargo.toml".to_owned(),
+                    path: Some("Cargo.toml".to_owned()),
+                    diff_type: Some(DiffType::Modified),
+                },
+            )
+        };
+
+        assert!(says(opening(false), "Check this change out"));
+        assert!(!says(opening(true), "Check this change out"));
+        assert!(says(opening(true), "Create a change on top of it"));
+    }
+
+    /// Taking the working copy to a change that deletes the file leaves
+    /// nothing to open there, so neither way of getting to that version
+    /// is one to offer.
+    #[test]
+    fn a_file_the_change_deletes_is_not_offered_at_that_change() {
+        set_test_env();
+        let opening = |path: &str| {
+            ask_open_file(
+                JjConfig::default(),
+                &head("a", false),
+                &File {
+                    line: format!("D {path}"),
+                    path: Some(path.to_owned()),
+                    diff_type: Some(DiffType::Deleted),
+                },
+            )
+        };
+
+        assert!(!says(opening("Cargo.toml"), "Check this change out"));
+        assert!(!says(opening("Cargo.toml"), "Create a change on top of it"));
+        assert!(says(opening("Cargo.toml"), "as the working copy has it"));
+        assert!(says(
+            opening("gone.txt"),
+            "There is no version of the file to open"
+        ));
+    }
+
+    /// A line naming no file is one to say so about rather than one to
+    /// take the working copy anywhere for.
+    #[test]
+    fn a_line_naming_no_file_moves_the_working_copy_nowhere() -> Result<()> {
+        set_test_env();
+        let file = File {
+            line: "Some other line".to_owned(),
+            path: None,
+            diff_type: None,
+        };
+
+        assert!(says(
+            ask_open_file(JjConfig::default(), &head("a", false), &file),
+            "names no file to open"
+        ));
+
+        let action = open_file(&file, &OpenAt::Checkout(CommitId("commit-a".to_owned())))?
+            .expect("the line is refused");
+        assert!(says(action, "names no file to open"));
+
+        Ok(())
     }
 
     #[test]

--- a/src/app/command.rs
+++ b/src/app/command.rs
@@ -77,6 +77,9 @@ pub enum OpenAt {
     /// The file as this change has it, reached by a new change on top of
     /// it, for a change that cannot be edited itself.
     NewOnTop(CommitId),
+    /// The file at a revision, this URL naming both, for an editor that
+    /// reads a revision itself and so needs nothing checked out.
+    AtRevision(String),
 }
 
 /// The change the set-bookmark dialog was opened for, which is all it
@@ -426,21 +429,24 @@ fn open_file(file: &File, at: &OpenAt) -> Result<Option<AppAction>> {
         )));
     };
 
-    let moved = match at {
-        OpenAt::WorkingCopy => None,
+    let (moved, target) = match at {
+        OpenAt::WorkingCopy => (None, path),
         OpenAt::Checkout(commit_id) => match new_commander().run_edit(commit_id, false) {
-            Ok(()) => Some(show_change(new_commander().get_current_head()?)),
+            Ok(()) => (Some(show_change(new_commander().get_current_head()?)), path),
             Err(err) => return Ok(Some(refused("Edit", err))),
         },
         OpenAt::NewOnTop(commit_id) => {
             match new_commander().run_new_with_insert(commit_id, NewInsertMode::Child) {
-                Ok(()) => Some(show_change(new_commander().get_current_head()?)),
+                Ok(()) => (Some(show_change(new_commander().get_current_head()?)), path),
                 Err(err) => return Ok(Some(refused("New", err))),
             }
         }
+        // The editor reads the revision itself, so the working copy
+        // stays where it is and the URL goes where the file would.
+        OpenAt::AtRevision(url) => (None, url.as_str()),
     };
 
-    let opened = open_in_editor(&editor, path);
+    let opened = open_in_editor(&editor, target);
 
     Ok(match moved {
         Some(moved) => Some(AppAction::Multiple(
@@ -450,12 +456,12 @@ fn open_file(file: &File, at: &OpenAt) -> Result<Option<AppAction>> {
     })
 }
 
-/// Open the working copy's `path` in `editor`, either with the terminal
-/// handed over to it or left running on its own, as the configuration
-/// says.
-fn open_in_editor(editor: &Editor, path: &str) -> Option<AppAction> {
+/// Open `target`, a file of the working copy or a URL naming one at a
+/// revision, in `editor`, either with the terminal handed over to it or
+/// left running on its own, as the configuration says.
+fn open_in_editor(editor: &Editor, target: &str) -> Option<AppAction> {
     let env = get_env();
-    let program = Program::new(editor.program(), env.root.clone()).args(editor.args(path));
+    let program = Program::new(editor.program(), env.root.clone()).args(editor.args(target));
 
     match env.jj_config.editor_mode() {
         EditorMode::Terminal => Some(AppAction::RunInteractive(Interactive {
@@ -471,11 +477,12 @@ fn open_in_editor(editor: &Editor, path: &str) -> Option<AppAction> {
     }
 }
 
-/// Asking where to open `file`, which is shown at `head` rather than in
-/// the working copy: what is on disk now, or what that change has, which
-/// means taking the working copy there first. Only the versions there
-/// are to open are offered.
-pub fn ask_open_file(config: JjConfig, head: &Head, file: &File) -> AppAction {
+/// Asking where to open `file`, which is shown at `head`, named
+/// `revision` to an editor, rather than in the working copy: what is on
+/// disk now, what that change has, which means taking the working copy
+/// there first, or, for an editor that reads a revision itself, the file
+/// at `revision`. Only the versions there are to open are offered.
+pub fn ask_open_file(config: JjConfig, head: &Head, revision: &str, file: &File) -> AppAction {
     let open = |at| {
         AppAction::Run(Command::OpenFile {
             file: file.clone(),
@@ -487,14 +494,27 @@ pub fn ask_open_file(config: JjConfig, head: &Head, file: &File) -> AppAction {
         return message("Open", "The line names no file to open.");
     };
 
+    // The change has no version of a file it deletes, however the tab
+    // shows it.
+    let at_change = file.diff_type != Some(DiffType::Deleted);
+
     let mut items = Vec::new();
+    // An editor that reads the revision itself gets at the file without
+    // anything being checked out, which makes it the first thing to
+    // offer wherever it is configured.
+    if at_change && let Some(url) = config.editor_url(revision, path) {
+        items.push((
+            Line::raw("Open the file at this revision"),
+            open(OpenAt::AtRevision(url)),
+        ));
+    }
     if in_working_copy(path) {
         items.push((
             Line::raw("Open the file as the working copy has it"),
             open(OpenAt::WorkingCopy),
         ));
     }
-    if file.diff_type != Some(DiffType::Deleted) {
+    if at_change {
         if !head.immutable {
             items.push((
                 Line::raw("Check this change out and open the file there"),
@@ -1095,6 +1115,43 @@ mod tests {
         ));
     }
 
+    /// Opening a file at a revision is only something an editor that
+    /// reads revisions itself can do, which is what a URL to name one by
+    /// says the configured editor does.
+    #[test]
+    fn the_file_at_the_revision_is_only_offered_with_a_url_to_name_it_by() {
+        set_test_env();
+        let opening = |config, diff_type| {
+            ask_open_file(
+                config,
+                &head("a", false),
+                "change-a",
+                &File {
+                    line: "M Cargo.toml".to_owned(),
+                    path: Some("Cargo.toml".to_owned()),
+                    diff_type: Some(diff_type),
+                },
+            )
+        };
+        let configured = || {
+            toml::from_str::<JjConfig>(r#"blazingjj.editor-url = "jj://$revision/$file""#)
+                .expect("the configuration parses")
+        };
+
+        assert!(!says(
+            opening(JjConfig::default(), DiffType::Modified),
+            "at this revision"
+        ));
+        assert!(says(
+            opening(configured(), DiffType::Modified),
+            "at this revision"
+        ));
+        assert!(
+            !says(opening(configured(), DiffType::Deleted), "at this revision"),
+            "the revision has no version of a file it deletes"
+        );
+    }
+
     /// A file the working copy does not have is one there is nothing to
     /// open at `@`, whatever the change being shown says about it.
     #[test]
@@ -1104,6 +1161,7 @@ mod tests {
             ask_open_file(
                 JjConfig::default(),
                 &head("a", false),
+                "change-a",
                 &File {
                     line: format!("M {path}"),
                     path: Some(path.to_owned()),
@@ -1125,6 +1183,7 @@ mod tests {
             ask_open_file(
                 JjConfig::default(),
                 &head("a", immutable),
+                "change-a",
                 &File {
                     line: "M Cargo.toml".to_owned(),
                     path: Some("Cargo.toml".to_owned()),
@@ -1148,6 +1207,7 @@ mod tests {
             ask_open_file(
                 JjConfig::default(),
                 &head("a", false),
+                "change-a",
                 &File {
                     line: format!("D {path}"),
                     path: Some(path.to_owned()),
@@ -1177,7 +1237,7 @@ mod tests {
         };
 
         assert!(says(
-            ask_open_file(JjConfig::default(), &head("a", false), &file),
+            ask_open_file(JjConfig::default(), &head("a", false), "change-a", &file),
             "names no file to open"
         ));
 

--- a/src/app/command.rs
+++ b/src/app/command.rs
@@ -31,11 +31,14 @@ use crate::commander::jj::RebaseTarget;
 use crate::commander::log::Head;
 use crate::commander::new_commander;
 use crate::commander::operation::Operation;
+use crate::commander::program::Program;
 use crate::commander::revset::Revset;
+use crate::env::EditorMode;
 use crate::env::JjConfig;
 use crate::env::get_env;
 use crate::keybinds::PushScope;
 use crate::ui::AppAction;
+use crate::ui::Interactive;
 use crate::ui::dialog::BookmarkNameMode;
 use crate::ui::dialog::BookmarkNamePopup;
 use crate::ui::dialog::BookmarkSetPopup;
@@ -114,6 +117,9 @@ pub enum Command {
     RevertOperation(OperationId),
     RestoreFile(File),
     UntrackFile(File),
+    /// Open the working copy's version of the file in the configured
+    /// editor.
+    OpenFile(File),
     CreateBookmark(String),
     RenameBookmark {
         old_name: String,
@@ -303,6 +309,7 @@ impl Command {
                 Ok(_) => Ok(Some(show_working_copy_files()?)),
                 Err(err) => Ok(Some(refused("Untrack", err))),
             },
+            Command::OpenFile(file) => open_file(&file),
             Command::CreateBookmark(name) => match new_commander().create_bookmark(&name) {
                 Ok(_) => Ok(Some(AppAction::Multiple(vec![
                     AppAction::ViewBookmark(name),
@@ -379,6 +386,38 @@ impl Command {
                 Err(err) => Ok(Some(refused("Unset", err))),
             },
         }
+    }
+}
+
+/// Open the working copy's `file` in the configured editor, either with
+/// the terminal handed over to it or left running on its own, as the
+/// configuration says.
+fn open_file(file: &File) -> Result<Option<AppAction>> {
+    let env = get_env();
+    let Some(path) = file.path.as_deref() else {
+        return Ok(Some(message("Open", "The line names no file to open.")));
+    };
+    let Some(editor) = env.jj_config.editor() else {
+        return Ok(Some(message(
+            "Open",
+            "There is no editor to open the file in. Set `blazingjj.editor`, \
+             or `VISUAL` or `EDITOR` in the environment.",
+        )));
+    };
+
+    let program = Program::new(editor.program(), env.root.clone()).args(editor.args(path));
+
+    match env.jj_config.editor_mode() {
+        EditorMode::Terminal => Ok(Some(AppAction::RunInteractive(Interactive {
+            program,
+            // The editor leaves the file it edited on the screen, which
+            // is not something to read once it is closed.
+            hold_screen: false,
+        }))),
+        EditorMode::Detached => match program.run_detached() {
+            Ok(()) => Ok(None),
+            Err(err) => Ok(Some(refused("Open", err))),
+        },
     }
 }
 

--- a/src/commander/mod.rs
+++ b/src/commander/mod.rs
@@ -20,7 +20,7 @@ invocation with [Commander::jj], which returns a [JjCommand] builder:
 * [JjCommand::run] - Execute the command and return its output
 * [JjCommand::run_void] - Execute the command and discard the output
 * [JjCommand::run_cancellable] - Execute the command so it can be killed
-* [JjCommand::run_foreground] - Execute the command attached to the terminal
+* [JjCommand::foreground] - The command as a program to attach to the terminal
 
 */
 
@@ -32,6 +32,7 @@ pub mod ids;
 pub mod jj;
 pub mod log;
 pub mod operation;
+pub mod program;
 pub mod revset;
 
 use std::ffi::OsStr;
@@ -40,8 +41,6 @@ use std::io;
 use std::io::Read;
 use std::io::Write;
 use std::process::Child;
-use std::process::Command;
-use std::process::ExitStatus;
 use std::process::Stdio;
 use std::string::FromUtf8Error;
 use std::thread;
@@ -59,6 +58,7 @@ use version_compare::Cmp;
 use version_compare::compare;
 
 use crate::commander::cancel::CancelToken;
+use crate::commander::program::Program;
 use crate::env::DiffFormat;
 use crate::env::DiffPager;
 use crate::env::Env;
@@ -169,7 +169,7 @@ impl Commander {
     /// The returned [JjCommand] carries the per-command options (color,
     /// quiet, ...) and is executed with [JjCommand::run],
     /// [JjCommand::run_void], [JjCommand::run_cancellable] or
-    /// [JjCommand::run_foreground].
+    /// [JjCommand::foreground].
     pub fn jj<I, S>(&self, args: I) -> JjCommand
     where
         I: IntoIterator<Item = S>,
@@ -254,8 +254,8 @@ impl Commander {
 /// Carries the arguments and the per-command options. Configuration
 /// methods consume and return the builder so they can be chained; the
 /// command is run exactly once with [Self::run], [Self::run_void],
-/// [Self::run_cancellable] or [Self::run_foreground], the last of which
-/// leaves the output options to jj.
+/// [Self::run_cancellable], or handed to the terminal as the program
+/// [Self::foreground] returns.
 pub struct JjCommand {
     jj_bin: String,
     root: String,
@@ -380,13 +380,13 @@ impl JjCommand {
         }))
     }
 
-    /// Run the command with the terminal handed over to it, so it can page,
-    /// colorize and prompt as it would outside the app, and return how it
-    /// exited. The terminal is the command's to read and write as it sees
-    /// fit, so [Self::stdin], [Self::color] and [Self::verbose] have no say
-    /// here.
-    pub fn run_foreground(self) -> io::Result<ExitStatus> {
-        self.build_command().status()
+    /// The command as a program to run with the terminal handed over to
+    /// it, so it can page, colorize and prompt as it would outside the
+    /// app. The terminal is the program's to read and write as it sees
+    /// fit, so [Self::stdin], [Self::color] and [Self::verbose] have no
+    /// say in what it does.
+    pub fn foreground(self) -> Program {
+        self.build_jj()
     }
 
     /// Configure and run the command as a child process, as described in
@@ -394,22 +394,21 @@ impl JjCommand {
     fn execute(mut self, stdout: Stdio, cancel: &CancelToken) -> Result<Vec<u8>, CommandError> {
         let input = self.stdin.take().map(String::into_bytes);
 
-        let mut command = self.build_command();
-        command.args(get_output_args(
+        let program = self.build_jj().args(get_output_args(
             !self.force_no_color && self.color,
             self.quiet,
         ));
 
         let Some(pager) = self.pager.take() else {
-            return run_child(command, input, stdout, cancel, self.with_stderr);
+            return run_child(&program, input, stdout, cancel, self.with_stderr);
         };
 
         // The pager is what produces the output, so what jj writes is
         // captured whatever the caller asked for.
-        let piped = run_child(command, input, Stdio::piped(), cancel, self.with_stderr)?;
+        let piped = run_child(&program, input, Stdio::piped(), cancel, self.with_stderr)?;
 
         run_child(
-            self.build_pager_command(&pager),
+            &self.build_pager(&pager),
             Some(piped),
             stdout,
             cancel,
@@ -417,32 +416,28 @@ impl JjCommand {
         )
     }
 
-    /// Construct a Command ready for execution. The caller adds the output
+    /// The jj invocation as a program to run. The caller adds the output
     /// args, which only suit a command whose output it captures.
-    fn build_command(&self) -> Command {
-        let mut command = Command::new(&self.jj_bin);
-        command.args(&self.args);
-
+    fn build_jj(&self) -> Program {
+        let mut args = self.args.clone();
         if self.ignore_working_copy {
-            command.arg("--ignore-working-copy");
+            args.push("--ignore-working-copy".into());
         }
 
-        command.current_dir(&self.root);
-        command.envs(self.env_var.iter().cloned());
-        command
+        Program::new(&self.jj_bin, self.root.clone())
+            .args(args)
+            .envs(self.env_var.iter().cloned())
     }
 
-    /// Construct a Command running the pager the output goes through
-    fn build_pager_command(&self, pager: &DiffPager) -> Command {
-        let mut command = Command::new(pager.program());
-        command.args(pager.args(self.columns.unwrap_or(0)));
-        command.current_dir(&self.root);
-        command.envs(self.env_var.iter().cloned());
-        command
+    /// The pager the output goes through, as a program to run
+    fn build_pager(&self, pager: &DiffPager) -> Program {
+        Program::new(pager.program(), self.root.clone())
+            .args(pager.args(self.columns.unwrap_or(0)))
+            .envs(self.env_var.iter().cloned())
     }
 }
 
-/// Run `command` in a child process `cancel` can kill, blocking until it is
+/// Run `program` in a child process `cancel` can kill, blocking until it is
 /// done, and return its captured standard output.
 ///
 /// `input` is fed to the child on standard input, if there is any. `stdout`
@@ -451,12 +446,13 @@ impl JjCommand {
 /// so it can be surfaced on failure, and `with_stderr` appends it to the
 /// output of a child that succeeded.
 fn run_child(
-    mut command: Command,
+    program: &Program,
     input: Option<Vec<u8>>,
     stdout: Stdio,
     cancel: &CancelToken,
     with_stderr: bool,
 ) -> Result<Vec<u8>, CommandError> {
+    let mut command = program.command();
     command
         .stdin(if input.is_some() {
             Stdio::piped()
@@ -647,7 +643,7 @@ pub mod tests {
     }
 
     #[test]
-    fn run_foreground_reports_how_the_command_exited() -> Result<()> {
+    fn a_foreground_command_reports_how_it_exited() -> Result<()> {
         let test_repo = TestRepo::new()?;
 
         // The command writes to the terminal the test runs in, so it has
@@ -655,6 +651,7 @@ pub mod tests {
         let status = test_repo
             .commander
             .jj(["bookmark", "list"])
+            .foreground()
             .run_foreground()?;
         assert!(status.success());
 

--- a/src/commander/program.rs
+++ b/src/commander/program.rs
@@ -1,0 +1,98 @@
+/*! Running a program, which is what every command of the app comes down
+to.
+
+A [Program] describes what to run, with what and where. It is run with
+the terminal handed over to it ([Program::run_foreground]), or turned
+into a [Command] ([Program::command]) for a caller that drives the child
+process itself.
+*/
+
+use std::ffi::OsStr;
+use std::ffi::OsString;
+use std::io;
+use std::path::PathBuf;
+use std::process::Command;
+use std::process::ExitStatus;
+
+/// A program to run, with the arguments and the environment it is to run
+/// with.
+#[derive(Clone, Debug)]
+pub struct Program {
+    program: OsString,
+    args: Vec<OsString>,
+    /// The working directory the program is run in.
+    dir: PathBuf,
+    env: Vec<(String, String)>,
+}
+
+impl Program {
+    /// The program `program`, run in `dir` with no arguments.
+    pub fn new(program: impl AsRef<OsStr>, dir: impl Into<PathBuf>) -> Self {
+        Self {
+            program: program.as_ref().to_owned(),
+            args: Vec::new(),
+            dir: dir.into(),
+            env: Vec::new(),
+        }
+    }
+
+    /// The program with `args` appended to the arguments it has so far.
+    pub fn args<I, S>(mut self, args: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        self.args
+            .extend(args.into_iter().map(|arg| arg.as_ref().to_owned()));
+        self
+    }
+
+    /// The program with the given variables set in its environment, on
+    /// top of the one the app was started with.
+    pub fn envs(mut self, env: impl IntoIterator<Item = (String, String)>) -> Self {
+        self.env.extend(env);
+        self
+    }
+
+    /// The program as a command to configure and run, for a caller that
+    /// handles the child process itself.
+    pub fn command(&self) -> Command {
+        let mut command = Command::new(&self.program);
+        command.args(&self.args);
+        command.current_dir(&self.dir);
+        command.envs(self.env.iter().cloned());
+        command
+    }
+
+    /// Run the program with the terminal handed over to it, so it can
+    /// page, colorize and prompt as it would outside the app, and return
+    /// how it exited.
+    pub fn run_foreground(&self) -> io::Result<ExitStatus> {
+        self.command().status()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+
+    use super::*;
+
+    #[test]
+    fn run_foreground_reports_how_the_program_exited() -> Result<()> {
+        let program = Program::new("false", ".");
+
+        assert!(!program.run_foreground()?.success());
+
+        Ok(())
+    }
+
+    #[test]
+    fn a_program_that_is_not_there_fails_to_start() {
+        assert!(
+            Program::new("blazingjj-no-such-program", ".")
+                .run_foreground()
+                .is_err()
+        );
+    }
+}

--- a/src/commander/program.rs
+++ b/src/commander/program.rs
@@ -2,17 +2,21 @@
 to.
 
 A [Program] describes what to run, with what and where. It is run with
-the terminal handed over to it ([Program::run_foreground]), or turned
-into a [Command] ([Program::command]) for a caller that drives the child
-process itself.
+the terminal handed over to it ([Program::run_foreground]), left running
+on its own ([Program::run_detached]), or turned into a [Command]
+([Program::command]) for a caller that drives the child process itself.
 */
 
 use std::ffi::OsStr;
 use std::ffi::OsString;
 use std::io;
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
 use std::process::Command;
 use std::process::ExitStatus;
+use std::process::Stdio;
+use std::thread;
 
 /// A program to run, with the arguments and the environment it is to run
 /// with.
@@ -70,10 +74,34 @@ impl Program {
     pub fn run_foreground(&self) -> io::Result<ExitStatus> {
         self.command().status()
     }
+
+    /// Start the program and leave it running on its own, with neither
+    /// the terminal nor anything to say to the app.
+    ///
+    /// It is put in a process group of its own, so that the keys the app
+    /// answers to are not read as signals by it, and waited on in a
+    /// thread of its own, so that it is reaped whenever it exits.
+    pub fn run_detached(&self) -> io::Result<()> {
+        let mut command = self.command();
+        command
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        #[cfg(unix)]
+        command.process_group(0);
+
+        let mut child = command.spawn()?;
+        thread::spawn(move || child.wait());
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+    use std::time::Instant;
+
     use anyhow::Result;
 
     use super::*;
@@ -94,5 +122,23 @@ mod tests {
                 .run_foreground()
                 .is_err()
         );
+        assert!(
+            Program::new("blazingjj-no-such-program", ".")
+                .run_detached()
+                .is_err()
+        );
+    }
+
+    /// A detached program is the app's only in that it started it, so
+    /// the app carries on while it runs.
+    #[test]
+    fn a_detached_program_is_not_waited_for() -> Result<()> {
+        let started = Instant::now();
+
+        Program::new("sleep", ".").args(["3"]).run_detached()?;
+
+        assert!(started.elapsed() < Duration::from_secs(1));
+
+        Ok(())
     }
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -353,35 +353,43 @@ const WIDTH_PLACEHOLDER: &str = "$width";
 /// writes the rendering to standard output; `$width` in an argument stands
 /// for the number of columns it has to render into.
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Hash)]
-#[serde(try_from = "ConfiguredDiffPager")]
+#[serde(try_from = "ConfiguredCommandLine")]
 pub struct DiffPager {
     program: String,
     args: Vec<String>,
 }
 
-/// A pager as it is configured: the program on its own, or a command line
-/// of the program and its arguments.
+/// A command line as it is configured: the program on its own, or the
+/// program and its arguments.
 #[derive(Deserialize)]
 #[serde(untagged)]
-enum ConfiguredDiffPager {
+enum ConfiguredCommandLine {
     Program(String),
     CommandLine(Vec<String>),
 }
 
-impl TryFrom<ConfiguredDiffPager> for DiffPager {
-    type Error = &'static str;
-
-    fn try_from(configured: ConfiguredDiffPager) -> Result<Self, Self::Error> {
-        let (program, args) = match configured {
-            ConfiguredDiffPager::Program(program) => (program, Vec::new()),
-            ConfiguredDiffPager::CommandLine(mut command_line) => {
+impl ConfiguredCommandLine {
+    /// The program to run and the arguments to run it with, refused when
+    /// there is no program to run.
+    fn split(self) -> Result<(String, Vec<String>), &'static str> {
+        match self {
+            ConfiguredCommandLine::Program(program) => Ok((program, Vec::new())),
+            ConfiguredCommandLine::CommandLine(mut command_line) => {
                 if command_line.is_empty() {
-                    return Err("a diff pager needs a program to run");
+                    return Err("a command line needs a program to run");
                 }
                 let args = command_line.split_off(1);
-                (command_line.remove(0), args)
+                Ok((command_line.remove(0), args))
             }
-        };
+        }
+    }
+}
+
+impl TryFrom<ConfiguredCommandLine> for DiffPager {
+    type Error = &'static str;
+
+    fn try_from(configured: ConfiguredCommandLine) -> Result<Self, Self::Error> {
+        let (program, args) = configured.split()?;
 
         Ok(Self { program, args })
     }
@@ -567,7 +575,7 @@ mod tests {
         let error = toml::from_str::<JjConfig>("blazingjj.diff-pager = []\n")
             .expect_err("a pager without a program is an error");
         assert!(
-            error.to_string().contains("a diff pager needs a program"),
+            error.to_string().contains("a command line needs a program"),
             "the error does not say what is wrong: {error}"
         );
     }

--- a/src/env.rs
+++ b/src/env.rs
@@ -120,6 +120,8 @@ pub struct JjConfigBlazingjj {
     diff_format: Option<ConfiguredDiffFormat>,
     diff_tool: Option<String>,
     diff_pager: Option<DiffPager>,
+    editor: Option<Editor>,
+    editor_mode: EditorMode,
     bookmark_template: Option<String>,
     confirm_push: bool,
     layout: JJLayout,
@@ -146,6 +148,8 @@ impl Default for JjConfigBlazingjj {
             diff_format: None,
             diff_tool: None,
             diff_pager: None,
+            editor: None,
+            editor_mode: EditorMode::default(),
             bookmark_template: None,
             layout: JJLayout::default(),
             keybinds: None,
@@ -231,6 +235,19 @@ impl JjConfig {
     /// Whether a push is to be shown and asked about before it is sent.
     pub fn confirm_push(&self) -> bool {
         self.blazingjj.confirm_push
+    }
+
+    /// The editor a file is opened in, which the environment names while
+    /// the configuration says nothing about it.
+    pub fn editor(&self) -> Option<Editor> {
+        self.blazingjj
+            .editor
+            .clone()
+            .or_else(Editor::from_environment)
+    }
+
+    pub fn editor_mode(&self) -> EditorMode {
+        self.blazingjj.editor_mode
     }
 
     pub fn highlight_color(&self) -> Color {
@@ -329,6 +346,84 @@ pub enum DescribeMode {
     #[default]
     Popup,
     Jj,
+}
+
+/// What an editor argument says to have the file to open substituted
+/// into it
+const FILE_PLACEHOLDER: &str = "$file";
+
+/// The editor a file is opened in, like `nvim`. `$file` in an argument
+/// stands for the file to open; an editor whose arguments say nothing
+/// about it is given it as the last one.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
+#[serde(try_from = "ConfiguredCommandLine")]
+pub struct Editor {
+    program: String,
+    args: Vec<String>,
+}
+
+impl TryFrom<ConfiguredCommandLine> for Editor {
+    type Error = &'static str;
+
+    fn try_from(configured: ConfiguredCommandLine) -> Result<Self, Self::Error> {
+        let (program, args) = configured.split()?;
+
+        Ok(Self { program, args })
+    }
+}
+
+impl Editor {
+    /// The editor the environment names, which is what the app opens a
+    /// file in while `blazingjj.editor` says nothing.
+    fn from_environment() -> Option<Self> {
+        ["VISUAL", "EDITOR"]
+            .into_iter()
+            .filter_map(|variable| std::env::var(variable).ok())
+            .find_map(|command_line| Self::from_command_line(&command_line))
+    }
+
+    /// The editor `command_line` names, reading it as a shell would,
+    /// arguments and all. One that names no program, whether because it
+    /// is empty or because it does not read as a command line at all,
+    /// names no editor.
+    fn from_command_line(command_line: &str) -> Option<Self> {
+        let words = shell_words::split(command_line).ok()?;
+        let (program, args) = ConfiguredCommandLine::CommandLine(words).split().ok()?;
+
+        Some(Self { program, args })
+    }
+
+    pub fn program(&self) -> &str {
+        &self.program
+    }
+
+    /// The arguments to open `file` with, which is appended when no
+    /// argument asks for it.
+    pub fn args(&self, file: &str) -> Vec<String> {
+        let mut args: Vec<String> = self
+            .args
+            .iter()
+            .map(|arg| arg.replace(FILE_PLACEHOLDER, file))
+            .collect();
+        if !self.args.iter().any(|arg| arg.contains(FILE_PLACEHOLDER)) {
+            args.push(file.to_owned());
+        }
+
+        args
+    }
+}
+
+/// How the app runs the editor a file is opened in.
+#[derive(Clone, Copy, Debug, Deserialize, Default, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum EditorMode {
+    /// Hand the terminal over to the editor and take it back once it is
+    /// done, as a terminal editor needs.
+    #[default]
+    Terminal,
+    /// Leave the editor running on its own and carry on, as an editor
+    /// with a window of its own is used.
+    Detached,
 }
 
 /// A diff format as `blazingjj.diff-format` and `ui.diff.format` name it.
@@ -532,6 +627,13 @@ mod tests {
             .expect("the setting configures a pager")
     }
 
+    /// The editor the given `blazingjj.editor` value configures
+    fn editor(setting: &str) -> Editor {
+        config(&format!("blazingjj.editor = {setting}\n"))
+            .editor()
+            .expect("the setting configures an editor")
+    }
+
     #[test]
     fn only_formats_that_scale_are_told_the_panel_width() {
         for format in [
@@ -594,6 +696,42 @@ mod tests {
             ["--line-numbers"],
             "an argument asking for a width there is none of is left out"
         );
+    }
+
+    #[test]
+    fn an_editor_is_configured_as_a_program_or_as_a_command_line() {
+        let program = editor(r#""nvim""#);
+        assert_eq!(program.program(), "nvim");
+        assert_eq!(program.args("src/main.rs"), ["src/main.rs"]);
+
+        let command_line = editor(r#"["code", "--wait"]"#);
+        assert_eq!(command_line.program(), "code");
+        assert_eq!(command_line.args("src/main.rs"), ["--wait", "src/main.rs"]);
+    }
+
+    /// An editor that takes the file among its arguments rather than
+    /// after them says where it goes, and is given it nowhere else.
+    #[test]
+    fn an_argument_asking_for_the_file_is_given_it() {
+        let editor = editor(r#"["kak", "-e", "edit $file", "--"]"#);
+
+        assert_eq!(editor.args("src/main.rs"), ["-e", "edit src/main.rs", "--"]);
+    }
+
+    /// `VISUAL` and `EDITOR` hold a command line rather than a program,
+    /// and one naming no program is one to look past: the next variable
+    /// still gets its say, as does the app's own message about there
+    /// being no editor.
+    #[test]
+    fn an_editor_variable_is_read_as_a_shell_would() {
+        let editor =
+            Editor::from_command_line("code --wait").expect("the variable names an editor");
+        assert_eq!(editor.program(), "code");
+        assert_eq!(editor.args("a.txt"), ["--wait", "a.txt"]);
+
+        assert_eq!(Editor::from_command_line(""), None);
+        assert_eq!(Editor::from_command_line("   "), None);
+        assert_eq!(Editor::from_command_line("nvim 'unbalanced"), None);
     }
 
     #[test]

--- a/src/env.rs
+++ b/src/env.rs
@@ -122,6 +122,7 @@ pub struct JjConfigBlazingjj {
     diff_pager: Option<DiffPager>,
     editor: Option<Editor>,
     editor_mode: EditorMode,
+    editor_url: Option<String>,
     bookmark_template: Option<String>,
     confirm_push: bool,
     layout: JJLayout,
@@ -150,6 +151,7 @@ impl Default for JjConfigBlazingjj {
             diff_pager: None,
             editor: None,
             editor_mode: EditorMode::default(),
+            editor_url: None,
             bookmark_template: None,
             layout: JJLayout::default(),
             keybinds: None,
@@ -248,6 +250,19 @@ impl JjConfig {
 
     pub fn editor_mode(&self) -> EditorMode {
         self.blazingjj.editor_mode
+    }
+
+    /// What names `path` at `revision` to an editor that opens a file at
+    /// a revision of its own accord, for as long as one is configured.
+    /// It goes to the editor in place of the file to open.
+    pub fn editor_url(&self, revision: &str, path: &str) -> Option<String> {
+        Some(
+            self.blazingjj
+                .editor_url
+                .as_ref()?
+                .replace(REVISION_PLACEHOLDER, revision)
+                .replace(FILE_PLACEHOLDER, path),
+        )
     }
 
     pub fn highlight_color(&self) -> Color {
@@ -351,6 +366,10 @@ pub enum DescribeMode {
 /// What an editor argument says to have the file to open substituted
 /// into it
 const FILE_PLACEHOLDER: &str = "$file";
+
+/// What an editor URL says to have the revision to open the file at
+/// substituted into it
+const REVISION_PLACEHOLDER: &str = "$revision";
 
 /// The editor a file is opened in, like `nvim`. `$file` in an argument
 /// stands for the file to open; an editor whose arguments say nothing
@@ -732,6 +751,20 @@ mod tests {
         assert_eq!(Editor::from_command_line(""), None);
         assert_eq!(Editor::from_command_line("   "), None);
         assert_eq!(Editor::from_command_line("nvim 'unbalanced"), None);
+    }
+
+    #[test]
+    fn an_editor_url_names_the_file_and_the_revision_it_is_read_at() {
+        let config = config(r#"blazingjj.editor-url = "jj://$revision/$file""#);
+
+        assert_eq!(
+            config.editor_url("kmxqmnmr", "src/main.rs").as_deref(),
+            Some("jj://kmxqmnmr/src/main.rs")
+        );
+        assert_eq!(
+            JjConfig::default().editor_url("kmxqmnmr", "src/main.rs"),
+            None
+        );
     }
 
     #[test]

--- a/src/keybinds/config.rs
+++ b/src/keybinds/config.rs
@@ -148,6 +148,7 @@ pub struct LogTabKeybindsConfig {
 pub struct FilesTabKeybindsConfig {
     pub untrack: Option<Keybind>,
     pub restore: Option<Keybind>,
+    pub open: Option<Keybind>,
 }
 
 #[derive(Debug, Clone, serde::Deserialize)]

--- a/src/keybinds/files_tab.rs
+++ b/src/keybinds/files_tab.rs
@@ -23,6 +23,7 @@ pub struct FilesTabKeybinds {
 pub enum FilesTabEvent {
     Untrack,
     Restore,
+    Open,
 
     Unbound,
 }
@@ -34,6 +35,7 @@ impl Default for FilesTabKeybinds {
             keys,
             FilesTabEvent::Untrack => "x",
             FilesTabEvent::Restore => "r",
+            FilesTabEvent::Open => "o",
         );
         Self { keys }
     }
@@ -59,6 +61,7 @@ impl FilesTabKeybinds {
             self.keys,
             FilesTabEvent::Untrack => config.untrack,
             FilesTabEvent::Restore => config.restore,
+            FilesTabEvent::Open => config.open,
         );
     }
 
@@ -73,6 +76,7 @@ impl FilesTabKeybinds {
             self.keys, Self::default().keys, Context::FilesTab,
             FilesTabEvent::Untrack => "untrack", Some(Section::Files), "untrack file",
             FilesTabEvent::Restore => "restore", Some(Section::Files), "restore file",
+            FilesTabEvent::Open => "open", Some(Section::Files), "open file in editor",
         )
     }
 }
@@ -101,6 +105,7 @@ mod tests {
                 Shortcut::from_str("u").expect("shortcut should parse"),
             )),
             restore: Some(Keybind::Enable(false)),
+            open: None,
         };
 
         let mut keybinds = FilesTabKeybinds::default();

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,10 +212,10 @@ fn run_interactive(
 
     let ran = {
         let _interrupts = catch_interrupts();
-        match interactive.command.run_foreground() {
+        match interactive.program.run_foreground() {
             Ok(status) => status.success(),
             Err(err) => {
-                println!("Could not run jj: {err}");
+                println!("Could not run the command: {err}");
                 false
             }
         }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -171,6 +171,13 @@ pub const SETTINGS: &[Setting] = &[
         kind: SettingKind::Choice(&["terminal", "detached"]),
     },
     Setting {
+        key: "blazingjj.editor-url",
+        section: "Files",
+        doc: "What names a file at a revision to an editor that reads revisions itself, like `jj://$revision/$file`. Setting it offers opening a file at the revision shown, without checking anything out.",
+        fallback: "no such editor",
+        kind: SettingKind::Text,
+    },
+    Setting {
         key: "blazingjj.describe-mode",
         section: "Changes",
         doc: "What describing a change puts up: the built-in editor, or `jj describe` with the terminal and your own editor.",
@@ -276,6 +283,12 @@ mod tests {
         assert_eq!(
             set("blazingjj.editor-mode", "\"detached\"").editor_mode(),
             EditorMode::Detached
+        );
+        assert_eq!(
+            set("blazingjj.editor-url", "\"jj://$revision/$file\"")
+                .editor_url("kmxqmnmr", "a.txt")
+                .as_deref(),
+            Some("jj://kmxqmnmr/a.txt")
         );
         assert_eq!(
             set("blazingjj.layout", "\"vertical\"").layout(),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -157,6 +157,20 @@ pub const SETTINGS: &[Setting] = &[
         kind: SettingKind::Text,
     },
     Setting {
+        key: "blazingjj.editor",
+        section: "Files",
+        doc: "The editor a file is opened in, like `code --wait $file`. $file stands for the file to open, and is passed as the last argument when no argument names it.",
+        fallback: "$VISUAL, else $EDITOR",
+        kind: SettingKind::CommandLine,
+    },
+    Setting {
+        key: "blazingjj.editor-mode",
+        section: "Files",
+        doc: "How the editor is run: with the terminal handed over to it, or left running on its own, as an editor with a window of its own is.",
+        fallback: "terminal",
+        kind: SettingKind::Choice(&["terminal", "detached"]),
+    },
+    Setting {
         key: "blazingjj.describe-mode",
         section: "Changes",
         doc: "What describing a change puts up: the built-in editor, or `jj describe` with the terminal and your own editor.",
@@ -195,6 +209,7 @@ mod tests {
     use super::*;
     use crate::env::DescribeMode;
     use crate::env::DiffFormat;
+    use crate::env::EditorMode;
     use crate::env::JJLayout;
     use crate::env::JjConfig;
 
@@ -251,6 +266,16 @@ mod tests {
         assert_eq!(
             set("blazingjj.describe-mode", "\"jj\"").describe_mode(),
             DescribeMode::Jj
+        );
+        assert_eq!(
+            set("blazingjj.editor", "\"nvim\"")
+                .editor()
+                .map(|editor| editor.program().to_owned()),
+            Some("nvim".to_owned())
+        );
+        assert_eq!(
+            set("blazingjj.editor-mode", "\"detached\"").editor_mode(),
+            EditorMode::Detached
         );
         assert_eq!(
             set("blazingjj.layout", "\"vertical\"").layout(),

--- a/src/ui/dialog/command.rs
+++ b/src/ui/dialog/command.rs
@@ -108,7 +108,7 @@ fn popup(title: String, output: String) -> AppAction {
 /// command is done so that what it printed can be read.
 fn run_interactively(command: JjCommand) -> AppAction {
     AppAction::RunInteractive(Interactive {
-        command,
+        program: command.foreground(),
         hold_screen: true,
     })
 }

--- a/src/ui/dialog/context_menu.rs
+++ b/src/ui/dialog/context_menu.rs
@@ -99,13 +99,16 @@ pub fn log_context_menu(
     Ok(ChoicePopup::new(config, anchor, "Actions", items))
 }
 
-/// The context menu for `file`.
-pub fn files_context_menu(config: JjConfig, anchor: Option<Position>, file: &File) -> ChoicePopup {
+/// The context menu for `file`, `open` being what opening it in an
+/// editor takes, which depends on what the tab is showing.
+pub fn files_context_menu(
+    config: JjConfig,
+    anchor: Option<Position>,
+    file: &File,
+    open: AppAction,
+) -> ChoicePopup {
     let items = vec![
-        (
-            Line::raw("Open in editor"),
-            AppAction::Run(Command::OpenFile(file.clone())),
-        ),
+        (Line::raw("Open in editor"), open),
         (
             Line::raw("Restore"),
             AppAction::Run(Command::RestoreFile(file.clone())),

--- a/src/ui/dialog/context_menu.rs
+++ b/src/ui/dialog/context_menu.rs
@@ -103,6 +103,10 @@ pub fn log_context_menu(
 pub fn files_context_menu(config: JjConfig, anchor: Option<Position>, file: &File) -> ChoicePopup {
     let items = vec![
         (
+            Line::raw("Open in editor"),
+            AppAction::Run(Command::OpenFile(file.clone())),
+        ),
+        (
             Line::raw("Restore"),
             AppAction::Run(Command::RestoreFile(file.clone())),
         ),

--- a/src/ui/dialog/describe.rs
+++ b/src/ui/dialog/describe.rs
@@ -49,7 +49,9 @@ pub fn describe_action(
             AppAction::SetPopup(Box::new(DescribePopup::new(head.clone(), seed()?)))
         }
         DescribeMode::Jj => AppAction::RunInteractive(Interactive {
-            command: new_commander().jj(["describe", head.commit_id.as_str()]),
+            program: new_commander()
+                .jj(["describe", head.commit_id.as_str()])
+                .foreground(),
             hold_screen: false,
         }),
     })

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -10,6 +10,8 @@ use tracing::instrument;
 
 use crate::app::TabId;
 use crate::app::command::Command;
+use crate::app::command::OpenAt;
+use crate::app::command::ask_open_file;
 use crate::background_tasks::BackgroundTasks;
 use crate::background_tasks::TaskOutput;
 use crate::background_tasks::TaskResult;
@@ -239,7 +241,22 @@ impl FilesTab {
             get_env().jj_config.clone(),
             anchor,
             file,
+            self.open(file),
         ))))
+    }
+
+    /// Opening `file` in an editor: the file itself while the tab is on
+    /// the working copy, and otherwise the question of which version of
+    /// it to open, the tab showing one the working copy does not have.
+    fn open(&self, file: &File) -> AppAction {
+        if self.is_current_head && !self.pinned {
+            return AppAction::Run(Command::OpenFile {
+                file: file.clone(),
+                at: OpenAt::WorkingCopy,
+            });
+        }
+
+        ask_open_file(get_env().jj_config.clone(), &self.head, file)
     }
 
     fn handle_event(&mut self, event: FilesTabEvent) -> Result<Option<AppAction>> {
@@ -252,10 +269,7 @@ impl FilesTab {
                 .file
                 .clone()
                 .map(|file| AppAction::Run(Command::RestoreFile(file)))),
-            FilesTabEvent::Open => Ok(self
-                .file
-                .clone()
-                .map(|file| AppAction::Run(Command::OpenFile(file)))),
+            FilesTabEvent::Open => Ok(self.file.as_ref().map(|file| self.open(file))),
             // Not an operation of its own; the key handler deals with it.
             FilesTabEvent::Unbound => Ok(None),
         }

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -126,6 +126,19 @@ impl OutputKey for FileDiffKey {
     }
 }
 
+/// How the revision the tab is on is named to something outside the app:
+/// by its change id, so that it is read as the change stands, except
+/// where what is shown is not the change as it stands. A version out of
+/// the evolog and one of several divergent commits are both only to be
+/// found by their commit id.
+fn shown_revision(head: &Head, pinned: bool) -> &str {
+    if pinned || head.divergent {
+        head.commit_id.as_str()
+    } else {
+        head.change_id.as_str()
+    }
+}
+
 fn get_current_file_index(
     current_file: Option<&File>,
     files_output: Result<&Vec<File>, &CommandError>,
@@ -256,7 +269,12 @@ impl FilesTab {
             });
         }
 
-        ask_open_file(get_env().jj_config.clone(), &self.head, file)
+        ask_open_file(
+            get_env().jj_config.clone(),
+            &self.head,
+            shown_revision(&self.head, self.pinned),
+            file,
+        )
     }
 
     fn handle_event(&mut self, event: FilesTabEvent) -> Result<Option<AppAction>> {
@@ -558,6 +576,29 @@ mod tests {
 
     fn key(change_id: &str, commit_id: &str, path: &str) -> FileDiffKey {
         FileDiffKey::new((head(change_id, commit_id), file(path)), DiffFormat::Git)
+    }
+
+    /// The change id is what an editor is given, so that it opens the
+    /// file as the change stands rather than as it stood when the tab
+    /// last read it.
+    #[test]
+    fn a_change_is_named_by_its_change_id_while_it_is_shown_as_it_stands() {
+        let head = head("change", "commit");
+
+        assert_eq!(shown_revision(&head, false), "change");
+        assert_eq!(
+            shown_revision(&head, true),
+            "commit",
+            "a version out of the evolog is only found by its commit id"
+        );
+
+        let mut divergent = head.clone();
+        divergent.divergent = true;
+        assert_eq!(
+            shown_revision(&divergent, false),
+            "commit",
+            "a change id names several commits while a change is divergent"
+        );
     }
 
     #[test]

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -252,6 +252,10 @@ impl FilesTab {
                 .file
                 .clone()
                 .map(|file| AppAction::Run(Command::RestoreFile(file)))),
+            FilesTabEvent::Open => Ok(self
+                .file
+                .clone()
+                .map(|file| AppAction::Run(Command::OpenFile(file)))),
             // Not an operation of its own; the key handler deals with it.
             FilesTabEvent::Unbound => Ok(None),
         }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -19,8 +19,8 @@ use ratatui::layout::Rect;
 use crate::app::TabId;
 use crate::app::command::Command;
 use crate::background_tasks::TaskResult;
-use crate::commander::JjCommand;
 use crate::commander::log::Head;
+use crate::commander::program::Program;
 use crate::event::Mouse;
 use crate::keybinds::Binding;
 
@@ -62,9 +62,9 @@ pub enum AppAction {
     RunInteractive(Interactive),
 }
 
-/// A command to run with the terminal handed over to it.
+/// A program to run with the terminal handed over to it.
 pub struct Interactive {
-    pub command: JjCommand,
+    pub program: Program,
     /// Whether to wait for the user before taking the screen back. Off for
     /// a command run for its effect, whose output is beside the point
     /// unless it failed.


### PR DESCRIPTION
The files tab can diff, restore and untrack a file, but there is no way
to get at the file itself, so editing what you are looking at means
leaving the app. Add `o` on a file, which opens it in an editor named by
`blazingjj.editor` or `$VISUAL`/`$EDITOR`.

Since the tab shows the files of whatever change is selected while the
disk only ever holds the working copy's version, opening asks which
version is meant: the one on disk, the change's own version (checking it
out to get at it), or that version through a change of our own on top.
Editors like neovim with jj.nvim can read a revision themselves, so
`blazingjj.editor-url` takes the URL such an editor is given
(`jj://$revision/$file`) and adds that as a further choice, the only one
available for an immutable change. Editors with a window of their own
cannot have the terminal handed to them, hence `blazingjj.editor-mode`
and its `detached` setting.