### PR TITLE
commands: Unmark the changes a command was run against

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,7 +118,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   name what the tab has selected by a placeholder: `$selected` (`$s`) for
   whatever the tab is about, `$marked` (`$m`) for the changes the log has
   marked, and `$revision`, `$file`, `$bookmark` and `$operation` for a
-  selection of that one kind
+  selection of that one kind. A command that named the marked changes and ran
+  leaves them unmarked, the way the built-in operations on them do
 - Diff format rendering the Git format with a pager like
   [delta](https://github.com/dandavison/delta), configured as
   `blazingjj.diff-pager` and toggled through with `w` like the others

--- a/src/app/command.rs
+++ b/src/app/command.rs
@@ -478,6 +478,7 @@ fn open_in_editor(editor: &Editor, target: &str) -> Option<AppAction> {
             // The editor leaves the file it edited on the screen, which
             // is not something to read once it is closed.
             hold_screen: false,
+            on_success: Vec::new(),
         })),
         EditorMode::Detached => match program.run_detached() {
             Ok(()) => None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -274,6 +274,13 @@ fn run_interactive(
     setup_terminal()?;
     terminal.clear()?;
     app.resume_input();
+
+    if ran {
+        for action in interactive.on_success {
+            app.handle_action(action)?;
+        }
+    }
+
     app.catch_up_with_repo()
 }
 

--- a/src/selection.rs
+++ b/src/selection.rs
@@ -163,13 +163,22 @@ impl Selection {
     /// command has been split into arguments, so that what a placeholder
     /// stands for is one argument however it reads. `$$` is a `$` of its
     /// own rather than the start of a placeholder.
-    pub fn substitute(&self, args: &[String]) -> Result<Vec<String>, Missing> {
-        args.iter().map(|arg| self.substitute_one(arg)).collect()
+    pub fn substitute(&self, args: &[String]) -> Result<Substituted, Missing> {
+        let mut used = Vec::new();
+        let args = args
+            .iter()
+            .map(|arg| self.substitute_one(arg, &mut used))
+            .collect::<Result<_, _>>()?;
+
+        Ok(Substituted {
+            args,
+            uses_marks: used.contains(&Placeholder::Marked),
+        })
     }
 
     /// `arg` with every placeholder replaced by what the selection has
-    /// for it.
-    fn substitute_one(&self, arg: &str) -> Result<String, Missing> {
+    /// for it, noting in `used` which ones it named.
+    fn substitute_one(&self, arg: &str, used: &mut Vec<Placeholder>) -> Result<String, Missing> {
         let mut left = arg;
         let mut done = String::with_capacity(arg.len());
 
@@ -186,6 +195,7 @@ impl Selection {
             match Self::placeholder_at(rest) {
                 Some((placeholder, name)) => {
                     done.push_str(&self.value(placeholder).ok_or(Missing(placeholder))?);
+                    used.push(placeholder);
                     left = &rest[name.len()..];
                 }
                 // A `$` that starts no placeholder is a `$` like any
@@ -217,6 +227,15 @@ impl Selection {
             Some((placeholder, *name))
         })
     }
+}
+
+/// A command with the selection put in it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Substituted {
+    pub args: Vec<String>,
+    /// Whether it names what the log has marked, and so is a command the
+    /// marks were there for.
+    pub uses_marks: bool,
 }
 
 /// A placeholder the tab it was to be filled from has nothing for.
@@ -261,7 +280,7 @@ mod tests {
     fn substituted(selection: &Selection, command: &[&str]) -> Result<String, Missing> {
         let args: Vec<String> = command.iter().map(|arg| (*arg).to_owned()).collect();
 
-        Ok(selection.substitute(&args)?.join(" "))
+        Ok(selection.substitute(&args)?.args.join(" "))
     }
 
     #[test]
@@ -389,9 +408,28 @@ mod tests {
         let selection = Selection::default().file("a file with spaces.txt");
 
         assert_eq!(
-            selection.substitute(&["diff".to_owned(), "$file".to_owned()]),
+            selection
+                .substitute(&["diff".to_owned(), "$file".to_owned()])
+                .map(|substituted| substituted.args),
             Ok(vec!["diff".to_owned(), "a file with spaces.txt".to_owned()])
         );
+    }
+
+    /// The marks are there for the command that names them, so it is
+    /// worth knowing which command that was.
+    #[test]
+    fn a_command_says_whether_it_names_what_is_marked() {
+        let uses_marks = |command: &[&str]| {
+            let args: Vec<String> = command.iter().map(|arg| (*arg).to_owned()).collect();
+
+            log(&["a"]).substitute(&args).map(|s| s.uses_marks)
+        };
+
+        assert_eq!(uses_marks(&["abandon", "$m"]), Ok(true));
+        assert_eq!(uses_marks(&["abandon", "$s"]), Ok(false));
+        // A command with a `$marked` of its own to pass on is not one
+        // run against the marks.
+        assert_eq!(uses_marks(&["abandon", "$$marked"]), Ok(false));
     }
 
     #[test]

--- a/src/ui/dialog/command.rs
+++ b/src/ui/dialog/command.rs
@@ -19,6 +19,7 @@ use crate::commander::new_commander;
 use crate::keybinds::PopupEvent;
 use crate::keybinds::PopupKeybinds;
 use crate::selection::Selection;
+use crate::selection::Substituted;
 use crate::theme::Role;
 use crate::ui::AppAction;
 use crate::ui::Component;
@@ -74,11 +75,15 @@ impl CommandPopup<'_> {
 
 /// Run the command and put its output up. It is left without an editor, as
 /// it cannot have the terminal while we hold it.
-fn run_captured(title: String, args: &[String]) -> ComponentInputResult {
+fn run_captured(title: String, command: &Substituted) -> ComponentInputResult {
+    let args = &command.args;
+    let mut ran = true;
+
     let said = match new_commander().jj(args).no_editor().color().verbose().run() {
         Ok(output) if output.trim().is_empty() => AppAction::ClosePopup,
         Ok(output) => popup(title, output),
         Err(err) => {
+            ran = false;
             // Having named the editor ourselves, we know a command that
             // wanted one when we see it, and can offer the way out.
             let wants_editor = err.to_string().contains(NO_EDITOR);
@@ -88,6 +93,7 @@ fn run_captured(title: String, args: &[String]) -> ComponentInputResult {
                     title,
                     report,
                     new_commander().jj(args),
+                    command.uses_marks,
                 )))
             } else {
                 popup(title, report)
@@ -95,9 +101,17 @@ fn run_captured(title: String, args: &[String]) -> ComponentInputResult {
         }
     };
 
+    let mut actions = vec![said];
+    // A command that named the marks is what they were put there for, so
+    // once it has run there is nothing left to keep them for.
+    if ran && command.uses_marks {
+        actions.push(AppAction::ClearLogMarks);
+    }
     // Even a command that came back unhappy may have moved the repo, jj
     // snapshotting the working copy before it gets that far.
-    ComponentInputResult::HandledAction(AppAction::Multiple(vec![said, AppAction::MarkTabsStale]))
+    actions.push(AppAction::MarkTabsStale);
+
+    ComponentInputResult::HandledAction(AppAction::Multiple(actions))
 }
 
 /// Put `output` up under `title`.
@@ -109,10 +123,14 @@ fn popup(title: String, output: String) -> AppAction {
 
 /// Run `command` with the terminal handed over to it, holding it once the
 /// command is done so that what it printed can be read.
-fn run_interactively(command: JjCommand) -> AppAction {
+fn run_interactively(command: JjCommand, uses_marks: bool) -> AppAction {
     AppAction::RunInteractive(Interactive {
         program: command.foreground(),
         hold_screen: true,
+        on_success: uses_marks
+            .then_some(AppAction::ClearLogMarks)
+            .into_iter()
+            .collect(),
     })
 }
 
@@ -123,10 +141,12 @@ struct RetryInteractivelyPopup<'a> {
     keybinds: PopupKeybinds,
     /// Taken when the offer is accepted, which happens at most once.
     command: Option<JjCommand>,
+    /// Whether the command names what the log has marked.
+    uses_marks: bool,
 }
 
 impl RetryInteractivelyPopup<'_> {
-    fn new(title: String, report: String, command: JjCommand) -> Self {
+    fn new(title: String, report: String, command: JjCommand, uses_marks: bool) -> Self {
         let keybinds = PopupKeybinds::dialog();
         let offer = keybinds.hint("run it interactively");
 
@@ -138,6 +158,7 @@ impl RetryInteractivelyPopup<'_> {
             .text_align(Alignment::Left),
             keybinds,
             command: Some(command),
+            uses_marks,
         }
     }
 }
@@ -154,7 +175,10 @@ impl Component for RetryInteractivelyPopup<'_> {
             && let Some(command) = self.command.take()
         {
             return Ok(ComponentInputResult::HandledAction(AppAction::Multiple(
-                vec![AppAction::ClosePopup, run_interactively(command)],
+                vec![
+                    AppAction::ClosePopup,
+                    run_interactively(command, self.uses_marks),
+                ],
             )));
         }
 
@@ -223,21 +247,24 @@ impl Component for CommandPopup<'_> {
                     // What ran is what the command came to once the
                     // selection was put in it, which is what there is to
                     // read the output against.
-                    let args = match self.selection.substitute(&args) {
-                        Ok(args) => args,
+                    let command = match self.selection.substitute(&args) {
+                        Ok(command) => command,
                         Err(missing) => {
                             let report = format!("Nothing to run the command against\n\n{missing}");
                             return Ok(ComponentInputResult::HandledAction(popup(typed, report)));
                         }
                     };
-                    let title = format!("jj {}", args.join(" "));
+                    let title = format!("jj {}", command.args.join(" "));
 
                     return Ok(match self.mode {
-                        CommandMode::Capture => run_captured(title, &args),
+                        CommandMode::Capture => run_captured(title, &command),
                         CommandMode::Interactive => {
                             ComponentInputResult::HandledAction(AppAction::Multiple(vec![
                                 AppAction::ClosePopup,
-                                run_interactively(new_commander().jj(args)),
+                                run_interactively(
+                                    new_commander().jj(command.args),
+                                    command.uses_marks,
+                                ),
                             ]))
                         }
                     });

--- a/src/ui/dialog/describe.rs
+++ b/src/ui/dialog/describe.rs
@@ -51,6 +51,7 @@ pub fn describe_action(
                 .jj(["describe", head.commit_id.as_str()])
                 .foreground(),
             hold_screen: false,
+            on_success: Vec::new(),
         }),
     })
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -72,6 +72,8 @@ pub struct Interactive {
     /// a command run for its effect, whose output is beside the point
     /// unless it failed.
     pub hold_screen: bool,
+    /// What to do once it has run, and only if it came back happy.
+    pub on_success: Vec<AppAction>,
 }
 
 /// When a Component process an input event, it returns an ComponentInputResult


### PR DESCRIPTION
After running a command that made use of the marked commit, they might be (partially) gone, e.g. after abandon or at least gone from the current revset e.g. after rebasing (because the refer to a commit id, not a change id). Thus, we should reset all marks after issuing any command that (successfully) makes use of them.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
