### PR TITLE
ci: Fix the preview release workflow failing to start

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -12,7 +12,8 @@ on:
         required: true
         type: string
 
-permissions: read-all
+# No workflow-wide permissions: as a called workflow we cannot ask for more
+# than the calling job was granted, and the jobs below state what they need.
 
 env:
   CARGO_INCREMENTAL: 0


### PR DESCRIPTION
The reusable workflow declares "permissions: read-all", which it inherited from the release workflow it was derived from. A called workflow can only narrow the token its caller was granted, so asking for read on every scope while the calling job holds nothing but "contents: write" makes the run fail before any job starts. The jobs already state what they need, so drop the workflow-wide grant.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
