### PR TITLE
app: Handle a stale working copy instead of dying on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - A stale working copy no longer makes the app fail to start: it asks whether
   to update it, and quits if you would rather do it yourself
+- A working copy that goes stale while the app is running now puts the same
+  question up, rather than taking the app down or leaving jj's error where
+  the panels should be. Saying no leaves the tabs where they are until the
+  next refresh
 - `@` in the bookmarks tab now goes to the bookmark on the working copy, or to
   the one it is standing on, rather than doing nothing while the help offers it
 - A keybinding on Home, End or the space bar now shows the key's name rather

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A stale working copy no longer makes the app fail to start: it asks whether
+  to update it, and quits if you would rather do it yourself
 - `@` in the bookmarks tab now goes to the bookmark on the working copy, or to
   the one it is standing on, rather than doing nothing while the help offers it
 - A keybinding on Home, End or the space bar now shows the key's name rather

--- a/src/app.rs
+++ b/src/app.rs
@@ -24,6 +24,7 @@ use tracing::instrument;
 use tracing::trace;
 use tracing::warn;
 
+use crate::app::command::ask_update_stale_workspace;
 use crate::app::repo_watch::Check;
 use crate::app::repo_watch::Moment;
 use crate::app::repo_watch::RepoWatch;
@@ -32,6 +33,7 @@ use crate::background_tasks::TaskOutput;
 use crate::background_tasks::TaskResult;
 use crate::background_tasks::TaskSlot;
 use crate::commander::ids::OperationId;
+use crate::commander::is_stale_working_copy;
 use crate::commander::new_commander;
 use crate::env::get_env;
 use crate::env::reload_env;
@@ -238,6 +240,9 @@ pub struct App<'a> {
     popup_keybinds: PopupKeybinds,
 
     repo_watch: RepoWatch,
+    /// Whether jj refuses to read the repo until the working copy is
+    /// updated, which the user has been asked about.
+    stale_workspace: bool,
 
     /// Interactive command queued by a component for the main loop to run
     /// after restoring the terminal.
