### PR TITLE
ci: Keep preview release tags out of the branch history

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -14,5 +14,5 @@ jobs:
       contents: write
     uses: ./.github/workflows/preview-release.yml
     with:
-      tag: dev
+      tag: dev-preview
       title: Dev preview

--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -26,9 +26,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Point tag at the built commit
+      - name: Point tag at an empty commit outside of history
         run: |
-          git tag -f "${{ inputs.tag }}"
+          # A tag on the built commit would make it and its ancestors
+          # immutable in jj, so anchor the release on a parentless commit with
+          # an empty tree: it has no ancestors to drag along and belongs to no
+          # branch. The source archives GitHub derives from it are empty,
+          # hence the pointer to the built commit in the notes below.
+          tree=$(git hash-object -w -t tree /dev/null)
+          commit=$(
+            git -c "user.name=github-actions[bot]" \
+                -c "user.email=41898282+github-actions[bot]@users.noreply.github.com" \
+                commit-tree "$tree" \
+                -m "${{ inputs.title }} of ${{ github.sha }}"
+          )
+          git tag -f "${{ inputs.tag }}" "$commit"
           git push --force origin "refs/tags/${{ inputs.tag }}"
       - name: Create or update release
         env:
@@ -37,7 +49,8 @@ jobs:
           notes="Preview build of \`${{ github.ref_name }}\` at ${{ github.sha }}, built $(date -u '+%Y-%m-%d %H:%M UTC').
 
           This is not a release: it gets overwritten whenever the branch moves
-          and is not published to crates.io."
+          and is not published to crates.io. Take the binaries below; the tag
+          and the source archives carry nothing."
           if gh release view "${{ inputs.tag }}" > /dev/null 2>&1; then
             gh release edit "${{ inputs.tag }}" --title "${{ inputs.title }}" --notes "$notes" --prerelease
           else

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ To build and install a pre-release version: `cargo install --git https://github.
 > - [`dev`](https://github.com/blazingjj/blazingjj/releases/tag/dev): the `dev`
 >   branch, rebuilt on every push.
 >
-> These are previews for testing only, their tags move, so don't pin anything to them.
+> These are previews for testing only, their tags move and carry no source, so
+> don't pin anything to them.
 
 ## Configuration
 


### PR DESCRIPTION
The "nightly" and "dev" tags point at the commit they were built from, which puts that commit and all of its ancestors into jj's immutable_heads(), so working on a change that has been through a preview build takes --ignore-immutable. Anchor the releases on a parentless commit with an empty tree instead: nothing is reachable from it, so nothing becomes immutable, and the built commit is named in the release notes, which is all a preview needs it for. The price is that GitHub's source archives for those tags are empty, which the notes and the README now say.

Also, jj preferring tag names over bookmarks makes it awkward to work with `dev` as the tag name for the preview, use dev-preview instead.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
