### PR TITLE
command: Name what a tab has selected by a placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `blazingjj.editor-url`, like `jj://$revision/$file`, adds opening the file
     at the revision shown to that question, for an editor that reads a
     revision itself, such as neovim with jj.nvim
+- A command typed into the command popup (`:`) or run interactively (`!`) can
+  name what the tab has selected by a placeholder: `$selected` (`$s`) for
+  whatever the tab is about, `$marked` (`$m`) for the changes the log has
+  marked, and `$revision`, `$file`, `$bookmark` and `$operation` for a
+  selection of that one kind
 - Diff format rendering the Git format with a pager like
   [delta](https://github.com/dandavison/delta), configured as
   `blazingjj.diff-pager` and toggled through with `w` like the others

--- a/README.md
+++ b/README.md
@@ -176,6 +176,13 @@ See all key mappings for the current tab with `?`.
   `toggle-layout` to, which comes unbound
 - Open the context menu for what the tab has selected with `Menu` or a right click
 - Open a command popup to run jj commands using `:` (jj prefix not required, e.g. write `new main` instead of `jj new main`)
+- A command can name what the tab has selected by a placeholder, so `:new $s` creates a change from the highlighted one and `:abandon $m` abandons the marked ones:
+  - `$selected`, or `$s`: what the tab is about, which is the file in the files tab, the bookmark in the bookmarks tab, the operation in the operation log and the revision everywhere else
+  - `$marked`, or `$m`: the changes the log has marked, as the one revset naming them all
+  - `$revision`: the revision the tab is on, whichever kind of thing it is about
+  - `$file`, `$bookmark`, `$operation`: the selection of that kind, for a command that only makes sense against one
+  - A placeholder is replaced inside the argument holding it, so `-r$s` names the selection as much as `$s` does, and what it stands for is one argument however it reads. A revset can be written around one, as in `$s-`; `$$` is a `$` of its own
+  - A command naming something the tab has nothing of is refused rather than run without it
 
 ### Log tab
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -956,12 +956,18 @@ impl<'a> App<'a> {
                                 }
                             }
                             GlobalEvent::CommandPopup => {
-                                self.popup =
-                                    Some(Box::new(CommandPopup::new(CommandMode::Capture)));
+                                let selection = self.get_current_tab().selection();
+                                self.popup = Some(Box::new(CommandPopup::new(
+                                    CommandMode::Capture,
+                                    selection,
+                                )));
                             }
                             GlobalEvent::InteractiveCommandPopup => {
-                                self.popup =
-                                    Some(Box::new(CommandPopup::new(CommandMode::Interactive)));
+                                let selection = self.get_current_tab().selection();
+                                self.popup = Some(Box::new(CommandPopup::new(
+                                    CommandMode::Interactive,
+                                    selection,
+                                )));
                             }
                             GlobalEvent::ToggleLayout => self.toggle_layout(),
                             GlobalEvent::OpenHelp => self.open_help()?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,7 @@ mod env;
 mod event;
 mod interrupt;
 mod keybinds;
