### PR TITLE
ui: Keep a tab's split ratio across terminal resizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- A resized terminal now keeps the ratio a tab is split in, so that both panels
+  grow and shrink, rather than the main panel keeping the columns or rows it
+  has; `blazingjj.layout-preserve-ratio = false` goes back to that
 - The tab bar now scrolls the current tab into the middle of what it shows
   when the window is too narrow for every tab, rather than cutting off the
   tabs that do not fit. The header no longer says which numbers pick a tab,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a restart. Clearing the field a value is typed in also takes the option out,
   which is the only way to reach one of several options written under the same
   key
+  - An option that is either on or off, such as `blazingjj.confirm-push`, is
+    turned over on `Enter` rather than asked about
 - Keybindings tab, opened from the settings tab's `blazingjj.keybinds` row,
   listing every action a key can be bound to under the heading of where its
   keys take effect. `Enter` takes the next key you press for the selected

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ You can optionally configure the following options through your jj config:
   - What is shown is what `jj git push --dry-run` says the push would do, so it takes a round trip to the remote to put the question
 - `blazingjj.layout`: Changes the layout of the main and details panel. Can be `horizontal` (default) or `vertical`
 - `blazingjj.layout-percent`: Changes the layout split of the main page. Should be number between 0 and 100. Defaults to `50`
+- `blazingjj.layout-preserve-ratio`: Whether a resized terminal keeps the ratio the tab is split in, so that both panels grow and shrink, rather than the size of the main panel. Defaults to `true`
 - `blazingjj.poll-interval`: Seconds between checks for work done outside the app. Set to `0` to only check when asked. Defaults to `1`
   - What is found is picked up while the terminal window has no focus; while it has focus, the header's `R: refresh` hint turns red instead, as refreshing what is being read moves it
   - A terminal that does not report focus changes counts as always focused, so there the hint is all you get