@@ -278,6 +283,7 @@ impl<'a> App<'a> {
             popup_keybinds: PopupKeybinds::dialog(),
 
             repo_watch: RepoWatch::new(get_env().jj_config.poll_interval(), Instant::now()),
+            stale_workspace: false,
             pending_interactive: None,
 
             running,
@@ -372,13 +378,35 @@ impl<'a> App<'a> {
 
         let stale = self.get_current_tab().is_stale();
         let hint_changed = self.repo_watch.leave_stale(stale);
-        if self.repo_watch.waiting_for_refresh() || !stale {
+        // A stale working copy is one the user has been asked about, and
+        // jj reads nothing until it is updated, so the tabs stay behind
+        // rather than asking again for every frame.
+        if self.repo_watch.waiting_for_refresh() || !stale || self.stale_workspace {
             return Ok(hint_changed);
         }
 
-        self.get_current_tab().refresh()?;
+        if let Err(err) = self.get_current_tab().refresh() {
+            if !is_stale_working_copy(&err) {
+                return Err(err);
+            }
+            self.ask_about_stale_workspace()?;
+        }
 
         Ok(true)
+    }
+
+    /// Put the question whether to update a stale working copy, which jj
+    /// refuses to read the repo until. It is only asked once, as a no is
+    /// an answer to leave alone until the repo can be read again.
+    fn ask_about_stale_workspace(&mut self) -> Result<()> {
+        // Whatever else is up was asked for, so it stays and the
+        // question comes back with the next read that fails.
+        if self.stale_workspace || self.popup.is_some() {
+            return Ok(());
+        }
+        self.stale_workspace = true;
+
+        self.handle_action(ask_update_stale_workspace(get_env().jj_config.clone()))
     }
 
     /// Read what operation the repo is at, keeping the slot until the
@@ -396,9 +424,18 @@ impl<'a> App<'a> {
 
     /// Take what a check found and mark every tab stale if the repo has
     /// moved since the last one.
-    fn repo_checked(&mut self, output: TaskOutput) {
+    fn repo_checked(&mut self, output: TaskOutput) -> Result<()> {
         let op_id = match output {
-            Ok(op_id) => Some(OperationId(op_id)),
+            Ok(op_id) => {
+                // The repo reads, so whatever was stale about the
+                // working copy has been dealt with.
+                self.stale_workspace = false;
+                Some(OperationId(op_id))
+            }
+            Err(err) if is_stale_working_copy(&err) => {
+                self.ask_about_stale_workspace()?;
+                None
+            }
             Err(err) => {
                 warn!("Could not read what the repo is at: {err}");
                 None
@@ -409,6 +446,8 @@ impl<'a> App<'a> {
             trace!("The repo has moved, so every tab is stale");
             self.mark_all_stale();
         }
+
+        Ok(())
     }
 
     /// Take up the configuration as it now reads, which every tab and
@@ -726,7 +765,7 @@ impl<'a> App<'a> {
             // The check is the app's own, and puts nothing on screen
             // itself.
             TaskSlot::RepoOpId => {
-                self.repo_checked(result.output);
+                self.repo_checked(result.output)?;
                 return Ok(Handled::Nothing);
             }
             TaskSlot::CommitShow(tab, _)
@@ -893,6 +932,10 @@ impl<'a> App<'a> {
                                     snapshot: true,
                                     ours: true,
                                 });
+                                // Asking for a read is asking to be told
+                                // again should it be a stale working copy
+                                // that stands in the way.
+                                self.stale_workspace = false;
                                 self.get_current_tab().drop_caches();
                                 // The check above is the one we want, so
                                 // there is nothing left but to have every

--- a/src/app/command.rs
+++ b/src/app/command.rs
@@ -173,6 +173,9 @@ pub enum Command {
     UnsetSetting {
         key: String,
     },
+    /// Update the working copy jj refuses to read the repo until it is
+    /// updated.
+    UpdateStaleWorkspace,
 }
 
 impl Command {
@@ -315,6 +318,12 @@ impl Command {
                 TaskSlot::GitFetch,
                 move || Ok(new_commander().git_fetch(all_remotes)?),
             ))),
+            Command::UpdateStaleWorkspace => match new_commander().update_stale_workspace() {
+                // The working copy is where the repo says it is now,
+                // which is not where any tab last read it.
+                Ok(_) => Ok(Some(repo_moved()?)),
+                Err(err) => Ok(Some(refused("Update", err))),
+            },
             Command::RestoreOperation(id) => match new_commander().run_op_restore(&id) {
                 Ok(()) => Ok(Some(repo_moved()?)),
                 Err(err) => Ok(Some(refused("Restore", err))),
@@ -923,6 +932,22 @@ pub fn ask_set_bookmark(config: JjConfig, bookmark: &Bookmark, head: &Head) -> A
             commit_id: head.commit_id.clone(),
             dialog: None,
         },
+    )
+}
+
+/// Asking whether to update a stale working copy, which jj refuses to
+/// read the repo until.
+pub fn ask_update_stale_workspace(config: JjConfig) -> AppAction {
+    confirm(
+        config,
+        "Stale working copy",
+        Text::from(vec![
+            Line::from("The working copy is stale: the repo has moved on since it was last"),
+            Line::from("updated, and jj reads nothing here until it is updated."),
+            Line::from(""),
+            Line::from("Update it now?"),
+        ]),
+        Command::UpdateStaleWorkspace,
     )
 }
 

--- a/src/commander/mod.rs
+++ b/src/commander/mod.rs
@@ -70,6 +70,10 @@ use crate::env::get_env;
 const JJ_MIN_VERSION: &str = "0.42.0";
 const JJ_VERSION_IGNORE_HELP: &str = "If you want to continue anyway, use --ignore-jj-version";
 
+/// What jj says when it refuses to read a repo whose working copy has to
+/// be updated first.
+const STALE_WORKING_COPY: &str = "The working copy is stale";
+
 /// The narrowest width jj is told to limit secondary programs to. Anything
 /// below this is ignored, as those programs produce garbage output at that
 /// size, so it makes no difference to what they print.
@@ -246,6 +250,31 @@ impl Commander {
             ),
             Ok(_) => Ok(()), // found >= min, so jj is recent enough
         }
+    }
+
+    /// Whether jj refuses to read the repo until the working copy is
+    /// updated with [update_stale_workspace](Self::update_stale_workspace).
+    ///
+    /// Anything else that is wrong with the repo comes out as not being
+    /// stale, so that it is reported by whoever went on to read it.
+    #[instrument(level = "trace", skip(self))]
+    pub fn is_workspace_stale(&self) -> bool {
+        // Every read hits the check, so this asks for the least jj can
+        // answer with.
+        let read = self.jj(["log", "-r", "@", "--no-graph", "-T", "''"]).run();
+
+        matches!(read, Err(CommandError::Status(err, _)) if err.contains(STALE_WORKING_COPY))
+    }
+
+    /// Update a stale working copy to the revision the repo has the
+    /// workspace on, and return what jj reports about it.
+    #[instrument(level = "trace", skip(self))]
+    pub fn update_stale_workspace(&self) -> Result<String> {
+        self.jj(["workspace", "update-stale"])
+            .verbose()
+            .with_stderr()
+            .run()
+            .context("Failed to update the working copy")
     }
 }
 
