### PR TITLE
status bar: Say how many marks are out of view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,8 +52,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Status bar along the foot of the window, saying which workspace the app is
   working in and where it is, the revset the log is showing and how many
-  changes it has marked. It has taken over the `q`/`?`/`R` hints and the
-  runtime counter from the header, which now holds the tab bar alone
+  changes it has marked, and how many of those the log is not showing. It has
+  taken over the `q`/`?`/`R` hints and the runtime counter from the header,
+  which now holds the tab bar alone
 - Every element of the interface can be given a foreground and a background
   under `blazingjj.colors`, as either the color to draw it in or a table of
   `fg` and `bg`. An element that says nothing about a color takes

--- a/src/app.rs
+++ b/src/app.rs
@@ -499,6 +499,7 @@ impl<'a> App<'a> {
             root: &get_env().root,
             revset: self.log.revset(),
             marked: self.log.marks(),
+            hidden_marks: self.log.hidden_marks(),
             stale: self.repo_watch.waiting_for_refresh(),
             elapsed: self.stats.start_time.elapsed(),
         }

--- a/src/ui/log_tab.rs
+++ b/src/ui/log_tab.rs
@@ -143,6 +143,11 @@ impl<'a> LogTab<'a> {
         self.log_panel.marked.len()
     }
 
+    /// How many of the marked changes the log is not showing.
+    pub fn hidden_marks(&self) -> usize {
+        self.log_panel.hidden_marks()
+    }
+
     /// Stop marking the changes that were marked, whatever they were
     /// marked for having been done to them.
     pub fn clear_marks(&mut self) {

--- a/src/ui/panel/log_panel.rs
+++ b/src/ui/panel/log_panel.rs
@@ -307,6 +307,19 @@ impl<'a, T: LogItem> LogPanel<'a, T> {
         let was_marked = self.is_item_marked(&self.selected);
         self.set_item_mark(&self.selected.clone(), !was_marked);
     }
+
+    /// How many marks sit on items the panel is not showing, and so
+    /// cannot be taken back where they are.
+    pub fn hidden_marks(&self) -> usize {
+        let Ok(log_output) = self.log_output.as_ref() else {
+            return self.marked.len();
+        };
+
+        self.marked
+            .iter()
+            .filter(|mark| !log_output.items.iter().any(|item| item.mark() == **mark))
+            .count()
+    }
 }
 
 impl<T: LogItem> Component for LogPanel<'_, T> {

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -43,6 +43,9 @@ pub struct Status<'a> {
     pub revset: Option<&'a str>,
     /// How many changes the log has marked.
     pub marked: usize,
+    /// How many of those it is not showing, and so cannot be unmarked
+    /// where they are.
+    pub hidden_marks: usize,
     /// Whether the repo has moved since what is on screen was read.
     pub stale: bool,
     /// How long the app has been at what it is doing, which is what the
@@ -83,6 +86,11 @@ fn where_we_are(status: &Status) -> Line<'static> {
     if status.marked > 0 {
         spans.extend(divider());
         spans.push(Span::raw(format!("{} marked", status.marked)));
+        // A mark the log is not showing is one nothing on screen says
+        // anything about, so the count is all there is to go by.
+        if status.hidden_marks > 0 {
+            spans.push(Span::raw(format!(" ({} out of view)", status.hidden_marks)));
+        }
     }
 
     Line::from(spans)
@@ -141,6 +149,7 @@ mod tests {
             root: "/tmp/repo",
             revset: None,
             marked: 0,
+            hidden_marks: 0,
             stale: false,
             elapsed: Duration::ZERO,
         }
@@ -169,6 +178,21 @@ mod tests {
             ..status()
         };
         assert_eq!(text(&showing), " default /tmp/repo │ trunk()..@ │ 2 marked");
+    }
+
+    /// A mark on a change the log is not showing is one the bar has to
+    /// account for, there being nothing on screen that does.
+    #[test]
+    fn the_bar_says_how_many_marks_are_out_of_view() {
+        let hiding = Status {
+            marked: 2,
+            hidden_marks: 1,
+            ..status()
+        };
+        assert_eq!(
+            text(&hiding),
+            " default /tmp/repo │ 2 marked (1 out of view)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
A mark stays on a change whether or not the log still lists it, so changing the revset or reading fewer changes leaves marks that nothing on screen accounts for. The count in the status bar is then the only sign they are there, and it does not say that acting on the marks will reach more changes than the ones on screen, so break the number that are out of view out of it.

<!--
    Please provide some information on what this PR tries to accomplish.

    Also make sure to have proper commit messages, those are more important than
    the PR message.

    blazingjj has a CHANGELOG.md file, make sure to update it if needed
-->
