### PR TITLE
settings: Say what a setting takes when a value is refused

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -115,6 +115,7 @@ pub struct JjConfig {
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case", default)]
 pub struct JjConfigBlazingjj {
+    #[serde(deserialize_with = "deserialize_highlight_color")]
     highlight_color: Color,
     describe_mode: DescribeMode,
     diff_format: Option<ConfiguredDiffFormat>,
@@ -151,24 +152,44 @@ impl Default for JjConfigBlazingjj {
     }
 }
 
+/// Reads a colour, of which ratatui says only that it failed to parse
+/// one, leaving out what one looks like.
+fn deserialize_highlight_color<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Color, D::Error> {
+    let text = String::deserialize(deserializer)?;
+
+    text.parse().map_err(|_| {
+        de::Error::custom(format!(
+            "{text:?} is neither a colour name nor a #rrggbb code"
+        ))
+    })
+}
+
 /// Reads a share of a tab, which is refused above the whole of it: a
 /// share the panels cannot be divided in is one to say something about
 /// where it is set rather than one to make what we can of.
 fn deserialize_layout_percent<'de, D: Deserializer<'de>>(deserializer: D) -> Result<u16, D::Error> {
-    let percent = u16::deserialize(deserializer)?;
-    if percent > 100 {
-        return Err(de::Error::custom("a share of a tab is 100 percent at most"));
-    }
-
-    Ok(percent)
+    // Whichever way a number misses, what to say about it is the same,
+    // so we read it as a value and say the range rather than letting
+    // serde report the type it does not fit in.
+    toml::Value::deserialize(deserializer)?
+        .as_integer()
+        .and_then(|percent| u16::try_from(percent).ok())
+        .filter(|percent| *percent <= 100)
+        .ok_or_else(|| de::Error::custom("a share of a tab is a whole number from 0 to 100"))
 }
 
 /// Reads a number of seconds, of which zero means never checking.
 fn deserialize_poll_interval<'de, D: Deserializer<'de>>(
     deserializer: D,
 ) -> Result<Option<Duration>, D::Error> {
-    let seconds = f64::deserialize(deserializer)?;
-    let interval = Duration::try_from_secs_f64(seconds).map_err(de::Error::custom)?;
+    let seconds = toml::Value::deserialize(deserializer)?;
+    let interval = seconds
+        .as_float()
+        .or_else(|| seconds.as_integer().map(|seconds| seconds as f64))
+        .and_then(|seconds| Duration::try_from_secs_f64(seconds).ok())
+        .ok_or_else(|| de::Error::custom("an interval is a number of seconds, 0 or more"))?;
 
     Ok(Some(interval).filter(|interval| !interval.is_zero()))
 }
@@ -630,6 +651,34 @@ mod tests {
         // that names nothing the setting can be.
         assert!(check_config_value("blazingjj.layout-percent", "\"40\"").is_err());
         assert!(check_config_value("blazingjj.layout", "\"sideways\"").is_err());
+    }
+
+    /// A value is refused for what the setting takes rather than for the
+    /// type it is read into, that being what whoever typed it can do
+    /// something about.
+    #[test]
+    fn a_refused_value_says_what_the_setting_takes() {
+        let refusal = |key, value| {
+            let error = check_config_value(key, value).expect_err("the value is refused");
+
+            format!("{error:#}")
+        };
+
+        for percent in ["40.5", "-3", "101"] {
+            assert_eq!(
+                refusal("blazingjj.layout-percent", percent),
+                "The setting cannot take that value: a share of a tab is a whole number from 0 to 100",
+                "{percent}"
+            );
+        }
+        assert_eq!(
+            refusal("blazingjj.poll-interval", "-1"),
+            "The setting cannot take that value: an interval is a number of seconds, 0 or more"
+        );
+        assert_eq!(
+            refusal("blazingjj.highlight-color", "\"chartreuse\""),
+            "The setting cannot take that value: \"chartreuse\" is neither a colour name nor a #rrggbb code"
+        );
     }
 
     #[test]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -7,6 +7,8 @@ expression `jj config set` takes, which is also what the configuration
 is checked against before anything is written.
 */
 
+use std::str::FromStr;
+
 use anyhow::Result;
 use anyhow::bail;
 
@@ -49,7 +51,19 @@ impl Setting {
     pub fn value_of(&self, input: &str) -> Result<String> {
         let value = match self.kind {
             SettingKind::Keybindings => bail!("The keybindings are not an option to type"),
-            SettingKind::Number => input.trim().to_owned(),
+            SettingKind::Number => {
+                let input = input.trim();
+                // TOML reads anything but a number here as text that
+                // was left unquoted, which says nothing about what the
+                // option takes.
+                match input {
+                    "" => bail!("The setting takes a number"),
+                    input if !is_number(input) => {
+                        bail!("The setting takes a number, not {input:?}")
+                    }
+                    input => input.to_owned(),
+                }
+            }
             SettingKind::Choice(_) | SettingKind::Text => {
                 toml::Value::String(input.to_owned()).to_string()
             }
@@ -99,6 +113,14 @@ impl Setting {
             _ => None,
         }
     }
+}
+
+/// Whether `input` is a number as TOML writes one.
+fn is_number(input: &str) -> bool {
+    matches!(
+        toml::Value::from_str(input),
+        Ok(toml::Value::Integer(_) | toml::Value::Float(_))
+    )
 }
 
 /// How many bindings `value` holds, counting the ones in the tables of
@@ -308,6 +330,23 @@ mod tests {
 
         assert_eq!(percent.value_of(" 40 ").unwrap(), "40");
         assert!(percent.value_of("half").is_err());
+    }
+
+    /// TOML reads what is not a number as text that was left unquoted,
+    /// which is not what to say to whoever typed it: what the option
+    /// wants is a number.
+    #[test]
+    fn what_is_not_a_number_is_refused_for_not_being_one() {
+        let percent = setting("blazingjj.layout-percent");
+
+        assert_eq!(
+            percent.value_of(" ").unwrap_err().to_string(),
+            "The setting takes a number"
+        );
+        assert_eq!(
+            percent.value_of("half").unwrap_err().to_string(),
+            "The setting takes a number, not \"half\""
+        );
     }
 
     /// A number the option cannot take is refused where it is typed,


### PR DESCRIPTION
A value the tab refuses is reported in the words of whatever read it: an empty input or unquoted text comes back as "string values must be quoted", and a number outside the range as the Rust type it did not fit in. Neither says anything about what to type instead, so we check that a number is one before handing it on, and read the share of a tab, the poll interval and the highlight colour as TOML values whose deserializers say what the setting takes rather than leaving serde to report the type it read them into.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
