### PR TITLE
log: Read the newest 200 changes and no more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,6 +229,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The log tab now reads the newest 200 changes of the revset it shows and
+  reads twice as far back on `m` (`load-more`), the way the operation log tab
+  does
 - A resized terminal now keeps the ratio a tab is split in, so that both panels
   grow and shrink, rather than the main panel keeping the columns or rows it
   has; `blazingjj.layout-preserve-ratio = false` goes back to that

--- a/docs/keybindings.md
+++ b/docs/keybindings.md
@@ -125,6 +125,7 @@ toggle-wrap = "shift+w"
 mark-head = "space"
 goto-parent = "-"
 goto-child = "+"
+load-more = "m"
 
 create-new = "n"
 create-new-describe = "shift+n"

--- a/src/commander/log.rs
+++ b/src/commander/log.rs
@@ -280,12 +280,18 @@ impl Commander {
         })
     }
 
-    /// Get log. Returns human readable log and mapping to log line to item.
+    /// Get log, no more than `limit` changes of it. Returns human readable
+    /// log and mapping to log line to item.
     /// Leaves the working copy alone.
     /// Maps to `jj log --ignore-working-copy`
     #[instrument(level = "trace", skip(self))]
-    pub fn get_log(&self, revset: &Option<String>) -> Result<LogOutput<Head>, CommandError> {
-        let mut command = vec!["log"];
+    pub fn get_log(
+        &self,
+        revset: &Option<String>,
+        limit: usize,
+    ) -> Result<LogOutput<Head>, CommandError> {
+        let limit = limit.to_string();
+        let mut command = vec!["log", "-n", &limit];
         if let Some(revset) = revset {
             command.push("-r");
             command.push(revset);
@@ -534,7 +540,7 @@ mod tests {
     fn get_log() -> Result<()> {
         let test_repo = TestRepo::new()?;
 
-        let log = test_repo.commander.get_log(&None)?;
+        let log = test_repo.commander.get_log(&None, 100)?;
 
         let mut settings = insta::Settings::clone_current();
         settings.add_filter(r"[k-z]{8} .*? [0-9a-fA-F]{8}", "[LINE]");
@@ -547,6 +553,19 @@ mod tests {
                 .as_ref()
                 .is_none_or(|graph_item| log.items.contains(graph_item))
         }));
+
+        Ok(())
+    }
+
+    #[test]
+    fn get_log_reads_no_more_changes_than_it_is_asked_for() -> Result<()> {
+        let test_repo = TestRepo::new()?;
+
+        test_repo.commander.jj(["describe", "-m", "first"]).run()?;
+        test_repo.commander.jj(["new"]).run()?;
+        test_repo.commander.jj(["describe", "-m", "second"]).run()?;
+
+        assert_eq!(test_repo.commander.get_log(&None, 2)?.items.len(), 2);
 
         Ok(())
     }

--- a/src/keybinds/config.rs
+++ b/src/keybinds/config.rs
@@ -115,6 +115,7 @@ pub struct LogTabKeybindsConfig {
     pub mark_head: Option<Keybind>,
     pub goto_parent: Option<Keybind>,
     pub goto_child: Option<Keybind>,
+    pub load_more: Option<Keybind>,
 
     pub duplicate: Option<Keybind>,
     pub create_new: Option<Keybind>,

--- a/src/keybinds/log_tab.rs
+++ b/src/keybinds/log_tab.rs
@@ -25,6 +25,7 @@ pub enum LogTabEvent {
     ToggleHeadMark,
 
     Goto(Relation),
+    LoadMore,
 
     CreateNew { describe: bool },
     Duplicate,
@@ -80,6 +81,7 @@ impl Default for LogTabKeybinds {
             LogTabEvent::ToggleHeadMark => "space",
             LogTabEvent::Goto(Relation::Parent) => "-",
             LogTabEvent::Goto(Relation::Child) => "+",
+            LogTabEvent::LoadMore => "m",
             LogTabEvent::Duplicate => "shift+d",
             LogTabEvent::CreateNew { describe: false } => "n",
             LogTabEvent::CreateNew { describe: true } => "shift+n",
@@ -135,6 +137,7 @@ impl LogTabKeybinds {
             LogTabEvent::ToggleHeadMark => config.mark_head,
             LogTabEvent::Goto(Relation::Parent) => config.goto_parent,
             LogTabEvent::Goto(Relation::Child) => config.goto_child,
+            LogTabEvent::LoadMore => config.load_more,
             LogTabEvent::Duplicate => config.duplicate,
             LogTabEvent::CreateNew { describe: false } => config.create_new,
             LogTabEvent::CreateNew { describe: true } => config.create_new_describe,
@@ -172,6 +175,7 @@ impl LogTabKeybinds {
             LogTabEvent::OpenFiles => "open-files", Some(Section::Navigation), "see files",
             LogTabEvent::OpenEvolog => "open-evolog", Some(Section::Navigation), "see how the change evolved",
             LogTabEvent::EditRevset => "edit-revset", Some(Section::Navigation), "set revset",
+            LogTabEvent::LoadMore => "load-more", Some(Section::Navigation), "read further back in the log",
 
             LogTabEvent::ToggleHeadMark => "mark-head", Some(Section::Changes), "mark change to act on",
             LogTabEvent::CreateNew { describe: false } => "create-new", Some(Section::Changes), "new change",

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -51,10 +51,18 @@ use crate::ui::styles::clear;
 use crate::ui::utils::PaneDivider;
 use crate::ui::utils::centered_rect_line_height;
 
+/// How far the tab reads before it is asked for more. A revset that puts
+/// every change of a long-lived repo in the log runs to thousands of them,
+/// which take as many jj has to render.
+const INITIAL_LIMIT: usize = 200;
+
 /// Log tab. Shows `jj log` in main panel and shows selected change details of in details panel.
 pub struct LogTab<'a> {
     /// The revset filter to apply to jj log
     log_revset: Option<String>,
+
+    /// How many changes the tab reads
+    limit: usize,
 
     /// Editor for the filter, up while it is being changed
     log_revset_textarea: Option<TextArea<'a>>,
@@ -108,6 +116,8 @@ impl<'a> LogTab<'a> {
             log_revset: get_env().default_revset.clone(),
             log_revset_textarea: None,
 
+            limit: INITIAL_LIMIT,
+
             log_panel: LogPanel::new(head.clone(), LOG_LINES_PER_ITEM),
 
             head,
@@ -149,12 +159,23 @@ impl<'a> LogTab<'a> {
     /// Update the log panel and diff panel. This will also refresh
     /// the diff cache.
     fn refresh_log_output(&mut self) {
-        let title = match &self.log_revset {
-            Some(log_revset) => format!(" Log for: {log_revset} "),
-            None => " Log ".to_owned(),
+        let log = new_commander().get_log(&self.log_revset, self.limit);
+
+        // Reading as many changes as were asked for says that there may
+        // well be more, which is when the key that reads further is worth
+        // mentioning.
+        let more = log.as_ref().is_ok_and(|log| log.items.len() >= self.limit);
+        let subject = match &self.log_revset {
+            Some(log_revset) => format!("Log for: {log_revset}"),
+            None => "Log".to_owned(),
         };
-        self.log_panel
-            .show(new_commander().get_log(&self.log_revset), title);
+        let title = if more {
+            format!(" {subject} (newest {}, m for more) ", self.limit)
+        } else {
+            format!(" {subject} ")
+        };
+
+        self.log_panel.show(log, title);
         self.head_panel.set_active(self.log_panel.items());
         self.sync_head_output();
     }
@@ -357,6 +378,10 @@ impl<'a> LogTab<'a> {
             }
             LogTabEvent::Goto(relation) => {
                 return self.handle_goto(relation);
+            }
+            LogTabEvent::LoadMore => {
+                self.limit = self.limit.saturating_mul(2);
+                self.refresh_log_output();
             }
 
             LogTabEvent::Unbound => {}
@@ -581,5 +606,39 @@ impl Component for LogTab<'_> {
         }
         self.sync_head_output();
         Ok(ComponentInputResult::Handled)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commander::ids::ChangeId;
+    use crate::env::set_test_env;
+
+    fn tab() -> LogTab<'static> {
+        set_test_env();
+        let (sender, _receiver) = std::sync::mpsc::channel();
+
+        let head = Head {
+            change_id: ChangeId(String::new()),
+            commit_id: CommitId(String::new()),
+            divergent: false,
+            immutable: false,
+        };
+
+        LogTab::new(BackgroundTasks::new(sender), head)
+    }
+
+    #[test]
+    fn asking_for_more_changes_reads_further_back_every_time() -> Result<()> {
+        let mut tab = tab();
+
+        tab.handle_event(LogTabEvent::LoadMore)?;
+        assert_eq!(tab.limit, INITIAL_LIMIT * 2);
+
+        tab.handle_event(LogTabEvent::LoadMore)?;
+        assert_eq!(tab.limit, INITIAL_LIMIT * 4);
+
+        Ok(())
     }
 }


### PR DESCRIPTION
Users without a revset of their own get the whole repo in the log, and rendering thousands of changes on every refresh brings the app to a halt. The operation log already stops at 200 entries and reads twice as far back on "m", so we do the same here, and say in the panel title how far the log goes while there is more of it.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