+mod selection;
 mod settings;
 mod ui;
 use crate::app::App;

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -1,0 +1,434 @@
+/*! What a tab has selected, and the placeholders a command names it by.
+
+A command the user writes, whether typed into the command popup or
+configured as one of their own, says what to run it against by putting a
+placeholder where the argument goes. What each one stands for is
+whatever the tab it is run from has selected, so `$selected` means the
+change in the log and the file in the files tab.
+
+A placeholder the current tab has nothing for is an error rather than an
+empty argument: a command that was to be run against something is not
+one to run against nothing instead.
+*/
+
+use std::fmt;
+
+use crate::commander::ids::CommitId;
+use crate::commander::ids::OperationId;
+use crate::commander::log::Head;
+use crate::commander::revset::Revset;
+
+/// How the revision a tab is on is named to something outside the app:
+/// by its change id, so that it is read as the change stands, except
+/// where what is shown is not the change as it stands. A version out of
+/// the evolog and one of several divergent commits are both only to be
+/// found by their commit id.
+pub fn shown_revision(head: &Head, pinned: bool) -> &str {
+    if pinned || head.divergent {
+        head.commit_id.as_str()
+    } else {
+        head.change_id.as_str()
+    }
+}
+
+/// One of the placeholders a command is written with.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Placeholder {
+    /// What the tab is about: the revision, or the file, bookmark or
+    /// operation where the tab has one of those.
+    Selected,
+    Revision,
+    Marked,
+    File,
+    Bookmark,
+    Operation,
+}
+
+impl Placeholder {
+    /// Every placeholder there is, in the order they are documented in.
+    pub const ALL: [Self; 6] = [
+        Self::Selected,
+        Self::Marked,
+        Self::Revision,
+        Self::File,
+        Self::Bookmark,
+        Self::Operation,
+    ];
+
+    /// The names it is written as, of which the first is the one to
+    /// read it back by.
+    pub fn names(self) -> &'static [&'static str] {
+        match self {
+            Self::Selected => &["$selected", "$s"],
+            Self::Revision => &["$revision"],
+            Self::Marked => &["$marked", "$m"],
+            Self::File => &["$file"],
+            Self::Bookmark => &["$bookmark"],
+            Self::Operation => &["$operation"],
+        }
+    }
+
+    /// What it stands for, as the help and the settings tab say it.
+    pub fn doc(self) -> &'static str {
+        match self {
+            Self::Selected => "what the tab has selected",
+            Self::Revision => "the revision the tab is on",
+            Self::Marked => "the changes the log has marked, as one revset",
+            Self::File => "the selected file",
+            Self::Bookmark => "the selected bookmark",
+            Self::Operation => "the selected operation",
+        }
+    }
+}
+
+impl fmt::Display for Placeholder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.names()[0])
+    }
+}
+
+/// What a tab has selected, of each of the kinds a placeholder names.
+///
+/// A tab is about one kind of thing but may know of others: the files
+/// tab has a file and the revision it is shown at, so a command run
+/// from it can name either.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Selection {
+    revision: Option<String>,
+    marked: Vec<CommitId>,
+    file: Option<String>,
+    bookmark: Option<String>,
+    operation: Option<String>,
+}
+
+impl Selection {
+    /// The selection with the revision `head` is on, named as
+    /// [shown_revision] names it.
+    pub fn revision(mut self, head: &Head, pinned: bool) -> Self {
+        self.revision = Some(shown_revision(head, pinned).to_owned());
+        self
+    }
+
+    /// The selection with `marked` marked, which only the log has.
+    pub fn marked(mut self, marked: &[CommitId]) -> Self {
+        self.marked = marked.to_vec();
+        self
+    }
+
+    pub fn file(mut self, path: &str) -> Self {
+        self.file = Some(path.to_owned());
+        self
+    }
+
+    pub fn bookmark(mut self, name: &str) -> Self {
+        self.bookmark = Some(name.to_owned());
+        self
+    }
+
+    pub fn operation(mut self, id: &OperationId) -> Self {
+        self.operation = Some(id.as_str().to_owned());
+        self
+    }
+
+    /// What `placeholder` stands for, or None where the tab has nothing
+    /// of that kind.
+    fn value(&self, placeholder: Placeholder) -> Option<String> {
+        match placeholder {
+            // What the tab is about is the most particular thing it has:
+            // the file in the files tab, whose revision is only what it
+            // is read at.
+            Placeholder::Selected => self
+                .operation
+                .clone()
+                .or_else(|| self.bookmark.clone())
+                .or_else(|| self.file.clone())
+                .or_else(|| self.revision.clone()),
+            Placeholder::Revision => self.revision.clone(),
+            // Several changes go to a command as the one revset that
+            // names them all, that being how jj takes more than one.
+            Placeholder::Marked => {
+                Revset::union(&self.marked).map(|revset| revset.as_str().to_owned())
+            }
+            Placeholder::File => self.file.clone(),
+            Placeholder::Bookmark => self.bookmark.clone(),
+            Placeholder::Operation => self.operation.clone(),
+        }
+    }
+
+    /// `args` with every placeholder replaced by what the selection has
+    /// for it, refused when one of them has nothing to stand for.
+    ///
+    /// Substitution happens inside an argument, so that `--rev=$s` names
+    /// the selection as much as `$s` on its own does, and after the
+    /// command has been split into arguments, so that what a placeholder
+    /// stands for is one argument however it reads. `$$` is a `$` of its
+    /// own rather than the start of a placeholder.
+    pub fn substitute(&self, args: &[String]) -> Result<Vec<String>, Missing> {
+        args.iter().map(|arg| self.substitute_one(arg)).collect()
+    }
+
+    /// `arg` with every placeholder replaced by what the selection has
+    /// for it.
+    fn substitute_one(&self, arg: &str) -> Result<String, Missing> {
+        let mut left = arg;
+        let mut done = String::with_capacity(arg.len());
+
+        while let Some(at) = left.find('$') {
+            done.push_str(&left[..at]);
+            let rest = &left[at..];
+
+            if let Some(escaped) = rest.strip_prefix("$$") {
+                done.push('$');
+                left = escaped;
+                continue;
+            }
+
+            match Self::placeholder_at(rest) {
+                Some((placeholder, name)) => {
+                    done.push_str(&self.value(placeholder).ok_or(Missing(placeholder))?);
+                    left = &rest[name.len()..];
+                }
+                // A `$` that starts no placeholder is a `$` like any
+                // other character, as a revset full of them has.
+                None => {
+                    done.push('$');
+                    left = &rest[1..];
+                }
+            }
+        }
+        done.push_str(left);
+
+        Ok(done)
+    }
+
+    /// The placeholder `arg` starts with and the name it is written as,
+    /// if it starts with one at all.
+    ///
+    /// A name has to end where the word does, so that the short names
+    /// do not turn every word starting with one into a placeholder:
+    /// `$selection` is not `$s` with `election` after it.
+    fn placeholder_at(arg: &str) -> Option<(Placeholder, &'static str)> {
+        Placeholder::ALL.into_iter().find_map(|placeholder| {
+            let name = placeholder.names().iter().find(|name| {
+                arg.strip_prefix(**name)
+                    .is_some_and(|rest| !rest.starts_with(|char: char| char.is_alphanumeric()))
+            })?;
+
+            Some((placeholder, *name))
+        })
+    }
+}
+
+/// A placeholder the tab it was to be filled from has nothing for.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Missing(pub Placeholder);
+
+impl fmt::Display for Missing {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} stands for {}, and this tab has none.",
+            self.0,
+            self.0.doc()
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commander::ids::ChangeId;
+
+    fn head(change_id: &str, commit_id: &str, divergent: bool) -> Head {
+        Head {
+            change_id: ChangeId(change_id.to_owned()),
+            commit_id: CommitId(commit_id.to_owned()),
+            divergent,
+            immutable: false,
+        }
+    }
+
+    /// The selection of a log with `marked` marked on top of a change
+    fn log(marked: &[&str]) -> Selection {
+        let marked: Vec<CommitId> = marked.iter().map(|id| CommitId((*id).to_owned())).collect();
+
+        Selection::default()
+            .revision(&head("change", "commit", false), false)
+            .marked(&marked)
+    }
+
+    /// What `command` reads as against `selection`, as one line
+    fn substituted(selection: &Selection, command: &[&str]) -> Result<String, Missing> {
+        let args: Vec<String> = command.iter().map(|arg| (*arg).to_owned()).collect();
+
+        Ok(selection.substitute(&args)?.join(" "))
+    }
+
+    #[test]
+    fn a_placeholder_stands_for_what_the_tab_has_selected() {
+        let selection = log(&[]);
+
+        assert_eq!(
+            substituted(&selection, &["show", "$selected"]),
+            Ok("show change".to_owned())
+        );
+        assert_eq!(
+            substituted(&selection, &["show", "$s"]),
+            Ok("show change".to_owned())
+        );
+        assert_eq!(
+            substituted(&selection, &["show", "$revision"]),
+            Ok("show change".to_owned())
+        );
+    }
+
+    /// What the tab is about is the most particular thing it knows of,
+    /// not the revision every tab about a change has.
+    #[test]
+    fn the_selection_is_what_the_tab_is_about() {
+        let files = Selection::default()
+            .revision(&head("change", "commit", false), false)
+            .file("src/main.rs");
+        assert_eq!(
+            substituted(&files, &["$selected", "$revision"]),
+            Ok("src/main.rs change".to_owned())
+        );
+
+        let bookmarks = Selection::default()
+            .revision(&head("change", "commit", false), false)
+            .bookmark("main");
+        assert_eq!(
+            substituted(&bookmarks, &["$selected"]),
+            Ok("main".to_owned())
+        );
+
+        let operations = Selection::default().operation(&OperationId("op".to_owned()));
+        assert_eq!(
+            substituted(&operations, &["$selected"]),
+            Ok("op".to_owned())
+        );
+    }
+
+    /// A change that is only to be found by its commit id is named by
+    /// it, as it is everywhere else the app names one outside itself.
+    #[test]
+    fn a_revision_not_shown_as_the_change_stands_is_named_by_its_commit() {
+        let pinned = Selection::default().revision(&head("change", "commit", false), true);
+        assert_eq!(
+            substituted(&pinned, &["$revision"]),
+            Ok("commit".to_owned())
+        );
+
+        let divergent = Selection::default().revision(&head("change", "commit", true), false);
+        assert_eq!(
+            substituted(&divergent, &["$revision"]),
+            Ok("commit".to_owned())
+        );
+    }
+
+    /// jj takes more than one revision as the revset that names them
+    /// all, so that is what the marks come to.
+    #[test]
+    fn the_marked_changes_are_one_revset() {
+        assert_eq!(
+            substituted(&log(&["a", "b"]), &["abandon", "$marked"]),
+            Ok("abandon a | b".to_owned())
+        );
+        assert_eq!(
+            substituted(&log(&["a"]), &["abandon", "$m"]),
+            Ok("abandon a".to_owned())
+        );
+    }
+
+    /// A command that was to be run against what is marked is not one
+    /// to run against everything or nothing instead.
+    #[test]
+    fn nothing_marked_leaves_the_marked_placeholder_with_nothing_to_stand_for() {
+        assert_eq!(
+            substituted(&log(&[]), &["abandon", "$marked"]),
+            Err(Missing(Placeholder::Marked))
+        );
+    }
+
+    #[test]
+    fn a_placeholder_the_tab_has_nothing_for_is_refused() {
+        assert_eq!(
+            substituted(&log(&[]), &["$file"]),
+            Err(Missing(Placeholder::File))
+        );
+        assert_eq!(
+            substituted(&log(&[]), &["$bookmark"]),
+            Err(Missing(Placeholder::Bookmark))
+        );
+        assert_eq!(
+            substituted(&log(&[]), &["$operation"]),
+            Err(Missing(Placeholder::Operation))
+        );
+        // A tab about nothing at all has nothing to select.
+        assert_eq!(
+            substituted(&Selection::default(), &["$selected"]),
+            Err(Missing(Placeholder::Selected))
+        );
+    }
+
+    /// A placeholder stands for the selection wherever in an argument it
+    /// is written, so that the flags that take a revision can name it.
+    #[test]
+    fn a_placeholder_is_replaced_inside_the_argument_holding_it() {
+        assert_eq!(
+            substituted(&log(&["a", "b"]), &["--rev=$s", "-r$m"]),
+            Ok("--rev=change -ra | b".to_owned())
+        );
+    }
+
+    /// What a placeholder stands for is one argument however it reads,
+    /// the command having been split into arguments before it was put
+    /// there.
+    #[test]
+    fn what_a_placeholder_stands_for_is_never_split_into_arguments() {
+        let selection = Selection::default().file("a file with spaces.txt");
+
+        assert_eq!(
+            selection.substitute(&["diff".to_owned(), "$file".to_owned()]),
+            Ok(vec!["diff".to_owned(), "a file with spaces.txt".to_owned()])
+        );
+    }
+
+    #[test]
+    fn a_dollar_that_starts_no_placeholder_is_one_of_its_own() {
+        let selection = log(&[]);
+
+        assert_eq!(
+            substituted(&selection, &["show", "$revset"]),
+            Ok("show $revset".to_owned())
+        );
+        assert_eq!(substituted(&selection, &["$"]), Ok("$".to_owned()));
+        // A word that only starts with the name of a placeholder is not
+        // that placeholder with the rest of the word after it.
+        assert_eq!(
+            substituted(&selection, &["$selection"]),
+            Ok("$selection".to_owned())
+        );
+    }
+
+    /// A revset says what to do to the changes around one, so what
+    /// follows a placeholder is as much a part of the revset as the
+    /// placeholder is.
+    #[test]
+    fn a_revset_can_be_written_around_a_placeholder() {
+        assert_eq!(
+            substituted(&log(&["a", "b"]), &["$s-", "$s::", "($m)|$s"]),
+            Ok("change- change:: (a | b)|change".to_owned())
+        );
+    }
+
+    /// A command with a `$` of its own to pass on writes it twice, as
+    /// one meant for a shell variable is.
+    #[test]
+    fn a_doubled_dollar_is_a_dollar_of_its_own() {
+        assert_eq!(
+            substituted(&log(&[]), &["$$selected", "$$$s"]),
+            Ok("$selected $change".to_owned())
+        );
+    }
+}

