### PR TITLE
ci: Provide nightly and dev preview builds

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,0 +1,18 @@
+name: Dev preview
+
+on:
+  push:
+    branches:
+      - dev
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  preview-release:
+    permissions:
+      contents: write
+    uses: ./.github/workflows/preview-release.yml
+    with:
+      tag: dev
+      title: Dev preview

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,17 @@
+name: Nightly
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  preview-release:
+    permissions:
+      contents: write
+    uses: ./.github/workflows/preview-release.yml
+    with:
+      tag: nightly
+      title: Nightly

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -1,0 +1,93 @@
+name: Preview release
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: Tag and release to update in place
+        required: true
+        type: string
+      title:
+        description: Release title
+        required: true
+        type: string
+
+permissions: read-all
+
+env:
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  create-release:
+    name: Create GitHub prerelease
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Point tag at the built commit
+        run: |
+          git tag -f "${{ inputs.tag }}"
+          git push --force origin "refs/tags/${{ inputs.tag }}"
+      - name: Create or update release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          notes="Preview build of \`${{ github.ref_name }}\` at ${{ github.sha }}, built $(date -u '+%Y-%m-%d %H:%M UTC').
+
+          This is not a release: it gets overwritten whenever the branch moves
+          and is not published to crates.io."
+          if gh release view "${{ inputs.tag }}" > /dev/null 2>&1; then
+            gh release edit "${{ inputs.tag }}" --title "${{ inputs.title }}" --notes "$notes" --prerelease
+          else
+            gh release create "${{ inputs.tag }}" --title "${{ inputs.title }}" --notes "$notes" --prerelease
+          fi
+  publish-binaries:
+    name: Publish binaries
+    needs: create-release
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        build: [linux-musl, macos-x86_64, macos-aarch64, win-msvc]
+        include:
+          - build: linux-musl
+            os: ubuntu-22.04
+            target: x86_64-unknown-linux-musl
+          - build: macos-x86_64
+            os: macos-14
+            target: x86_64-apple-darwin
+          - build: macos-aarch64
+            os: macos-14
+            target: aarch64-apple-darwin
+          - build: win-msvc
+            os: windows-2022
+            target: x86_64-pc-windows-msvc
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          target: ${{ matrix.target }}
+      - name: Build release binary
+        run: cargo build --target ${{ matrix.target }} --verbose --release --locked
+      - name: Build archive
+        shell: bash
+        run: |
+          outdir="target/${{ matrix.target }}/release"
+          name="blazingjj-${{ inputs.tag }}-${{ matrix.target }}"
+          cd "$outdir"
+          if [ "${{ matrix.os }}" = "windows-2022" ]; then
+            7z a "../../../$name.zip" blazingjj.exe
+            echo "ASSET=$name.zip" >> $GITHUB_ENV
+          else
+            tar czf "../../../$name.tar.gz" blazingjj
+            echo "ASSET=$name.tar.gz" >> $GITHUB_ENV
+          fi
+      - name: Upload release archive
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run:
+          gh release upload "${{ inputs.tag }}" "${{ env.ASSET }}" --clobber

--- a/README.md
+++ b/README.md
@@ -85,6 +85,21 @@ Make sure you have [`jj`](https://martinvonz.github.io/jj/latest/install-and-set
 
 To build and install a pre-release version: `cargo install --git https://github.com/blazingjj/blazingjj.git --locked`
 
+> [!NOTE]
+> Want to try unreleased changes without compiling them yourself? We have
+> a nightly build of the main branch along with a dev preview branch that
+> contains features that are still rough around the edges, waiting for review or
+> might even get dropped in the future. The prereleases carry pre-built
+> binaries for the same platforms as a real release, rebuilt and replaced in
+> place and they are not published to crates.io.
+>
+> - [`nightly`](https://github.com/blazingjj/blazingjj/releases/tag/nightly):
+>   `main`, rebuilt every night.
+> - [`dev`](https://github.com/blazingjj/blazingjj/releases/tag/dev): the `dev`
+>   branch, rebuilt on every push.
+>
+> These are previews for testing only, their tags move, so don't pin anything to them.
+
 ## Configuration
 
 You can optionally configure the following options through your jj config:


### PR DESCRIPTION
Handing out binaries for testing something ahead of a release currently means building them by hand for every platform. Two schedule/push triggered workflows now share a reusable one that produces the same archives as a real release, attached to a prerelease that is rewritten in place: the "nightly" tag follows main once a night, "dev" follows every push to that branch. Neither publishes to crates.io, since these are previews and not versions anyone should depend on, and the tag is force-moved to the built commit so the release keeps pointing at what its assets contain.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