--- a/src/env.rs
+++ b/src/env.rs
@@ -131,6 +131,9 @@ pub struct JjConfigBlazingjj {
     /// the most.
     #[serde(deserialize_with = "deserialize_layout_percent")]
     layout_percent: u16,
+    /// Whether the main panel keeps its share of a resized tab, rather
+    /// than the cells it has.
+    layout_preserve_ratio: bool,
     keybinds: Option<KeybindsConfig>,
     /// How long to wait between checks for work done outside the app, or
     /// None to only check when one is asked for.
@@ -144,6 +147,7 @@ impl Default for JjConfigBlazingjj {
             highlight_color: Color::Rgb(50, 50, 150),
             confirm_push: true,
             layout_percent: 50,
+            layout_preserve_ratio: true,
             poll_interval: Some(Duration::from_secs(1)),
             // Standard defaults for the rest
             describe_mode: DescribeMode::default(),
@@ -308,6 +312,12 @@ impl JjConfig {
 
     pub fn layout_percent(&self) -> u16 {
         self.blazingjj.layout_percent
+    }
+
+    /// Whether a pane split keeps its ratio when the terminal is
+    /// resized, rather than the size of the main panel.
+    pub fn layout_preserve_ratio(&self) -> bool {
+        self.blazingjj.layout_preserve_ratio
     }
 
     pub fn keybinds(&self) -> Option<&KeybindsConfig> {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -167,6 +167,13 @@ pub const SETTINGS: &[Setting] = &[
         kind: SettingKind::Number,
     },
     Setting {
+        key: "blazingjj.layout-preserve-ratio",
+        section: "Appearance",
+        doc: "Whether a resized terminal keeps the ratio a tab is split in, rather than the size of the main panel.",
+        fallback: "true",
+        kind: SettingKind::Toggle(|| get_env().jj_config.layout_preserve_ratio()),
+    },
+    Setting {
         key: "blazingjj.diff-format",
         section: "Diffs",
         doc: "How a diff is rendered. Without one, a configured diff pager or diff tool is used.",
@@ -334,6 +341,7 @@ mod tests {
         );
         assert_eq!(set("blazingjj.layout-percent", "40").layout_percent(), 40);
         assert!(!set("blazingjj.confirm-push", "false").confirm_push());
+        assert!(set("blazingjj.layout-preserve-ratio", "true").layout_preserve_ratio());
         assert!(
             set("blazingjj.keybinds", "{ quit = \"x\" }")
                 .keybinds()
@@ -368,6 +376,10 @@ mod tests {
         assert_eq!(
             as_fallback("blazingjj.confirm-push").confirm_push(),
             default.confirm_push()
+        );
+        assert_eq!(
+            as_fallback("blazingjj.layout-preserve-ratio").layout_preserve_ratio(),
+            default.layout_preserve_ratio()
         );
         assert_eq!(
             as_fallback("blazingjj.poll-interval").poll_interval(),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -13,12 +13,17 @@ use anyhow::Result;
 use anyhow::bail;
 
 use crate::env::check_config_value;
+use crate::env::get_env;
 
 /// What kind of value an option takes, which decides both how it is
 /// asked for and how what is typed becomes a TOML expression.
 pub enum SettingKind {
     /// One of a fixed set of values.
     Choice(&'static [&'static str]),
+    /// On or off, written as a boolean. The function says which of the
+    /// two the app goes by, the configuration being free to say nothing
+    /// and leave it to the app.
+    Toggle(fn() -> bool),
     /// Free text.
     Text,
     /// A number, which is written as one rather than as the text of one.
@@ -64,6 +69,10 @@ impl Setting {
                     input => input.to_owned(),
                 }
             }
+            SettingKind::Toggle(_) => match input.trim() {
+                boolean @ ("true" | "false") => boolean.to_owned(),
+                input => bail!("The setting is either true or false, not {input:?}"),
+            },
             SettingKind::Choice(_) | SettingKind::Text => {
                 toml::Value::String(input.to_owned()).to_string()
             }
@@ -214,6 +223,13 @@ pub const SETTINGS: &[Setting] = &[
         kind: SettingKind::Text,
     },
     Setting {
+        key: "blazingjj.confirm-push",
+        section: "Changes",
+        doc: "Whether a push is shown and asked about before it is sent. What is shown is what `jj git push --dry-run` says the push would do, so putting the question takes a round trip to the remote.",
+        fallback: "true",
+        kind: SettingKind::Toggle(|| get_env().jj_config.confirm_push()),
+    },
+    Setting {
         key: "blazingjj.poll-interval",
         section: "Watching the repo",
         doc: "Seconds between checks for work done outside the app, or 0 to only check when asked.",
@@ -317,6 +333,7 @@ mod tests {
             JJLayout::Vertical
         );
         assert_eq!(set("blazingjj.layout-percent", "40").layout_percent(), 40);
+        assert!(!set("blazingjj.confirm-push", "false").confirm_push());
         assert!(
             set("blazingjj.keybinds", "{ quit = \"x\" }")
                 .keybinds()
@@ -349,6 +366,10 @@ mod tests {
             default.layout_percent()
         );
         assert_eq!(
+            as_fallback("blazingjj.confirm-push").confirm_push(),
+            default.confirm_push()
+        );
+        assert_eq!(
             as_fallback("blazingjj.poll-interval").poll_interval(),
             default.poll_interval()
         );
@@ -360,6 +381,19 @@ mod tests {
 
         assert_eq!(color.value_of("#123456").unwrap(), "\"#123456\"");
         assert!(color.value_of("chartreuse").is_err());
+    }
+
+    /// An option that is either on or off is written as the boolean it
+    /// is, and anything else is refused for not being one.
+    #[test]
+    fn what_is_neither_true_nor_false_is_refused_for_not_being_either() {
+        let confirm = setting("blazingjj.confirm-push");
+
+        assert_eq!(confirm.value_of(" false ").unwrap(), "false");
+        assert_eq!(
+            confirm.value_of("no").unwrap_err().to_string(),
+            "The setting is either true or false, not \"no\""
+        );
     }
 
     #[test]

--- a/src/ui/settings_tab.rs
+++ b/src/ui/settings_tab.rs
@@ -117,8 +117,18 @@ impl SettingsTab {
     /// it takes, when it only takes one of a few, or what it is to be.
     fn change_selected(&self) -> Option<AppAction> {
         let setting = self.selected()?;
-        if matches!(setting.kind, SettingKind::Keybindings) {
-            return Some(AppAction::ViewTab(TabId::Keybindings));
+        match setting.kind {
+            SettingKind::Keybindings => return Some(AppAction::ViewTab(TabId::Keybindings)),
+            SettingKind::Toggle(now) => {
+                return Some(AppAction::Run(Command::SetSetting {
+                    key: setting.key.to_owned(),
+                    value: setting.value_of(&(!now()).to_string()).ok()?,
+                }));
+            }
+            SettingKind::Choice(_)
+            | SettingKind::Text
+            | SettingKind::Number
+            | SettingKind::CommandLine => {}
         }
 
         let values = self.values.as_ref().ok()?;
@@ -429,6 +439,20 @@ mod tests {
         tab
     }
 
+    /// Put the selection on the option `key` names, which the tab has to
+    /// list for the test to be testing anything.
+    fn select(tab: &mut SettingsTab, key: &str) {
+        for _ in 0..SETTINGS.len() {
+            if tab.selected().is_some_and(|setting| setting.key == key) {
+                return;
+            }
+
+            tab.settings.scroll(1);
+        }
+
+        panic!("the tab lists {key}");
+    }
+
     /// What the whole tab says, as one string per row of the terminal.
     fn screen(tab: &mut SettingsTab) -> Vec<String> {
         drawn(tab, 100, 20)
@@ -505,15 +529,27 @@ mod tests {
         );
     }
 
+    /// An option that is either on or off has nothing worth asking
+    /// about, so changing it turns it over where it stands rather than
+    /// putting up a list of the two values it can take.
+    #[test]
+    fn an_option_that_is_on_or_off_is_turned_over_rather_than_asked_about() {
+        let mut tab = tab("");
+        select(&mut tab, "blazingjj.confirm-push");
+
+        // A push is asked about unless the configuration says
+        // otherwise, so turning it over asks for false.
+        let Some(AppAction::Run(Command::SetSetting { key, value })) = tab.change_selected() else {
+            panic!("changing it asks for it to be set");
+        };
+        assert_eq!(key, "blazingjj.confirm-push");
+        assert_eq!(value, "false");
+    }
+
     #[test]
     fn only_what_the_users_own_config_sets_can_be_taken_back_out() {
         let mut tab = tab("blazingjj.layout = \"vertical\"\n");
-        while !tab
-            .selected()
-            .is_some_and(|setting| setting.key == "blazingjj.layout")
-        {
-            tab.settings.scroll(1);
-        }
+        select(&mut tab, "blazingjj.layout");
 
         assert!(tab.unset_selected().is_some());
 

--- a/src/ui/utils.rs
+++ b/src/ui/utils.rs
@@ -27,16 +27,19 @@ use crate::keybinds::Shortcut;
 /// Tracks the split position between two panes and handles drag-to-resize mouse events.
 #[derive(Default)]
 pub struct PaneDivider {
-    /// Which way round the panes sit and what share of the area the
-    /// first one takes, as the configuration read when the divider was
-    /// last placed; it is placed afresh whenever either changes. Its
-    /// position counts cells along the axis the panes are divided on,
-    /// so it says nothing about them once they turn.
-    configured: Option<(JJLayout, u16)>,
+    /// Which way round the panes sit, what share of the area the first
+    /// one takes and whether that share is what a resize holds on to, as
+    /// the configuration read when the divider was last placed; it is
+    /// placed afresh whenever any of them changes. Its position counts
+    /// cells along the axis the panes are divided on, so it says nothing
+    /// about them once they turn.
+    configured: Option<(JJLayout, u16, bool)>,
     /// The way round the panes have been turned at runtime, which the
     /// configured layout takes back over from when it changes.
     turned_to: Option<JJLayout>,
-    size: Option<u16>,
+    /// Where the divider was put, as the cells the first pane took of
+    /// the cells there were for both.
+    placed: Option<(u16, u16)>,
     dragging: bool,
     rects: [Rect; 2],
 }
@@ -46,7 +49,11 @@ impl PaneDivider {
     /// the resulting rects for hit-testing in `handle_mouse`.
     pub fn split(&mut self, area: Rect) -> [Rect; 2] {
         let config = &get_env().jj_config;
-        let configured = (config.layout(), config.layout_percent());
+        let configured = (
+            config.layout(),
+            config.layout_percent(),
+            config.layout_preserve_ratio(),
+        );
         // Reading the configuration for the first time is not a change
         // to it, so a tab drawn only now still shows what it was told
         // to while it was not.
@@ -56,24 +63,16 @@ impl PaneDivider {
             .is_some_and(|was| was != configured)
         {
             self.turned_to = None;
-            self.size = None;
+            self.placed = None;
         }
-        let (_, percent) = configured;
+        let (_, percent, preserve_ratio) = configured;
 
         let layout = self.layout();
         let total = match layout {
             JJLayout::Horizontal => area.width,
             JJLayout::Vertical => area.height,
         };
-        let size = match self.size {
-            None => {
-                let s = ((total as u32 * percent as u32) / 100) as u16;
-                self.size = Some(s);
-                s
-            }
-            Some(s) => s,
-        };
-        let size = size.min(total);
+        let size = self.place(total, percent, preserve_ratio);
 
         let chunks = Layout::default()
             .direction(layout.into())
@@ -81,6 +80,30 @@ impl PaneDivider {
             .split(area);
         self.rects = [chunks[0], chunks[1]];
         self.rects
+    }
+
+    /// How many of the `total` cells the first pane takes, being
+    /// `percent` of them until the divider has been put anywhere else.
+    /// A divider that preserves the ratio moves along with an area that
+    /// has changed size, one that does not stays where it was put.
+    fn place(&mut self, total: u16, percent: u16, preserve_ratio: bool) -> u16 {
+        // Every size is worked out from where the divider was put, so
+        // that a pane an area has become too small for is itself again
+        // once there is room, and so that rescaling it again and again
+        // does not walk it away from the ratio it was put at.
+        let size = match self.placed {
+            None => {
+                let size = ((total as u32 * percent as u32) / 100) as u16;
+                self.placed = Some((size, total));
+                size
+            }
+            Some((size, was)) if was != total && was != 0 && preserve_ratio => {
+                ((size as u32 * total as u32 + was as u32 / 2) / was as u32) as u16
+            }
+            Some((size, _)) => size,
+        };
+
+        size.min(total)
     }
 
     /// Handle a mouse event. Returns true if the event was consumed.
@@ -138,7 +161,7 @@ impl PaneDivider {
     /// says otherwise, placing the divider afresh as it does.
     pub fn toggle_layout(&mut self) {
         self.turned_to = Some(self.layout().toggle());
-        self.size = None;
+        self.placed = None;
     }
 
     fn update_size(&mut self, position: Position, layout: JJLayout) {
@@ -161,7 +184,7 @@ impl PaneDivider {
         } else {
             pos.max(1)
         };
-        self.size = Some(size);
+        self.placed = Some((size, total));
     }
 }
 
@@ -459,9 +482,25 @@ mod tests {
 
         // What the divider remembers is what the configuration said
         // when it was last placed, so it stands in for a change of it.
-        divider.configured = Some((JJLayout::Horizontal, 80));
+        divider.configured = Some((JJLayout::Horizontal, 80, true));
         let [main, _] = divider.split(area);
         assert_eq!(main.width, 50);
+    }
+
+    /// Turning what a resize holds on to over is a change like any
+    /// other, so the divider is placed afresh rather than going back to
+    /// a size it had before the last resize.
+    #[test]
+    fn test_a_divider_goes_back_when_what_a_resize_holds_on_to_changes() {
+        set_test_env();
+        let mut divider = PaneDivider::default();
+
+        divider.split(Rect::new(0, 0, 100, 10));
+        divider.update_size(Position::new(20, 0), JJLayout::Horizontal);
+        divider.configured = Some((JJLayout::Horizontal, 50, false));
+
+        let [main, _] = divider.split(Rect::new(0, 0, 60, 10));
+        assert_eq!(main.width, 30);
     }
 
     /// It goes back to it when the panes turn as well.
@@ -473,7 +512,7 @@ mod tests {
 
         divider.split(area);
         divider.update_size(Position::new(20, 0), JJLayout::Horizontal);
-        divider.configured = Some((JJLayout::Vertical, 50));
+        divider.configured = Some((JJLayout::Vertical, 50, true));
 
         let [main, _] = divider.split(area);
         assert_eq!(main.width, 50);
@@ -492,6 +531,69 @@ mod tests {
         let [main, _] = divider.split(area);
 
         assert_eq!(main.width, 100);
+    }
+
+    /// A divider that keeps the size it was given leaves the growing
+    /// and the shrinking to the second pane.
+    #[test]
+    fn test_a_divider_that_does_not_preserve_the_ratio_stays_where_it_was_put() {
+        let mut divider = PaneDivider::default();
+
+        assert_eq!(divider.place(100, 50, false), 50);
+        assert_eq!(divider.place(60, 50, false), 50);
+        assert_eq!(divider.place(200, 50, false), 50);
+    }
+
+    /// A divider that preserves the ratio moves along with the area,
+    /// keeping the ratio it was dragged to rather than the configured one.
+    #[test]
+    fn test_a_divider_that_preserves_the_ratio_moves_with_the_area() {
+        let mut divider = PaneDivider::default();
+
+        assert_eq!(divider.place(100, 50, true), 50);
+        assert_eq!(divider.place(60, 50, true), 30);
+
+        divider.placed = Some((20, 100));
+        assert_eq!(divider.place(50, 50, true), 10);
+    }
+
+    /// One resize after another is worked out from where the divider
+    /// was put, so the ratio does not walk away from it.
+    #[test]
+    fn test_resizing_again_and_again_keeps_the_ratio() {
+        let mut divider = PaneDivider::default();
+
+        assert_eq!(divider.place(100, 30, true), 30);
+        for total in [93, 71, 70, 45, 44, 43, 17, 100] {
+            divider.place(total, 30, true);
+        }
+
+        assert_eq!(divider.place(100, 30, true), 30);
+    }
+
+    /// The panes are split where the configuration says, and follow the
+    /// area from there while it says to keep the ratio.
+    #[test]
+    fn test_the_panes_are_split_where_configured_and_follow_the_area() {
+        set_test_env();
+        let mut divider = PaneDivider::default();
+
+        let [main, _] = divider.split(Rect::new(0, 0, 100, 10));
+        assert_eq!(main.width, 50);
+
+        let [main, _] = divider.split(Rect::new(0, 0, 60, 10));
+        assert_eq!(main.width, 30);
+    }
+
+    /// An area too small for the pane does not cut it down to what fits:
+    /// once there is room again, the pane is the size it was given.
+    #[test]
+    fn test_a_pane_squeezed_out_comes_back() {
+        let mut divider = PaneDivider::default();
+
+        assert_eq!(divider.place(100, 80, false), 80);
+        assert_eq!(divider.place(40, 80, false), 40);
+        assert_eq!(divider.place(100, 80, false), 80);
     }
 
     /// A label marks the key that picks it in place where the key is one


### PR DESCRIPTION
A resized terminal gives everything it gains and takes everything it
loses from the details panel alone, since the divider is a column
count once the tab has first been drawn. Hold on to the proportions
the panes were last put in instead; `blazingjj.layout-preserve-ratio
= false` is there for whoever sizes the main panel to what it holds
rather than to the window.

That option is the first the settings tab has that is either on or
off, so the tab needs a kind for one: `Enter` turns it over where it
stands rather than putting up a list of two values, and
`blazingjj.confirm-push`, which had nowhere to be listed before, comes
along into the tab with it.

The default is the new behaviour, so the split follows the window
unless your config says otherwise.