@@ -567,6 +596,7 @@ pub fn get_output_args(color: bool, quiet: bool) -> Vec<String> {
 
 #[cfg(test)]
 pub mod tests {
+    use std::fs;
     use std::time::Duration;
 
     use tempfile::TempDir;
@@ -638,6 +668,43 @@ pub mod tests {
         let test_repo = TestRepo::new()?;
 
         test_repo.commander.jj(["status"]).color().run()?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn a_stale_working_copy_is_recognized_and_updated() -> Result<()> {
+        let test_repo = TestRepo::new()?;
+        let repo = &test_repo.commander;
+        assert!(!repo.is_workspace_stale());
+
+        // A workspace goes stale when the repo is taken back to before
+        // the working copy it has recorded, which is what another
+        // workspace undoing its own work does to it.
+        let workspace_directory = TempDir::with_prefix("blazingjj-workspace")?;
+        let workspace_path = workspace_directory.path().join("other");
+        repo.jj([
+            OsStr::new("workspace"),
+            OsStr::new("add"),
+            workspace_path.as_os_str(),
+        ])
+        .run_void()?;
+        let before = repo
+            .jj(["op", "log", "-n1", "--no-graph", "-T", "self.id()"])
+            .ignore_working_copy()
+            .run()?;
+
+        let mut workspace = repo.clone();
+        workspace.env.root = workspace_path.to_string_lossy().into_owned();
+        fs::write(workspace_path.join("README"), b"AAA")?;
+        workspace.jj(["commit", "-m", "work"]).run_void()?;
+        assert!(!workspace.is_workspace_stale());
+
+        repo.jj(["op", "restore", &before]).run_void()?;
+        assert!(workspace.is_workspace_stale());
+
+        workspace.update_stale_workspace()?;
+        assert!(!workspace.is_workspace_stale());
 
         Ok(())
     }

--- a/src/commander/mod.rs
+++ b/src/commander/mod.rs
@@ -37,6 +37,7 @@ pub mod revset;
 
 use std::ffi::OsStr;
 use std::ffi::OsString;
+use std::fmt;
 use std::io;
 use std::io::Read;
 use std::io::Write;
@@ -132,6 +133,12 @@ pub struct Commander {
     // Used for testing
     pub jj_config_toml: Option<Vec<String>>,
     pub force_no_color: bool,
+}
+
+/// Whether a command failed because jj refuses to read the repo until
+/// the working copy is updated.
+pub fn is_stale_working_copy(err: &impl fmt::Display) -> bool {
+    format!("{err:#}").contains(STALE_WORKING_COPY)
 }
 
 /// Initialize a new [Commander] using [get_env]
@@ -263,7 +270,7 @@ impl Commander {
         // answer with.
         let read = self.jj(["log", "-r", "@", "--no-graph", "-T", "''"]).run();
 
-        matches!(read, Err(CommandError::Status(err, _)) if err.contains(STALE_WORKING_COPY))
+        read.err().is_some_and(|err| is_stale_working_copy(&err))
     }
 
     /// Update a stale working copy to the revision the repo has the
@@ -702,6 +709,18 @@ pub mod tests {
 
         repo.jj(["op", "restore", &before]).run_void()?;
         assert!(workspace.is_workspace_stale());
+
+        // A read that fails on it says so, wherever it is made from, and
+        // a failure of any other kind is not taken for it.
+        let stale = workspace
+            .get_current_head()
+            .expect_err("jj will not read a stale workspace");
+        assert!(is_stale_working_copy(&stale), "{stale:#}");
+        let refused = repo
+            .jj(["log", "-r", "nosuchrevision"])
+            .run()
+            .expect_err("the revset names nothing");
+        assert!(!is_stale_working_copy(&refused), "{refused:#}");
 
         workspace.update_stale_workspace()?;
         assert!(!workspace.is_workspace_stale());

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use std::env::current_dir;
 use std::fs::OpenOptions;
 use std::fs::canonicalize;
 use std::io::ErrorKind;
+use std::io::Write;
 use std::io::{self};
 use std::process::Command;
 use std::time::Duration;
@@ -44,6 +45,7 @@ mod ui;
 use crate::app::App;
 use crate::app::Handled;
 use crate::commander::Commander;
+use crate::commander::new_commander;
 use crate::env::Env;
 use crate::env::set_env;
 use crate::interrupt::catch_interrupts;
@@ -74,6 +76,12 @@ struct Args {
 fn main() -> Result<()> {
     // Setup environment
     set_env(init_env()?);
+
+    // A stale working copy has to be dealt with before anything can
+    // read the repo.
+    if !update_stale_workspace()? {
+        return Ok(());
+    }
 
     // Setup app
     let mut app = App::new()?;
@@ -166,6 +174,29 @@ fn init_env() -> Result<Env> {
 
     // Return initialized environment
     Ok(env)
+}
+
+/// Offer to update the working copy if it is stale, which jj refuses to
+/// read the repo until, and report whether the app can go on.
+fn update_stale_workspace() -> Result<bool> {
+    let commander = new_commander();
+    if !commander.is_workspace_stale() {
+        return Ok(true);
+    }
+
+    println!("The working copy is stale: the repo has moved on since it was last updated.");
+    print!("Update it now? [y/N] ");
+    io::stdout().flush()?;
+
+    let mut answer = String::new();
+    io::stdin().read_line(&mut answer)?;
+    if !matches!(answer.trim(), "y" | "Y" | "yes") {
+        return Ok(false);
+    }
+
+    print!("{}", commander.update_stale_workspace()?);
+
+    Ok(true)
 }
 
 fn run_app(terminal: &mut DefaultTerminal, app: &mut App) -> Result<()> {


### PR DESCRIPTION
jj refuses to read a repo whose working copy is stale, and we do
nothing about that: at startup the first command fails and the app
exits with jj's error before drawing anything, and a workspace that
goes stale while running takes the app down or leaves jj's error
where the log and bookmarks should be. Recognize that failure and
offer to run `jj workspace update-stale`, which is what jj tells you
to do, both at startup and from a running app; declining quits at
startup and leaves the tabs behind until a read gets through
otherwise, so the question is not asked again for every frame.