--- a/src/ui/bookmarks_tab.rs
+++ b/src/ui/bookmarks_tab.rs
@@ -27,6 +27,7 @@ use crate::keybinds::BookmarksTabEvent;
 use crate::keybinds::BookmarksTabKeybinds;
 use crate::keybinds::DetailsPanelEvent;
 use crate::keybinds::DetailsPanelKeybinds;
+use crate::selection::Selection;
 use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
@@ -442,6 +443,19 @@ impl Tab for BookmarksTab {
             self.get_current_bookmark_index()
                 .and_then(|index| self.bookmarks_pane.item_anchor(index, 1)),
         ))
+    }
+
+    /// The tab is about the bookmark, which points at a change, so a
+    /// command run here can name either. A line that is no bookmark to
+    /// operate on names neither.
+    fn selection(&self) -> Selection {
+        let Some((bookmark, head)) = self.selected_target() else {
+            return Selection::default();
+        };
+
+        Selection::default()
+            .revision(head, false)
+            .bookmark(&bookmark.to_string())
     }
 
     fn main_panel_bindings(&self) -> Vec<Binding> {

--- a/src/ui/dialog/command.rs
+++ b/src/ui/dialog/command.rs
@@ -22,6 +22,7 @@ use crate::commander::NO_EDITOR;
 use crate::commander::new_commander;
 use crate::keybinds::PopupEvent;
 use crate::keybinds::PopupKeybinds;
+use crate::selection::Selection;
 use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
@@ -45,14 +46,18 @@ pub enum CommandMode {
 pub struct CommandPopup<'a> {
     mode: CommandMode,
     command_textarea: TextArea<'a>,
+    /// What the tab the popup was opened over has selected, which the
+    /// placeholders of the command stand for.
+    selection: Selection,
     keybinds: PopupKeybinds,
 }
 
 impl CommandPopup<'_> {
-    pub fn new(mode: CommandMode) -> Self {
+    pub fn new(mode: CommandMode, selection: Selection) -> Self {
         Self {
             mode,
             command_textarea: TextArea::new(vec![]),
+            selection,
             keybinds: PopupKeybinds::text_line(),
         }
     }
@@ -209,14 +214,25 @@ impl Component for CommandPopup<'_> {
                         return cancel;
                     }
 
-                    let title = format!("jj {command}");
+                    let typed = format!("jj {command}");
                     let args = match split(&command) {
                         Ok(args) => args,
                         Err(err) => {
                             let report = format!("Failed to split command input\n\n{err}");
-                            return Ok(ComponentInputResult::HandledAction(popup(title, report)));
+                            return Ok(ComponentInputResult::HandledAction(popup(typed, report)));
                         }
                     };
+                    // What ran is what the command came to once the
+                    // selection was put in it, which is what there is to
+                    // read the output against.
+                    let args = match self.selection.substitute(&args) {
+                        Ok(args) => args,
+                        Err(missing) => {
+                            let report = format!("Nothing to run the command against\n\n{missing}");
+                            return Ok(ComponentInputResult::HandledAction(popup(typed, report)));
+                        }
+                    };
+                    let title = format!("jj {}", args.join(" "));
 
                     return Ok(match self.mode {
                         CommandMode::Capture => run_captured(title, &args),
@@ -245,6 +261,7 @@ mod tests {
         CommandPopup {
             mode: CommandMode::Capture,
             command_textarea: TextArea::new(vec![typed.to_owned()]),
+            selection: Selection::default(),
             keybinds: PopupKeybinds::text_line(),
         }
         .command()

--- a/src/ui/evolog_tab.rs
+++ b/src/ui/evolog_tab.rs
@@ -26,6 +26,7 @@ use crate::keybinds::DetailsPanelEvent;
 use crate::keybinds::DetailsPanelKeybinds;
 use crate::keybinds::EvologTabEvent;
 use crate::keybinds::EvologTabKeybinds;
+use crate::selection::Selection;
 use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
@@ -200,6 +201,13 @@ impl Tab for EvologTab<'_> {
 
     fn open_context_menu(&self) -> Result<Option<AppAction>> {
         Ok(self.context_menu(self.entry_panel.selected_position()))
+    }
+
+    /// A version of a change is only to be found by its commit id,
+    /// which is what the tab is about rather than the change it belongs
+    /// to.
+    fn selection(&self) -> Selection {
+        Selection::default().revision(&self.entry_panel.selected, true)
     }
 
     fn main_panel_bindings(&self) -> Vec<Binding> {

--- a/src/ui/files_tab.rs
+++ b/src/ui/files_tab.rs
@@ -31,6 +31,8 @@ use crate::keybinds::DetailsPanelEvent;
 use crate::keybinds::DetailsPanelKeybinds;
 use crate::keybinds::FilesTabEvent;
 use crate::keybinds::FilesTabKeybinds;
+use crate::selection::Selection;
+use crate::selection::shown_revision;
 use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
@@ -123,19 +125,6 @@ impl OutputKey for FileDiffKey {
 
     fn slot(owner: TabId, request: OutputRequest<Self>) -> TaskSlot {
         TaskSlot::FileDiff(owner, request)
-    }
-}
-
-/// How the revision the tab is on is named to something outside the app:
-/// by its change id, so that it is read as the change stands, except
-/// where what is shown is not the change as it stands. A version out of
-/// the evolog and one of several divergent commits are both only to be
-/// found by their commit id.
-fn shown_revision(head: &Head, pinned: bool) -> &str {
-    if pinned || head.divergent {
-        head.commit_id.as_str()
-    } else {
-        head.change_id.as_str()
     }
 }
 
@@ -366,6 +355,17 @@ impl Tab for FilesTab {
             self.get_current_file_index()
                 .and_then(|index| self.files_pane.item_anchor(index, 1)),
         ))
+    }
+
+    /// The tab is about the file, which is only shown at the change it
+    /// belongs to, so a command run here can name either.
+    fn selection(&self) -> Selection {
+        let selection = Selection::default().revision(&self.head, self.pinned);
+
+        match self.file.as_ref().and_then(|file| file.path.as_deref()) {
+            Some(path) => selection.file(path),
+            None => selection,
+        }
     }
 
     fn main_panel_bindings(&self) -> Vec<Binding> {

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -31,6 +31,7 @@ use crate::keybinds::LogTabKeybinds;
 use crate::keybinds::PopupEvent;
 use crate::keybinds::PopupKeybinds;
 use crate::keybinds::Relation;
+use crate::selection::Selection;
 use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
@@ -415,6 +416,12 @@ impl Tab for LogTab<'_> {
 
     fn open_context_menu(&self) -> Result<Option<AppAction>> {
         self.context_menu(self.log_panel.selected_position())
+    }
+
+    fn selection(&self) -> Selection {
+        Selection::default()
+            .revision(&self.head, false)
+            .marked(&self.marked())
     }
 
     fn main_panel_bindings(&self) -> Vec<Binding> {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -23,6 +23,7 @@ use crate::commander::log::Head;
 use crate::commander::program::Program;
 use crate::event::Mouse;
 use crate::keybinds::Binding;
+use crate::selection::Selection;
 
 /// Action commmands from component to application
 pub enum AppAction {
@@ -184,6 +185,13 @@ pub trait Tab: Component {
     /// The menu of what can be done to what the tab has selected, put
     /// where the selection is.
     fn open_context_menu(&self) -> Result<Option<AppAction>>;
+
+    /// What the tab has selected, which a command run from it names by
+    /// its placeholders. A tab about the app itself has nothing to run
+    /// a command against.
+    fn selection(&self) -> Selection {
+        Selection::default()
+    }
 
     /// Keybindings of the main panel, for the help popup.
     fn main_panel_bindings(&self) -> Vec<Binding>;

--- a/src/ui/op_log_tab.rs
+++ b/src/ui/op_log_tab.rs
@@ -25,6 +25,7 @@ use crate::keybinds::DetailsPanelEvent;
 use crate::keybinds::DetailsPanelKeybinds;
 use crate::keybinds::OpLogTabEvent;
 use crate::keybinds::OpLogTabKeybinds;
+use crate::selection::Selection;
 use crate::ui::AppAction;
 use crate::ui::Component;
 use crate::ui::ComponentInputResult;
@@ -225,6 +226,10 @@ impl Tab for OpLogTab<'_> {
 
     fn open_context_menu(&self) -> Result<Option<AppAction>> {
         Ok(self.context_menu(self.op_panel.selected_position()))
+    }
+
+    fn selection(&self) -> Selection {
+        Selection::default().operation(&self.op_panel.selected.id)
     }
 
     fn main_panel_bindings(&self) -> Vec<Binding> {


### PR DESCRIPTION
Running a command against the change you are looking at means reading its id off the screen and typing it out, although the tab has it already. A placeholder names it instead. The names are the ones the configuration already uses for a command line, $file and $revision among them, and $selected stands for whichever of them the tab is about, so one command works wherever it is run from. Substitution happens inside the argument holding a placeholder, so a revset can be written around one, and after the command has been split into arguments, so what it stands for cannot be read as arguments of its own. A placeholder the tab has nothing for is refused rather than dropped.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
